### PR TITLE
docs: add live demo link to documentation

### DIFF
--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -8,6 +8,8 @@ description: Integrate Ozwell's privacy-first AI chat into your website or web a
 
 This guide covers how to integrate Ozwell's AI chat interface into your website or web application. All frontend integrations use **scoped API keys** that are restricted to specific agents and their assigned permissions, making them safe for client-side use.
 
+> **Try it live:** See Ozwell in action at the [demo site](https://ozwellai-embedtest.opensource.mieweb.org/).
+
 ## Integration Approaches
 
 ```mermaid

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -364,7 +364,9 @@ If you're unsure whether your use case complies with our trademark policy, pleas
 
 ## Next Steps
 
-1. **New to Ozwell?** Start with the [CDN integration](./frontend/cdn-embed.md) for the fastest path to a working demo.
+1. **See it in action?** Try the [live demo](https://ozwellai-embedtest.opensource.mieweb.org/) to experience Ozwell's chat widget.
+
+2. **New to Ozwell?** Start with the [CDN integration](./frontend/cdn-embed.md) for the fastest path to a working demo.
 
 2. **Building a production app?** Check the [Framework guides](./frontend/overview.md) for React, Vue, Svelte, and more.
 


### PR DESCRIPTION
## Summary
- Add link to live demo site (https://ozwellai-embedtest.opensource.mieweb.org/) in documentation
- Added to `docs/overview.md` in Next Steps section
- Added to `docs/frontend/overview.md` as intro callout

## Test plan
- [ ] Verify demo link is accessible and working
- [ ] Verify Docusaurus renders the links correctly

Closes #50 (partial - demo link integration only)

> **Note:** The remaining requirements from #50 (verifying `react.md` props/callbacks against actual implementation) should be addressed in PR #39 which already modifies `docs/frontend/react.md`.
