### PR TITLE
Add demo site links and auto-deploy workflow

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -24,33 +24,7 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             cd ~/ozwellai-api
-
-            # Pull latest from main
             git fetch origin
             git checkout main
             git pull origin main
-
-            # Install dependencies and verify code
-            cd landing-page
-            npm ci
-
-            # Verify code syntax before deploying
-            node --check server.js || { echo "server.js syntax check failed!"; exit 1; }
-            
-            # Check that all critical public assets exist
-            test -f public/landing.html || { echo "Missing landing.html!"; exit 1; }
-            test -f public/landing.js || { echo "Missing landing.js!"; exit 1; }
-            test -f public/demo.css || { echo "Missing demo.css!"; exit 1; }
-            test -f public/tictactoe.html || { echo "Missing tictactoe.html!"; exit 1; }
-            test -f public/tictactoe-app.js || { echo "Missing tictactoe-app.js!"; exit 1; }
-            test -f public/tictactoe.css || { echo "Missing tictactoe.css!"; exit 1; }
-
-            # Restart landing page server with environment variable
-            pm2 stop embedtest || true
-            pm2 delete embedtest || true
-            REFERENCE_SERVER_URL=https://ozwellai-reference-server.opensource.mieweb.org pm2 start server.js --name embedtest
-            pm2 save
-
-            # Verify deployment
-            pm2 status
-            echo "Demo site deployed successfully!"
+            REFERENCE_SERVER_URL=https://ozwellai-reference-server.opensource.mieweb.org ./scripts/deploy-demo.sh

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,45 @@
+name: Deploy Demo Site
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'landing-page/**'
+      - '.github/workflows/deploy-demo.yml'
+      - 'reference-server/embed/**'
+
+jobs:
+  deploy:
+    name: Deploy to ozwellai-embedtest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to container
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EMBEDTEST_HOST }}
+          port: 2240
+          username: ${{ secrets.EMBEDTEST_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd ~/ozwellai-api
+
+            # Pull latest from main
+            git fetch origin
+            git checkout main
+            git pull origin main
+
+            # Install dependencies
+            cd landing-page
+            npm ci
+
+            # Restart landing page server with environment variable
+            pm2 stop embedtest || true
+            pm2 delete embedtest || true
+            REFERENCE_SERVER_URL=https://ozwellai-reference-server.opensource.mieweb.org pm2 start server.js --name embedtest
+            pm2 save
+
+            # Verify deployment
+            pm2 status
+            echo "Demo site deployed successfully!"

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -30,9 +30,20 @@ jobs:
             git checkout main
             git pull origin main
 
-            # Install dependencies
+            # Install dependencies and verify code
             cd landing-page
             npm ci
+
+            # Verify code syntax before deploying
+            node --check server.js || { echo "server.js syntax check failed!"; exit 1; }
+            
+            # Check that all critical public assets exist
+            test -f public/landing.html || { echo "Missing landing.html!"; exit 1; }
+            test -f public/landing.js || { echo "Missing landing.js!"; exit 1; }
+            test -f public/demo.css || { echo "Missing demo.css!"; exit 1; }
+            test -f public/tictactoe.html || { echo "Missing tictactoe.html!"; exit 1; }
+            test -f public/tictactoe-app.js || { echo "Missing tictactoe-app.js!"; exit 1; }
+            test -f public/tictactoe.css || { echo "Missing tictactoe.css!"; exit 1; }
 
             # Restart landing page server with environment variable
             pm2 stop embedtest || true

--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0-brightgreen.svg)](https://swagger.io/specification/)
 [![Zod](https://img.shields.io/badge/Schema-Zod-blue.svg)](https://github.com/colinhacks/zod)
 
+## Live Demo
+
+**Try it now:** [https://ozwellai-embedtest.opensource.mieweb.org](https://ozwellai-embedtest.opensource.mieweb.org)
+
+**Watch demo:** [YouTube Short](YOUTUBE_DEMO_SHORT_PLACEHOLDER)
+
+Experience the Ozwell AI chat widget with:
+- Real-time SSE streaming with Ollama
+- MCP tool calling via postMessage
+- Interactive demo with live event logging
+- Secure iframe isolation
+
+---
+
 ## Philosophy
 
 This public repository for Ozwell API is the canonical reference for the API, enabling both internal and external teams to build against a stable, well-documented contract.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **Try it now:** [https://ozwellai-embedtest.opensource.mieweb.org](https://ozwellai-embedtest.opensource.mieweb.org)
 
-**Watch demo:** [YouTube Short](YOUTUBE_DEMO_SHORT_PLACEHOLDER)
+**Watch demo:** [YouTube Short](https://youtube.com/shorts/mqcoEoQzQMM?si=FLa_dq_4y2TeO_48)
 
 Experience the Ozwell AI chat widget with:
 - Real-time SSE streaming with Ollama

--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -117,7 +117,7 @@
         Embedded chat with tool execution via iframe-sync and postMessage
       </p>
       <div class="demo-links">
-        <a href="YOUTUBE_DEMO_SHORT_PLACEHOLDER" target="_blank" class="demo-link">
+        <a href="https://youtube.com/shorts/mqcoEoQzQMM?si=FLa_dq_4y2TeO_48" target="_blank" class="demo-link">
           Watch Demo Video →
         </a>
         <a href="/tictactoe.html" class="demo-link">

--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -117,6 +117,9 @@
         Embedded chat with tool execution via iframe-sync and postMessage
       </p>
       <div class="demo-links">
+        <a href="YOUTUBE_DEMO_SHORT_PLACEHOLDER" target="_blank" class="demo-link">
+          Watch Demo Video →
+        </a>
         <a href="/tictactoe.html" class="demo-link">
           Play Tic-Tac-Toe Demo →
         </a>

--- a/reference-server/README.md
+++ b/reference-server/README.md
@@ -117,6 +117,8 @@ The server will start at `http://localhost:3000`
 
 **Live Demo:** https://ozwellai-embedtest.opensource.mieweb.org
 
+**Watch Demo:** [YouTube Short](https://youtube.com/shorts/mqcoEoQzQMM?si=FLa_dq_4y2TeO_48)
+
 The demo runs in mock AI mode by default (keyword-based pattern matching via `/mock/chat`). To use real LLM responses:
 - Change one line in the HTML to switch to Ollama mode
 - Ollama mode uses `/v1/chat/completions` endpoint which proxies to local Ollama instance

--- a/scripts/deploy-demo.sh
+++ b/scripts/deploy-demo.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deploy landing page demo site
+# This script deploys the landing page to the demo server using PM2
+# Can be run locally for testing or by CI workflows
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+LANDING_PAGE_DIR="$PROJECT_ROOT/landing-page"
+
+echo "🚀 Deploying demo site..."
+echo "📁 Working directory: $LANDING_PAGE_DIR"
+
+# Change to landing page directory
+cd "$LANDING_PAGE_DIR"
+
+# Install dependencies
+echo "📦 Installing dependencies..."
+npm ci
+
+# Verify code syntax before deploying
+echo "🔍 Verifying server code syntax..."
+node --check server.js || { echo "❌ server.js syntax check failed!"; exit 1; }
+
+# Check that all critical public assets exist
+echo "✅ Checking critical assets..."
+critical_assets=(
+    "public/landing.html"
+    "public/landing.js"
+    "public/demo.css"
+    "public/tictactoe.html"
+    "public/tictactoe-app.js"
+    "public/tictactoe.css"
+)
+
+for asset in "${critical_assets[@]}"; do
+    if [[ ! -f "$asset" ]]; then
+        echo "❌ Missing $asset!"
+        exit 1
+    fi
+    echo "  ✓ $asset"
+done
+
+# Restart landing page server with environment variable
+echo "🔄 Restarting PM2 service..."
+pm2 stop embedtest || true
+pm2 delete embedtest || true
+
+# Set reference server URL (use provided value or default)
+REFERENCE_SERVER_URL="${REFERENCE_SERVER_URL:-https://ozwellai-reference-server.opensource.mieweb.org}"
+echo "🌐 Using reference server: $REFERENCE_SERVER_URL"
+
+REFERENCE_SERVER_URL=$REFERENCE_SERVER_URL pm2 start server.js --name embedtest
+pm2 save
+
+# Verify deployment
+echo "📊 PM2 Status:"
+pm2 status
+
+echo "✅ Demo site deployed successfully!"
+echo ""
+echo "Next steps:"
+echo "  • Visit the demo site to verify it's working"
+echo "  • Check PM2 logs with: pm2 logs embedtest"


### PR DESCRIPTION
Closes #18

## Changes

### Auto-Deploy Workflow
- Add GitHub Actions workflow for automated deployment to ozwellai-embedtest container
- Triggers on push to main branch when landing-page files or workflow itself changes
- Uses SSH key authentication (port 2240)
- Automatically pulls latest code, installs dependencies, restarts PM2 process with proper environment variables, and verifies deployment

### Documentation and Demo Links
- Add live demo section to root README with links to:
  - Demo site: https://ozwellai-embedtest.opensource.mieweb.org
  - YouTube demo video: https://youtube.com/shorts/mqcoEoQzQMM?si=FLa_dq_4y2TeO_48
- Add demo video link to landing page with enhanced streaming architecture diagram
- Add comprehensive streaming architecture documentation to reference-server README
  - Mermaid sequence diagram showing SSE streaming flow
  - Ollama integration details
  - Widget isolation and tool call flow

## Files Changed
- `.github/workflows/deploy-demo.yml` - Auto-deploy workflow
- `README.md` - Live demo links section
- `landing-page/public/landing.html` - Demo video link
- `reference-server/README.md` - Demo video link

## Required Secrets
- `EMBEDTEST_HOST` - SSH host for deployment
- `EMBEDTEST_USER` - SSH username
- `SSH_PRIVATE_KEY` - SSH private key for authentication

## Dependencies
- PR #17 (streaming support) is now merged ✓
- This PR is rebased on latest main

## Testing
- All CI checks passing
- Workflow will activate automatically after merging to main
- Manual deployment process remains available for testing feature branches