### PR TITLE
fix: correct SSH port for reference-server deployment

### DIFF
--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -1,0 +1,35 @@
+name: Deploy Reference Server
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'reference-server/**'
+      - 'clients/typescript/**'
+      - '.github/workflows/deploy-reference-server.yml'
+
+jobs:
+  deploy:
+    name: Deploy to ozwellai-reference-server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to container
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.REFSERVER_HOST }}
+          port: 2240
+          username: ${{ secrets.REFSERVER_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd ~/ozwellai-api
+            git fetch origin
+            git checkout main
+            git reset --hard origin/main
+            cd reference-server
+            npm ci
+            npm run build
+            pm2 restart refserver
+            pm2 save
+            echo "✅ Reference server deployed successfully!"

--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -71,7 +71,7 @@ jobs:
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634
         with:
           host: ${{ secrets.REFSERVER_HOST }}
-          port: 2240
+          port: 2241
           username: ${{ secrets.REFSERVER_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: reference-server-build.tar.gz
@@ -82,7 +82,7 @@ jobs:
         uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
         with:
           host: ${{ secrets.REFSERVER_HOST }}
-          port: 2240
+          port: 2241
           username: ${{ secrets.REFSERVER_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |

--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -7,7 +7,12 @@ on:
     paths:
       - 'reference-server/**'
       - 'clients/typescript/**'
+      - 'spec/**'
       - '.github/workflows/deploy-reference-server.yml'
+
+concurrency:
+  group: deploy-reference-server
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -28,7 +33,6 @@ jobs:
             clients/typescript/package-lock.json
             reference-server/package-lock.json
 
-      # Build dependencies first (spec and typescript client)
       - name: Install and build spec
         working-directory: ./spec
         run: npm ci && npm run build
@@ -37,36 +41,12 @@ jobs:
         working-directory: ./clients/typescript
         run: npm ci && npm run build
 
-      # Build reference server
-      - name: Install reference server dependencies
+      - name: Install and build reference server
         working-directory: ./reference-server
-        run: npm ci
+        run: npm ci && npm run build
 
-      - name: Build reference server
-        working-directory: ./reference-server
-        run: npm run build
-
-      # Create deployment package
       - name: Create deployment package
-        run: |
-          mkdir -p deploy-package/reference-server
-          mkdir -p deploy-package/clients/typescript
-
-          # Copy reference server built files
-          cp -r reference-server/dist deploy-package/reference-server/
-          cp reference-server/package.json reference-server/package-lock.json deploy-package/reference-server/
-          cp -r reference-server/embed deploy-package/reference-server/ 2>/dev/null || true
-          cp -r reference-server/data deploy-package/reference-server/ 2>/dev/null || true
-
-          # Copy typescript client (needed as local dependency)
-          cp -r clients/typescript/dist deploy-package/clients/typescript/
-          cp clients/typescript/package.json deploy-package/clients/typescript/
-
-          # Create tarball
-          tar -czvf reference-server-build.tar.gz -C deploy-package .
-
-          echo "📦 Package contents:"
-          tar -tzvf reference-server-build.tar.gz
+        run: ./scripts/build-deploy-package.sh
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -86,8 +66,9 @@ jobs:
         with:
           name: reference-server-build
 
+      # v0.1.7
       - name: Upload to server
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634
         with:
           host: ${{ secrets.REFSERVER_HOST }}
           port: 2240
@@ -96,8 +77,9 @@ jobs:
           source: reference-server-build.tar.gz
           target: /tmp/
 
+      # v1.0.0
       - name: Extract and restart service
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
         with:
           host: ${{ secrets.REFSERVER_HOST }}
           port: 2240
@@ -106,6 +88,10 @@ jobs:
           script: |
             set -e
             cd ~/ozwellai-api
+
+            # Clean old build outputs to prevent stale files
+            echo "🧹 Cleaning old build outputs..."
+            rm -rf reference-server/dist clients/typescript/dist spec/dist
 
             # Extract the pre-built package
             echo "📦 Extracting build package..."

--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -10,12 +10,93 @@ on:
       - '.github/workflows/deploy-reference-server.yml'
 
 jobs:
-  deploy:
-    name: Deploy to ozwellai-reference-server
+  build:
+    name: Build Reference Server
     runs-on: ubuntu-latest
 
     steps:
-      - name: Deploy to container
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            spec/package-lock.json
+            clients/typescript/package-lock.json
+            reference-server/package-lock.json
+
+      # Build dependencies first (spec and typescript client)
+      - name: Install and build spec
+        working-directory: ./spec
+        run: npm ci && npm run build
+
+      - name: Install and build TypeScript client
+        working-directory: ./clients/typescript
+        run: npm ci && npm run build
+
+      # Build reference server
+      - name: Install reference server dependencies
+        working-directory: ./reference-server
+        run: npm ci
+
+      - name: Build reference server
+        working-directory: ./reference-server
+        run: npm run build
+
+      # Create deployment package
+      - name: Create deployment package
+        run: |
+          mkdir -p deploy-package/reference-server
+          mkdir -p deploy-package/clients/typescript
+
+          # Copy reference server built files
+          cp -r reference-server/dist deploy-package/reference-server/
+          cp reference-server/package.json reference-server/package-lock.json deploy-package/reference-server/
+          cp -r reference-server/embed deploy-package/reference-server/ 2>/dev/null || true
+          cp -r reference-server/data deploy-package/reference-server/ 2>/dev/null || true
+
+          # Copy typescript client (needed as local dependency)
+          cp -r clients/typescript/dist deploy-package/clients/typescript/
+          cp clients/typescript/package.json deploy-package/clients/typescript/
+
+          # Create tarball
+          tar -czvf reference-server-build.tar.gz -C deploy-package .
+
+          echo "📦 Package contents:"
+          tar -tzvf reference-server-build.tar.gz
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: reference-server-build
+          path: reference-server-build.tar.gz
+          retention-days: 1
+
+  deploy:
+    name: Deploy to ozwellai-reference-server
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: reference-server-build
+
+      - name: Upload to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.REFSERVER_HOST }}
+          port: 2240
+          username: ${{ secrets.REFSERVER_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: reference-server-build.tar.gz
+          target: /tmp/
+
+      - name: Extract and restart service
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.REFSERVER_HOST }}
@@ -23,13 +104,24 @@ jobs:
           username: ${{ secrets.REFSERVER_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
+            set -e
             cd ~/ozwellai-api
-            git fetch origin
-            git checkout main
-            git reset --hard origin/main
+
+            # Extract the pre-built package
+            echo "📦 Extracting build package..."
+            tar -xzvf /tmp/reference-server-build.tar.gz
+
+            # Install production dependencies only (no build needed)
+            echo "📥 Installing production dependencies..."
             cd reference-server
-            npm ci
-            npm run build
+            npm ci --production --ignore-scripts
+
+            # Restart service
+            echo "🔄 Restarting service..."
             pm2 restart refserver
             pm2 save
+
+            # Cleanup
+            rm /tmp/reference-server-build.tar.gz
+
             echo "✅ Reference server deployed successfully!"

--- a/scripts/build-deploy-package.sh
+++ b/scripts/build-deploy-package.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build and package reference server for deployment
+# Creates a tarball with all pre-built artifacts ready for deployment
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo "📦 Building deployment package for reference server..."
+
+# Create deploy package directory
+DEPLOY_DIR="$PROJECT_ROOT/deploy-package"
+rm -rf "$DEPLOY_DIR"
+mkdir -p "$DEPLOY_DIR/reference-server"
+mkdir -p "$DEPLOY_DIR/clients/typescript"
+mkdir -p "$DEPLOY_DIR/spec"
+
+# Copy spec (needed as local dependency)
+echo "  Copying spec..."
+cp -r "$PROJECT_ROOT/spec/dist" "$DEPLOY_DIR/spec/"
+cp "$PROJECT_ROOT/spec/package.json" "$DEPLOY_DIR/spec/"
+
+# Copy typescript client (needed as local dependency)
+echo "  Copying typescript client..."
+cp -r "$PROJECT_ROOT/clients/typescript/dist" "$DEPLOY_DIR/clients/typescript/"
+cp "$PROJECT_ROOT/clients/typescript/package.json" "$DEPLOY_DIR/clients/typescript/"
+
+# Copy reference server built files
+echo "  Copying reference server..."
+cp -r "$PROJECT_ROOT/reference-server/dist" "$DEPLOY_DIR/reference-server/"
+cp "$PROJECT_ROOT/reference-server/package.json" "$DEPLOY_DIR/reference-server/"
+cp "$PROJECT_ROOT/reference-server/package-lock.json" "$DEPLOY_DIR/reference-server/"
+
+# Copy runtime assets (embed files, etc.)
+if [[ -d "$PROJECT_ROOT/reference-server/embed" ]]; then
+    cp -r "$PROJECT_ROOT/reference-server/embed" "$DEPLOY_DIR/reference-server/"
+fi
+
+# Create tarball
+TARBALL="$PROJECT_ROOT/reference-server-build.tar.gz"
+echo "  Creating tarball..."
+tar -czvf "$TARBALL" -C "$DEPLOY_DIR" .
+
+# Show package contents
+echo ""
+echo "�� Package contents:"
+tar -tzvf "$TARBALL"
+
+# Cleanup
+rm -rf "$DEPLOY_DIR"
+
+echo ""
+echo "✅ Deployment package created: $TARBALL"


### PR DESCRIPTION
## Summary
- Fixes SSH port from 2240 to 2241 for the reference-server deployment workflow
- Port 2240 was incorrectly targeting the embedtest container instead of reference-server

## Root cause
The deployment was failing with `Process or Namespace refserver not found` because:
- Port 2240 → `ozwellai-embedtest` container (has `embedtest` PM2 process)
- Port 2241 → `ozwellai-reference-server` container (has `refserver` PM2 process)

## Test plan
- [x] Verified SSH connection on port 2241 reaches correct container
- [x] Confirmed `refserver` PM2 process exists on target
- [ ] Merge and verify deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)