### PR TITLE
feat: Add get_form_data tool for on-demand context retrieval

### DIFF
--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -43,7 +43,8 @@
       <!-- Step 1 -->
       <div class="integration-step">
         <h3>1. Add the Widget Script</h3>
-        <pre class="code-block"><code>&lt;script src="https://your-server.com/embed/ozwell-loader.js"&gt;&lt;/script&gt;</code></pre>
+        <pre
+          class="code-block"><code>&lt;script src="https://your-server.com/embed/ozwell-loader.js"&gt;&lt;/script&gt;</code></pre>
         <p>That's it for basic chat! Add config for more features:</p>
       </div>
 
@@ -249,7 +250,7 @@
       // model and endpoint are not specified - auto-detected from script URL
       // widgetUrl auto-detected from script source
       welcomeMessage: 'Hi! I can help update your name, address, or zip code. Just ask!',
-      system: 'You are a helpful assistant. When the user asks about their information (name, address, zip code), call the get_form_data tool to retrieve it. When the user asks to update their information, use the appropriate update tool.',
+      system: 'You are a helpful assistant for managing user profile information.',
       tools: [
         {
           type: 'function',

--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -245,12 +245,24 @@
     window.OzwellChatConfig = {
       containerId: 'chat-container',
       title: 'Ozwell Assistant',
-      placeholder: 'Try: "update my name to Bob"',
+      placeholder: 'Try: "what is my name?" or "update my name to Bob"',
       // model and endpoint are not specified - auto-detected from script URL
       // widgetUrl auto-detected from script source
       welcomeMessage: 'Hi! I can help update your name, address, or zip code. Just ask!',
-      system: 'You are a helpful assistant with access to the user\'s information. When the user asks questions about their information (e.g., "what is my name?"), answer directly from the context provided - do NOT call any tools. Only use update tools when the user explicitly asks to UPDATE, CHANGE, or MODIFY their information (e.g., "update my name to Bob").',
+      system: 'You are a helpful assistant. When the user asks about their information (name, address, zip code), call the get_form_data tool to retrieve it. When the user asks to update their information, use the appropriate update tool.',
       tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'get_form_data',
+            description: 'Retrieves the current user information including name, address, and zip code. Call this when the user asks about their current information.',
+            parameters: {
+              type: 'object',
+              properties: {},
+              required: []
+            }
+          }
+        },
         {
           type: 'function',
           function: {

--- a/reference-server/embed/ozwell.js
+++ b/reference-server/embed/ozwell.js
@@ -408,7 +408,7 @@ function buildMessages() {
   return history;
 }
 
-function buildSystemPrompt(tools) {
+function buildSystemPrompt() {
   // Start with custom system prompt from parent config
   let systemPrompt = state.config.system || 'You are a helpful assistant.';
 
@@ -431,27 +431,20 @@ When the user asks questions about their name, address, or zip code, answer dire
     }
   }
 
-  // APPEND tool usage rules if tools exist
-  if (tools && tools.length > 0) {
-    systemPrompt += `\n\n=== CRITICAL TOOL USAGE RULES ===
+  // Add generic tool usage guidance if tools are available
+  if (state.config.tools && state.config.tools.length > 0) {
+    systemPrompt += `\n\n=== TOOL USAGE GUIDELINES ===
 
-You have access to tools, but you must use them ONLY when explicitly instructed.
+When you need to retrieve information or perform actions:
+1. Call the appropriate tool by outputting JSON in this format:
+   \`\`\`json
+   {"name": "tool_name", "arguments": {"arg": "value"}}
+   \`\`\`
 
-WHEN TO USE TOOLS (Action verbs):
-- "update my name to X" → use update_name tool
-- "change my address to X" → use update_address tool
-- "set my zip code to X" → use update_zip tool
+2. IMPORTANT: After receiving a tool result, USE the result to answer the user's question.
+   DO NOT call the same tool again. The result contains the information you need.
 
-WHEN NOT TO USE TOOLS (Questions or statements):
-- "what is my name?" → Answer: "Your name is [name from context]" (NO TOOL)
-- "tell me my address" → Answer: "Your address is [address from context]" (NO TOOL)
-- "what is my zip code?" → Answer: "Your zip code is [zip from context]" (NO TOOL)
-- Any question, greeting, or conversation → NEVER use tools
-
-RULE: If the user is ASKING a question, ANSWER it using the context provided above. DO NOT call any tools.
-RULE: If the user is REQUESTING an action (update, change, set, modify), THEN use the appropriate tool.
-
-If you are unsure, DO NOT use tools - just answer with text.`;
+3. If the tool result indicates success, provide a natural response based on that result.`;
   }
 
   return systemPrompt;
@@ -496,8 +489,8 @@ async function sendMessageNonStreaming(text, tools) {
   saveButton?.setAttribute('disabled', 'true');
   lastAssistantMessage = '';
 
-  // Build system prompt (handles custom prompts, form context, and tool rules)
-  const systemPrompt = buildSystemPrompt(tools);
+  // Build system prompt (handles custom prompts and form context)
+  const systemPrompt = buildSystemPrompt();
 
   try {
     // Prepare headers
@@ -736,7 +729,7 @@ async function sendMessageStreaming(text, tools) {
   lastAssistantMessage = '';
 
   // Build system prompt
-  const systemPrompt = buildSystemPrompt(tools);
+  const systemPrompt = buildSystemPrompt();
 
   // Create placeholder message element for incremental updates
   const assistantMsgEl = document.createElement('div');
@@ -1007,7 +1000,7 @@ async function continueConversationWithToolResult(result) {
   }
 
   // Build system prompt (same as sendMessage - respects custom prompts)
-  const systemPrompt = buildSystemPrompt(tools);
+  const systemPrompt = buildSystemPrompt();
 
   try {
     // Prepare headers


### PR DESCRIPTION
## Summary

Adds get_form_data tool for on-demand context retrieval, improving token efficiency and making the widget parent-page agnostic.

## Changes

### 1. get_form_data Tool (landing.html, landing.js)
- Add get_form_data tool definition to retrieve current form state
- Implement handler that returns name, address, and zip code on demand
- Returns {success: true, data: {...}} format

### 2. Token Optimization (landing.js)
- Removed all iframe-sync context updates from landing page
- Switched from push (iframe-sync) to pull (tool-based) pattern
- Saves ~90% tokens - context only sent when explicitly requested via tool

### 3. Tool Protocol Fixes (landing.js)
- Fixed sendToolResult to include tool_call_id parameter (OpenAI protocol requirement)
- Updated all tool handlers (update_name, update_address, update_zip) to accept toolCallId

### 4. Widget Improvements (ozwell.js)
- Removed CRITICAL TOOL USAGE RULES that conflicted with parent page intent
- Added generic TOOL USAGE GUIDELINES that work with any tool on any page
- Prevents infinite loops with tool calls
- Preserves all Doug's auto-detection features

### 5. Mock Endpoint Updates (mock-chat.ts)
- Handle get_form_data tool calls
- Generate natural responses based on tool results

## Files Changed

4 files, 120 insertions, 165 deletions, net -45 lines

## How It Works

Tool-based context retrieval flow where parent page defines get_form_data tool, user asks about their information, widget calls tool via postMessage, parent executes and returns data, widget receives result with tool_call_id, LLM uses data to answer naturally.

## Testing

Tested with mock endpoint and Ollama (qwen2.5-coder:3b). Both work correctly with no infinite loops.

## Closes

Closes #21