### PR TITLE
fix: correct SSH port for reference-server deployment

### DIFF
--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -71,7 +71,7 @@ jobs:
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634
         with:
           host: ${{ secrets.REFSERVER_HOST }}
-          port: 2240
+          port: 2241
           username: ${{ secrets.REFSERVER_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: reference-server-build.tar.gz
@@ -82,7 +82,7 @@ jobs:
         uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
         with:
           host: ${{ secrets.REFSERVER_HOST }}
-          port: 2240
+          port: 2241
           username: ${{ secrets.REFSERVER_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |


### PR DESCRIPTION
## Summary
Deployment was connecting to the wrong container (embedtest on port 2240 instead of reference-server on port 2241).

## Test plan
- [x] Verified SSH on port 2241 reaches `ozwellai-reference-server` with `refserver` PM2 process
- [ ] Merge and verify deployment succeeds