### PR TITLE
feat(reference-server): add extensibility support for custom implementations

### DIFF
--- a/reference-server/package.json
+++ b/reference-server/package.json
@@ -1,8 +1,56 @@
 {
-  "name": "ozwellai-reference",
+  "name": "@mieweb/ozwellai-reference",
   "version": "1.0.0",
   "description": "OpenAI-compatible Fastify reference server for OzwellAI API",
   "main": "dist/reference-server/src/server.js",
+  "types": "dist/reference-server/src/server.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/reference-server/src/server.js",
+      "require": "./dist/reference-server/src/server.js",
+      "types": "./dist/reference-server/src/server.d.ts"
+    },
+    "./types": {
+      "import": "./dist/reference-server/src/types.js",
+      "require": "./dist/reference-server/src/types.js",
+      "types": "./dist/reference-server/src/types.d.ts"
+    },
+    "./util": {
+      "import": "./dist/reference-server/src/util/index.js",
+      "require": "./dist/reference-server/src/util/index.js",
+      "types": "./dist/reference-server/src/util/index.d.ts"
+    },
+    "./routes/models": {
+      "import": "./dist/reference-server/src/routes/models.js",
+      "require": "./dist/reference-server/src/routes/models.js",
+      "types": "./dist/reference-server/src/routes/models.d.ts"
+    },
+    "./routes/chat": {
+      "import": "./dist/reference-server/src/routes/chat.js",
+      "require": "./dist/reference-server/src/routes/chat.js",
+      "types": "./dist/reference-server/src/routes/chat.d.ts"
+    },
+    "./routes/responses": {
+      "import": "./dist/reference-server/src/routes/responses.js",
+      "require": "./dist/reference-server/src/routes/responses.js",
+      "types": "./dist/reference-server/src/routes/responses.d.ts"
+    },
+    "./routes/embeddings": {
+      "import": "./dist/reference-server/src/routes/embeddings.js",
+      "require": "./dist/reference-server/src/routes/embeddings.js",
+      "types": "./dist/reference-server/src/routes/embeddings.d.ts"
+    },
+    "./routes/files": {
+      "import": "./dist/reference-server/src/routes/files.js",
+      "require": "./dist/reference-server/src/routes/files.js",
+      "types": "./dist/reference-server/src/routes/files.d.ts"
+    },
+    "./routes/mock-chat": {
+      "import": "./dist/reference-server/src/routes/mock-chat.js",
+      "require": "./dist/reference-server/src/routes/mock-chat.js",
+      "types": "./dist/reference-server/src/routes/mock-chat.d.ts"
+    }
+  },
   "scripts": {
     "dev": "ts-node src/server.ts",
     "build": "tsc",

--- a/reference-server/src/types.ts
+++ b/reference-server/src/types.ts
@@ -1,0 +1,148 @@
+/**
+ * Server configuration and extensibility types
+ * These types enable the reference-server to be extended by private implementations
+ */
+
+import type { FastifyInstance, FastifyRequest, FastifyReply, preHandlerHookHandler } from 'fastify';
+
+/**
+ * Result of authentication validation
+ */
+export interface AuthResult {
+  /** Whether authentication succeeded */
+  valid: boolean;
+  /** Optional user/account identifier for logging or context */
+  userId?: string;
+  /** Optional organization identifier */
+  orgId?: string;
+  /** Optional error message if validation failed */
+  error?: string;
+  /** Additional context to attach to the request */
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Authentication handler function signature
+ * Override this to implement custom authentication (JWT, API keys, billing checks, etc.)
+ */
+export type AuthHandler = (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => Promise<AuthResult> | AuthResult;
+
+/**
+ * Lifecycle hook for extending server behavior
+ */
+export type ServerLifecycleHook = (server: FastifyInstance) => Promise<void> | void;
+
+/**
+ * Route registration options
+ */
+export interface RouteOptions {
+  /** Route prefix (e.g., '/v1' or '/api/v1') */
+  prefix?: string;
+  /** Whether to skip auth for this route group */
+  skipAuth?: boolean;
+}
+
+/**
+ * OpenAPI/Swagger configuration
+ */
+export interface SwaggerOptions {
+  /** API title */
+  title?: string;
+  /** API description */
+  description?: string;
+  /** API version */
+  version?: string;
+  /** Server URLs for documentation */
+  servers?: Array<{ url: string; description: string }>;
+  /** Contact information */
+  contact?: { name?: string; email?: string; url?: string };
+}
+
+/**
+ * Configuration options for building the server
+ * Pass these to buildServer() to customize behavior
+ */
+export interface ServerOptions {
+  /**
+   * Custom authentication handler
+   * Default: accepts any non-empty Bearer token (for testing)
+   */
+  authHandler?: AuthHandler;
+
+  /**
+   * Routes that should skip authentication entirely
+   * Default: ['/health', '/docs', '/openapi.json']
+   */
+  publicRoutes?: string[];
+
+  /**
+   * API route prefix
+   * Default: '' (routes at /v1/...)
+   * Example: '/api' would make routes available at /api/v1/...
+   */
+  routePrefix?: string;
+
+  /**
+   * Called after core plugins are registered but before routes
+   * Use this to register additional middleware or plugins
+   */
+  onBeforeRoutes?: ServerLifecycleHook;
+
+  /**
+   * Called after all routes are registered
+   * Use this to register additional routes or finalize configuration
+   */
+  onAfterRoutes?: ServerLifecycleHook;
+
+  /**
+   * Swagger/OpenAPI documentation options
+   */
+  swagger?: SwaggerOptions;
+
+  /**
+   * Whether to register the default API routes (models, chat, etc.)
+   * Default: true
+   * Set to false if you want to register routes manually
+   */
+  registerDefaultRoutes?: boolean;
+
+  /**
+   * Whether to register static file serving (public/, embed/)
+   * Default: true
+   */
+  serveStatic?: boolean;
+
+  /**
+   * Whether to register Swagger UI at /docs
+   * Default: true
+   */
+  enableDocs?: boolean;
+
+  /**
+   * Custom Fastify instance options
+   * Merged with defaults (logger based on NODE_ENV)
+   */
+  fastifyOptions?: {
+    logger?: boolean | object;
+    [key: string]: unknown;
+  };
+
+  /**
+   * Root directory for static files
+   * Default: process.cwd()
+   */
+  rootDir?: string;
+}
+
+/**
+ * Extended Fastify request with auth context
+ */
+declare module 'fastify' {
+  interface FastifyRequest {
+    /** Authentication context set by auth handler */
+    authContext?: AuthResult;
+  }
+}

--- a/reference-server/tsconfig.json
+++ b/reference-server/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "commonjs",
-    "lib": ["ES2020"],
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "lib": ["ES2022"],
     "outDir": "./dist",
+    "rootDir": "..",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -11,7 +13,8 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "noImplicitAny": false
   },
   "include": ["src/**/*", "../spec/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION

- Add ServerOptions interface for comprehensive server customization
- Add AuthHandler type for custom authentication (JWT, API keys, etc.)
- Add lifecycle hooks: onBeforeRoutes and onAfterRoutes
- Export individual route plugins for selective registration
- Add package.json exports for types, util, and routes
- Make routes, static serving, and docs conditionally registerable
- Add route prefix support for API versioning
- Update tsconfig for proper declaration generation
- Add comprehensive Extensibility documentation to README

This enables downstream projects to import and extend the reference server as a library, implementing custom auth, adding routes, and configuring behavior without forking.