### PR TITLE
Add GitHub documentation link to landing page integration guide

### DIFF
--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -40,6 +40,11 @@
       <button id="integration-close-btn" class="integration-close-btn">×</button>
     </div>
     <div class="integration-panel-content">
+      <!-- Documentation Link -->
+      <div class="integration-step" style="background: #f0f9ff; border-left: 4px solid #0066ff; padding: 12px;">
+        <p style="margin: 0;"><strong>📚 Full Documentation:</strong> For complete integration guides, advanced features, and API reference, see the <a href="https://github.com/mieweb/ozwellai-api/blob/main/reference-server/embed/README.md" target="_blank" rel="noopener noreferrer" style="color: #0066ff; text-decoration: underline;">official documentation on GitHub</a>.</p>
+      </div>
+
       <!-- Step 1 -->
       <div class="integration-step">
         <h3>1. Add the Widget Script</h3>


### PR DESCRIPTION
## Summary
Adds a prominent link to the official GitHub documentation in the landing page integration guide panel, making it easy for users to access complete integration guides and API reference.

## Changes
- Added blue info box at the top of the integration guide slide-out panel
- Link directs to `reference-server/embed/README.md` (the accurate documentation for the ozwell-loader.js implementation)
- Opens in new tab with proper security attributes (`target="_blank" rel="noopener noreferrer"`)

## Why This Documentation?
After analyzing the codebase, I found that:
- ✅ `reference-server/embed/README.md` accurately matches the landing page implementation
- ❌ `docs/frontend/` documents a different (commercial) product with scoped API keys and hosted services

The reference server documentation is the only accurate guide for the current ozwell-loader.js embed method.

## Testing
- [x] Verify link appears in integration guide panel
- [x] Confirm link opens correct GitHub page in new tab
- [x] Check styling matches integration panel design

Fixes #32