### PR TITLE
feat: add deploy workflow for reference-server container

### DIFF
--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -7,7 +7,12 @@ on:
     paths:
       - 'reference-server/**'
       - 'clients/typescript/**'
+      - 'spec/**'
       - '.github/workflows/deploy-reference-server.yml'
+
+concurrency:
+  group: deploy-reference-server
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -28,7 +33,6 @@ jobs:
             clients/typescript/package-lock.json
             reference-server/package-lock.json
 
-      # Build dependencies first (spec and typescript client)
       - name: Install and build spec
         working-directory: ./spec
         run: npm ci && npm run build
@@ -37,36 +41,12 @@ jobs:
         working-directory: ./clients/typescript
         run: npm ci && npm run build
 
-      # Build reference server
-      - name: Install reference server dependencies
+      - name: Install and build reference server
         working-directory: ./reference-server
-        run: npm ci
+        run: npm ci && npm run build
 
-      - name: Build reference server
-        working-directory: ./reference-server
-        run: npm run build
-
-      # Create deployment package
       - name: Create deployment package
-        run: |
-          mkdir -p deploy-package/reference-server
-          mkdir -p deploy-package/clients/typescript
-
-          # Copy reference server built files
-          cp -r reference-server/dist deploy-package/reference-server/
-          cp reference-server/package.json reference-server/package-lock.json deploy-package/reference-server/
-          cp -r reference-server/embed deploy-package/reference-server/ 2>/dev/null || true
-          cp -r reference-server/data deploy-package/reference-server/ 2>/dev/null || true
-
-          # Copy typescript client (needed as local dependency)
-          cp -r clients/typescript/dist deploy-package/clients/typescript/
-          cp clients/typescript/package.json deploy-package/clients/typescript/
-
-          # Create tarball
-          tar -czvf reference-server-build.tar.gz -C deploy-package .
-
-          echo "📦 Package contents:"
-          tar -tzvf reference-server-build.tar.gz
+        run: ./scripts/build-deploy-package.sh
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -86,8 +66,9 @@ jobs:
         with:
           name: reference-server-build
 
+      # v0.1.7
       - name: Upload to server
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634
         with:
           host: ${{ secrets.REFSERVER_HOST }}
           port: 2240
@@ -96,8 +77,9 @@ jobs:
           source: reference-server-build.tar.gz
           target: /tmp/
 
+      # v1.0.0
       - name: Extract and restart service
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
         with:
           host: ${{ secrets.REFSERVER_HOST }}
           port: 2240
@@ -106,6 +88,10 @@ jobs:
           script: |
             set -e
             cd ~/ozwellai-api
+
+            # Clean old build outputs to prevent stale files
+            echo "🧹 Cleaning old build outputs..."
+            rm -rf reference-server/dist clients/typescript/dist spec/dist
 
             # Extract the pre-built package
             echo "📦 Extracting build package..."

--- a/scripts/build-deploy-package.sh
+++ b/scripts/build-deploy-package.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build and package reference server for deployment
+# Creates a tarball with all pre-built artifacts ready for deployment
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo "📦 Building deployment package for reference server..."
+
+# Create deploy package directory
+DEPLOY_DIR="$PROJECT_ROOT/deploy-package"
+rm -rf "$DEPLOY_DIR"
+mkdir -p "$DEPLOY_DIR/reference-server"
+mkdir -p "$DEPLOY_DIR/clients/typescript"
+mkdir -p "$DEPLOY_DIR/spec"
+
+# Copy spec (needed as local dependency)
+echo "  Copying spec..."
+cp -r "$PROJECT_ROOT/spec/dist" "$DEPLOY_DIR/spec/"
+cp "$PROJECT_ROOT/spec/package.json" "$DEPLOY_DIR/spec/"
+
+# Copy typescript client (needed as local dependency)
+echo "  Copying typescript client..."
+cp -r "$PROJECT_ROOT/clients/typescript/dist" "$DEPLOY_DIR/clients/typescript/"
+cp "$PROJECT_ROOT/clients/typescript/package.json" "$DEPLOY_DIR/clients/typescript/"
+
+# Copy reference server built files
+echo "  Copying reference server..."
+cp -r "$PROJECT_ROOT/reference-server/dist" "$DEPLOY_DIR/reference-server/"
+cp "$PROJECT_ROOT/reference-server/package.json" "$DEPLOY_DIR/reference-server/"
+cp "$PROJECT_ROOT/reference-server/package-lock.json" "$DEPLOY_DIR/reference-server/"
+
+# Copy runtime assets (embed files, etc.)
+if [[ -d "$PROJECT_ROOT/reference-server/embed" ]]; then
+    cp -r "$PROJECT_ROOT/reference-server/embed" "$DEPLOY_DIR/reference-server/"
+fi
+
+# Create tarball
+TARBALL="$PROJECT_ROOT/reference-server-build.tar.gz"
+echo "  Creating tarball..."
+tar -czvf "$TARBALL" -C "$DEPLOY_DIR" .
+
+# Show package contents
+echo ""
+echo "�� Package contents:"
+tar -tzvf "$TARBALL"
+
+# Cleanup
+rm -rf "$DEPLOY_DIR"
+
+echo ""
+echo "✅ Deployment package created: $TARBALL"


### PR DESCRIPTION
## Summary
- Adds automated deployment workflow for the reference-server container
- Triggers on pushes to `main` affecting `reference-server/**` or `clients/typescript/**`
- Uses same SSH action pattern as the existing `deploy-demo.yml`

## Setup Required
Before merging, add these GitHub secrets:
- `REFSERVER_HOST` - set to `ozwellai-reference-server.opensource.mieweb.org`
- `REFSERVER_USER` - deployment username (e.g., `adamerla`)

On the reference-server container:
- Add the SSH public key (from `SSH_PRIVATE_KEY`) to `~/.ssh/authorized_keys`

## Test plan
- [x] Add GitHub secrets `REFSERVER_HOST` and `REFSERVER_USER`
- [x] Add SSH public key to reference-server container
- [ ] Merge PR and verify workflow runs successfully
- [ ] Check PM2 status on reference-server after deploy

Closes #48
