### PR TITLE
feat: integration guide with 3-method agent creation + visual Q builder

### DIFF
--- a/landing-page/package.json
+++ b/landing-page/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "node server.js --dev",
     "start": "node server.js",
+    "build:q": "esbuild scripts/q-entry.js --bundle --outfile=public/vendor/q-bundle.js --format=iife --global-name=QAgent --external:wavesurfer.js",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed",
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@playwright/test": "^1.57.0",
     "@types/node": "^24.10.1",
+    "esbuild": "^0.25.0",
     "typescript": "^5.9.3"
   }
 }

--- a/landing-page/public/demo.css
+++ b/landing-page/public/demo.css
@@ -309,6 +309,99 @@ body {
   font-weight: bold;
 }
 
+/* Method Accordion */
+.method-accordion {
+  margin: 1rem 0;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.method-tab {
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.method-tab:last-child {
+  border-bottom: none;
+}
+
+.method-tab-header {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: #f9fafb;
+  border: none;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1a1a1a;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: background 0.2s;
+}
+
+.method-tab-header:hover {
+  background: #f3f4f6;
+}
+
+.method-arrow {
+  font-size: 0.7rem;
+  color: #6b7280;
+  transition: transform 0.2s;
+}
+
+.method-tab-content {
+  display: none;
+  padding: 1rem;
+  background: #ffffff;
+}
+
+.method-tab-content.open {
+  display: block;
+}
+
+.method-tab-content .code-block {
+  margin: 0;
+}
+
+/* Swagger UI embed overrides */
+#swagger-ui-embed {
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+#swagger-ui-embed .swagger-ui .topbar,
+#swagger-ui-embed .swagger-ui .info,
+#swagger-ui-embed .swagger-ui .opblock-tag-section > .opblock-tag,
+#swagger-ui-embed .swagger-ui .operation-servers,
+#swagger-ui-embed .swagger-ui .responses-inner > .responses-table {
+  display: none;
+}
+
+#swagger-ui-embed .swagger-ui .scheme-container {
+  padding: 0.5rem 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+#swagger-ui-embed .swagger-ui .opblock {
+  box-shadow: none;
+}
+
+#swagger-ui-embed .swagger-ui textarea.body-param__text {
+  min-height: 150px;
+  font-size: 0.85rem;
+}
+
+.swagger-loading-hint {
+  color: #6b7280;
+  font-size: 0.85rem;
+  font-style: italic;
+  text-align: center;
+  padding: 1rem 0;
+}
+
 /* Main Container */
 .main-container {
   min-height: 100vh;
@@ -366,6 +459,19 @@ body {
 
 .demo-link:active {
   transform: translateY(0);
+}
+
+/* Coming soon nav button */
+.demo-link-coming-soon {
+  background: #94a3b8;
+  cursor: default;
+  position: relative;
+}
+
+.demo-link-coming-soon:hover {
+  background: #94a3b8;
+  transform: none;
+  box-shadow: none;
 }
 
 /* Demo Content */

--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -55,7 +55,7 @@
         <div class="method-accordion">
           <!-- Method 1: cURL -->
           <div class="method-tab">
-            <button class="method-tab-header" data-method="curl">
+            <button class="method-tab-header" data-method="curl" aria-expanded="false" aria-controls="method-curl">
               <span class="method-arrow">&#9654;</span> cURL
             </button>
             <div class="method-tab-content" id="method-curl">
@@ -78,7 +78,7 @@ tools:
         address:
           type: string
           description: The new address
-instructions: >
+instructions: |
   You help users fill out forms.
   Call get_form_data to read current field values.
   Call update_form_data to save changes.
@@ -88,7 +88,7 @@ instructions: >
 
           <!-- Method 2: Interactive API -->
           <div class="method-tab">
-            <button class="method-tab-header" data-method="swagger">
+            <button class="method-tab-header" data-method="swagger" aria-expanded="false" aria-controls="method-swagger">
               <span class="method-arrow">&#9654;</span> Interactive API
             </button>
             <div class="method-tab-content" id="method-swagger">
@@ -99,7 +99,7 @@ instructions: >
 
           <!-- Method 3: Visual Builder -->
           <div class="method-tab">
-            <button class="method-tab-header" data-method="builder">
+            <button class="method-tab-header" data-method="builder" aria-expanded="false" aria-controls="method-builder">
               <span class="method-arrow">&#9654;</span> Visual Builder
             </button>
             <div class="method-tab-content" id="method-builder">
@@ -336,13 +336,17 @@ instructions: >
         const isOpen = content.classList.contains('open');
 
         // Close all tabs
+        document.querySelectorAll('.method-tab-header').forEach(b => {
+          b.setAttribute('aria-expanded', 'false');
+          b.querySelector('.method-arrow').textContent = '\u25B6';
+        });
         document.querySelectorAll('.method-tab-content').forEach(c => c.classList.remove('open'));
-        document.querySelectorAll('.method-arrow').forEach(a => { a.textContent = '\u25B6'; });
 
         // Toggle clicked tab
         if (!isOpen) {
           content.classList.add('open');
           arrow.textContent = '\u25BC';
+          btn.setAttribute('aria-expanded', 'true');
 
           // Lazy-load Swagger UI on first open
           if (method === 'swagger' && !swaggerLoaded) {
@@ -354,6 +358,10 @@ instructions: >
 
             const script = document.createElement('script');
             script.src = '/swagger-ui/swagger-ui-bundle.js';
+            const embedEl = document.getElementById('swagger-ui-embed');
+            function showSwaggerError(msg) {
+              embedEl.textContent = 'Could not load API explorer: ' + msg;
+            }
             script.onload = () => {
               const hint = document.querySelector('.swagger-loading-hint');
               if (hint) hint.remove();
@@ -362,22 +370,28 @@ instructions: >
               fetch(normalizedBase + '/openapi.json')
                 .then(r => r.json())
                 .then(spec => {
-                  const filtered = Object.assign({}, spec, {
-                    paths: {
-                      '/v1/agents': { post: spec.paths['/v1/agents'].post }
-                    }
-                  });
-                  SwaggerUIBundle({
-                    dom_id: '#swagger-ui-embed',
-                    spec: filtered,
-                    docExpansion: 'full',
-                    defaultModelsExpandDepth: -1,
-                    tryItOutEnabled: true,
-                    presets: [SwaggerUIBundle.presets.apis],
-                    layout: 'BaseLayout'
-                  });
-                });
+                  try {
+                    const filtered = Object.assign({}, spec, {
+                      paths: {
+                        '/v1/agents': { post: spec.paths['/v1/agents'].post }
+                      }
+                    });
+                    SwaggerUIBundle({
+                      dom_id: '#swagger-ui-embed',
+                      spec: filtered,
+                      docExpansion: 'full',
+                      defaultModelsExpandDepth: -1,
+                      tryItOutEnabled: true,
+                      presets: [SwaggerUIBundle.presets.apis],
+                      layout: 'BaseLayout'
+                    });
+                  } catch (err) {
+                    showSwaggerError(err.message);
+                  }
+                })
+                .catch(err => showSwaggerError(err.message));
             };
+            script.onerror = () => showSwaggerError('failed to load swagger-ui-bundle.js');
             document.head.appendChild(script);
           }
         }

--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -49,8 +49,17 @@
       <!-- Step 1 -->
       <div class="integration-step">
         <h3>1. Create Your Agent</h3>
-        <p>Register an agent via the API with a name, instructions, and tool schemas:</p>
-        <pre class="code-block"><code>curl -X POST https://your-server.com/v1/agents \
+        <p>Register an agent via the API. Choose a method:</p>
+
+        <!-- Accordion -->
+        <div class="method-accordion">
+          <!-- Method 1: cURL -->
+          <div class="method-tab">
+            <button class="method-tab-header" data-method="curl">
+              <span class="method-arrow">&#9654;</span> cURL
+            </button>
+            <div class="method-tab-content" id="method-curl">
+              <pre class="code-block"><code>curl -X POST https://your-server.com/v1/agents \
   -H "Authorization: Bearer ozw_your-api-key" \
   -H "Content-Type: application/yaml" \
   -d '
@@ -74,6 +83,22 @@ instructions: >
   Call get_form_data to read current field values.
   Call update_form_data to save changes.
 '</code></pre>
+            </div>
+          </div>
+
+          <!-- Method 2: Interactive API -->
+          <div class="method-tab">
+            <button class="method-tab-header" data-method="swagger">
+              <span class="method-arrow">&#9654;</span> Interactive API
+            </button>
+            <div class="method-tab-content" id="method-swagger">
+              <div id="swagger-ui-embed"></div>
+              <p class="swagger-loading-hint">Loading API explorer...</p>
+            </div>
+          </div>
+
+        </div>
+
         <p>You'll get back an <code>agent_key</code> to use in the next step.
           The agent key carries the personality, model, and tools &mdash; no client-side config needed.</p>
         <p><strong>Key:</strong> Tool schemas (description + inputSchema) are stored server-side
@@ -285,6 +310,64 @@ instructions: >
       if (e.key === 'Escape' && panel.classList.contains('open')) {
         panel.classList.remove('open');
       }
+    });
+
+    // Method accordion
+    let swaggerLoaded = false;
+    document.querySelectorAll('.method-tab-header').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const method = btn.dataset.method;
+        const content = document.getElementById('method-' + method);
+        const arrow = btn.querySelector('.method-arrow');
+        const isOpen = content.classList.contains('open');
+
+        // Close all tabs
+        document.querySelectorAll('.method-tab-content').forEach(c => c.classList.remove('open'));
+        document.querySelectorAll('.method-arrow').forEach(a => { a.textContent = '\u25B6'; });
+
+        // Toggle clicked tab
+        if (!isOpen) {
+          content.classList.add('open');
+          arrow.textContent = '\u25BC';
+
+          // Lazy-load Swagger UI on first open
+          if (method === 'swagger' && !swaggerLoaded) {
+            swaggerLoaded = true;
+            const link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.href = '/swagger-ui/swagger-ui.css';
+            document.head.appendChild(link);
+
+            const script = document.createElement('script');
+            script.src = '/swagger-ui/swagger-ui-bundle.js';
+            script.onload = () => {
+              const hint = document.querySelector('.swagger-loading-hint');
+              if (hint) hint.remove();
+
+              // Fetch spec and filter to POST /v1/agents only
+              fetch(normalizedBase + '/openapi.json')
+                .then(r => r.json())
+                .then(spec => {
+                  const filtered = Object.assign({}, spec, {
+                    paths: {
+                      '/v1/agents': { post: spec.paths['/v1/agents'].post }
+                    }
+                  });
+                  SwaggerUIBundle({
+                    dom_id: '#swagger-ui-embed',
+                    spec: filtered,
+                    docExpansion: 'full',
+                    defaultModelsExpandDepth: -1,
+                    tryItOutEnabled: true,
+                    presets: [SwaggerUIBundle.presets.apis],
+                    layout: 'BaseLayout'
+                  });
+                });
+            };
+            document.head.appendChild(script);
+          }
+        }
+      });
     });
   </script>
 </body>

--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -97,6 +97,17 @@ instructions: >
             </div>
           </div>
 
+          <!-- Method 3: Visual Builder -->
+          <div class="method-tab">
+            <button class="method-tab-header" data-method="builder">
+              <span class="method-arrow">&#9654;</span> Visual Builder
+            </button>
+            <div class="method-tab-content" id="method-builder">
+              <p>Configure your agent visually using the Q form builder — no YAML or cURL needed.</p>
+              <a href="/register.html" class="demo-link" style="display:inline-block; margin-top:0.5rem;">Open Agent Builder →</a>
+            </div>
+          </div>
+
         </div>
 
         <p>You'll get back an <code>agent_key</code> to use in the next step.
@@ -158,6 +169,9 @@ instructions: >
         </a>
         <a href="/agent.html" class="demo-link">
           Talk to an Agent →
+        </a>
+        <a href="/register.html" class="demo-link">
+          Create an Agent →
         </a>
       </div>
     </header>

--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -158,7 +158,7 @@ instructions: |
     <header class="header">
       <h1 class="header-title">Ozwell Chatbot Client Demo</h1>
       <p class="header-subtitle">
-        Embedded chat with tool execution via iframe-sync and postMessage
+        Embedded chat with tool execution via MCP JSON-RPC and postMessage
       </p>
       <div class="demo-links">
         <a href="https://youtube.com/shorts/mqcoEoQzQMM?si=FLa_dq_4y2TeO_48" target="_blank" class="demo-link">
@@ -223,14 +223,11 @@ instructions: |
             Widget->>Widget: Parse tool calls from response
             end
 
-            Widget->>Handler: 4. postMessage: tool_call
+            Widget->>Handler: 4. MCP JSON-RPC: tools/call
             Note over Widget,Handler: Only tool calls cross boundary
             Handler->>Handler: 5. Execute tool (update form)
 
-            Handler-->>Widget: 6. postMessage: tool_result
-
-            Browser->>Widget: 7. iframe-sync: state update
-            Note over Browser,Widget: Widget always has page context
+            Handler-->>Widget: 6. MCP JSON-RPC response
           </div>
         </div>
       </div>
@@ -259,7 +256,7 @@ instructions: |
         <!-- Event Log -->
         <div class="event-log-container">
           <h3>Live Event Log</h3>
-          <p class="event-log-hint">Watch iframe-sync and postMessage in action</p>
+          <p class="event-log-hint">Watch MCP tool calls and postMessage in action</p>
           <div id="event-log" class="event-log"></div>
         </div>
       </div>
@@ -267,7 +264,7 @@ instructions: |
 
     <!-- Footer -->
     <footer class="footer">
-      Built with: Fastify • iframe-sync • postMessage • Mock AI
+      Built with: Fastify • MCP JSON-RPC • postMessage • Mock AI
     </footer>
   </div>
 

--- a/landing-page/public/register.html
+++ b/landing-page/public/register.html
@@ -248,7 +248,7 @@
       keyStatus.className = 'key-status';
 
       try {
-        const resp = await fetch(normalizedBase + '/v1/agents', {
+        const resp = await fetch(normalizedBase + '/v1/keys/validate', {
           headers: { 'Authorization': `Bearer ${key}` }
         });
         if (resp.ok) {
@@ -403,9 +403,13 @@
     }
 
     // Copy agent key
-    copyBtn.addEventListener('click', () => {
-      navigator.clipboard.writeText(agentKeyValue.textContent);
-      copyBtn.textContent = 'Copied!';
+    copyBtn.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(agentKeyValue.textContent);
+        copyBtn.textContent = 'Copied!';
+      } catch {
+        copyBtn.textContent = 'Failed';
+      }
       setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500);
     });
   </script>

--- a/landing-page/public/register.html
+++ b/landing-page/public/register.html
@@ -232,6 +232,13 @@
     const agentKeyValue = document.getElementById('agent-key-value');
     const copyBtn = document.getElementById('copy-btn');
 
+    // Reset validated state if key is edited after validation
+    apiKeyInput.addEventListener('input', () => {
+      apiKeyValidated = false;
+      keyStatus.textContent = '';
+      keyStatus.className = 'key-status';
+    });
+
     // Validate API key
     validateBtn.addEventListener('click', async () => {
       const key = apiKeyInput.value.trim();
@@ -291,24 +298,29 @@
       ],
     };
 
+    const YAML_SPECIAL_CHARS = /[:#\[\]{}&*!|>'"%@`]/;
+
     // Convert Q config object to Ozwell agent YAML
     function configToYaml(config) {
+      function scalarValue(val) {
+        return YAML_SPECIAL_CHARS.test(val) ? JSON.stringify(val) : val;
+      }
       const lines = [];
-      if (config.name) lines.push(`name: ${config.name}`);
-      if (config.instructions) lines.push(`instructions: >\n  ${config.instructions.replace(/\n/g, '\n  ')}`);
-      if (config.model) lines.push(`model: ${config.model}`);
+      if (config.name) lines.push(`name: ${scalarValue(config.name)}`);
+      if (config.instructions) lines.push(`instructions: |\n  ${config.instructions.replace(/\n/g, '\n  ')}`);
+      if (config.model) lines.push(`model: ${scalarValue(config.model)}`);
       if (config.temperature != null) lines.push(`temperature: ${config.temperature}`);
       if (config.tools && config.tools.length) {
         lines.push('tools:');
         for (const tool of config.tools) {
-          lines.push(`  - name: ${tool.name}`);
-          if (tool.description) lines.push(`    description: ${tool.description}`);
+          lines.push(`  - name: ${scalarValue(tool.name)}`);
+          if (tool.description) lines.push(`    description: ${scalarValue(tool.description)}`);
           if (tool.inputSchema) lines.push(`    inputSchema: ${JSON.stringify(tool.inputSchema)}`);
         }
       }
       if (config.behavior && config.behavior.greeting) {
         lines.push('behavior:');
-        lines.push(`  greeting: ${config.behavior.greeting}`);
+        lines.push(`  greeting: ${scalarValue(config.behavior.greeting)}`);
       }
       return lines.join('\n') + '\n';
     }

--- a/landing-page/public/register.html
+++ b/landing-page/public/register.html
@@ -125,23 +125,6 @@
       font-size: 14px;
     }
 
-    /* Action buttons */
-    .actions { display: flex; gap: 10px; margin-top: 12px; }
-    .btn {
-      padding: 10px 24px;
-      border-radius: 8px;
-      border: none;
-      cursor: pointer;
-      font-size: 14px;
-      font-weight: 500;
-      transition: background 0.2s, opacity 0.2s;
-    }
-    .btn:disabled { opacity: 0.4; cursor: not-allowed; }
-    .btn-primary { background: #0066ff; color: #fff; }
-    .btn-primary:hover:not(:disabled) { background: #0052cc; }
-    .btn-secondary { background: #f3f4f6; color: #374151; border: 1px solid #e5e7eb; }
-    .btn-secondary:hover:not(:disabled) { background: #e5e7eb; }
-
     /* Result section */
     .result-section { display: none; }
     .result-section.visible { display: block; }
@@ -197,7 +180,7 @@
         <a href="/" class="back-link">&larr; Back to demos</a>
       </div>
       <h1 class="header-title">Create an Agent</h1>
-      <p class="header-subtitle">Configure your agent visually, then register it with one click.</p>
+      <p class="header-subtitle">Configure your agent visually, then hit Submit to register.</p>
     </header>
 
     <!-- 1. API Key -->
@@ -222,17 +205,7 @@
       </div>
     </div>
 
-    <!-- 3. Actions -->
-    <div class="section">
-      <h3>3. Create your agent</h3>
-      <p>Submit will generate the YAML and register the agent automatically.</p>
-      <div class="actions">
-        <button id="create-btn" class="btn btn-primary" disabled>Create Agent</button>
-        <button id="download-btn" class="btn btn-secondary" disabled>Download YAML</button>
-      </div>
-    </div>
-
-    <!-- 4. Result -->
+    <!-- 3. Result -->
     <div id="result-section" class="section result-section">
       <h3>Your agent key</h3>
       <p>Use this key in the widget embed code to connect to your agent.</p>
@@ -255,8 +228,6 @@
     const validateBtn = document.getElementById('validate-btn');
     const keyStatus = document.getElementById('key-status');
     const qOverlay = document.getElementById('q-overlay');
-    const createBtn = document.getElementById('create-btn');
-    const downloadBtn = document.getElementById('download-btn');
     const resultSection = document.getElementById('result-section');
     const agentKeyValue = document.getElementById('agent-key-value');
     const copyBtn = document.getElementById('copy-btn');
@@ -278,8 +249,6 @@
           keyStatus.textContent = 'Valid key';
           keyStatus.className = 'key-status valid';
           qOverlay.classList.add('hidden');
-          createBtn.disabled = false;
-          downloadBtn.disabled = false;
           mountQ();
         } else {
           keyStatus.textContent = 'Invalid key';
@@ -389,17 +358,12 @@
       });
     }
 
-    // Create agent
-    createBtn.addEventListener('click', createAgent);
-
     async function createAgent() {
       if (!apiKeyValidated || isCreating) return;
 
       const yaml = currentYaml || DEFAULT_YAML;
 
       isCreating = true;
-      createBtn.disabled = true;
-      createBtn.textContent = 'Creating...';
 
       try {
         const resp = await fetch(normalizedBase + '/v1/agents', {
@@ -424,14 +388,7 @@
       }
 
       isCreating = false;
-      createBtn.disabled = false;
-      createBtn.textContent = 'Create Agent';
     }
-
-    // Download YAML
-    downloadBtn.addEventListener('click', () => {
-      downloadYaml(currentYaml || DEFAULT_YAML);
-    });
 
     // Copy agent key
     copyBtn.addEventListener('click', () => {

--- a/landing-page/public/register.html
+++ b/landing-page/public/register.html
@@ -91,6 +91,9 @@
     .key-status.valid { color: #16a34a; }
     .key-status.invalid { color: #dc2626; }
 
+    /* Hide IVR-specific "Skip Patient Confirmation" checkbox from Q */
+    #q-mount .mb-4.pr-12 { display: none; }
+
     /* Q sandbox area */
     .q-section { position: relative; }
     .q-overlay {

--- a/landing-page/public/register.html
+++ b/landing-page/public/register.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Create an Agent — Ozwell</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      background: #fafafa;
+      min-height: 100vh;
+      padding: 20px;
+    }
+
+    .main-container { max-width: 800px; margin: 0 auto; }
+
+    /* Header — matches agent.html / tictactoe.html */
+    .header {
+      text-align: center;
+      color: #1a1a1a;
+      margin-bottom: 40px;
+      position: relative;
+    }
+    .back-link-container { position: absolute; left: 0; top: 10px; }
+    .back-link {
+      color: #0066ff;
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      opacity: 0.9;
+      transition: opacity 0.2s;
+    }
+    .back-link:hover { opacity: 1; text-decoration: underline; }
+    .header-title {
+      font-size: 32px;
+      font-weight: 700;
+      margin-bottom: 8px;
+      letter-spacing: -0.025em;
+    }
+    .header-subtitle { font-size: 16px; color: #6b7280; }
+
+    /* Sections */
+    .section {
+      background: #ffffff;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 20px;
+    }
+    .section h3 {
+      font-size: 16px;
+      font-weight: 700;
+      color: #1a1a1a;
+      margin-bottom: 8px;
+    }
+    .section p {
+      font-size: 14px;
+      color: #6b7280;
+      margin-bottom: 12px;
+    }
+
+    /* API Key input */
+    .api-key-row { display: flex; gap: 8px; }
+    .api-key-input {
+      flex: 1;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 10px 14px;
+      color: #1a1a1a;
+      font-family: monospace;
+      font-size: 14px;
+      outline: none;
+      transition: border-color 0.2s;
+    }
+    .api-key-input:focus { border-color: #0066ff; }
+    .validate-btn {
+      background: #0066ff;
+      border: none;
+      border-radius: 8px;
+      padding: 10px 20px;
+      color: #fff;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 500;
+      transition: background 0.2s;
+    }
+    .validate-btn:hover { background: #0052cc; }
+    .key-status { margin-top: 8px; font-size: 13px; min-height: 1.2em; }
+    .key-status.valid { color: #16a34a; }
+    .key-status.invalid { color: #dc2626; }
+
+    /* Q sandbox area */
+    .q-section { position: relative; }
+    .q-overlay {
+      position: absolute;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: rgba(250, 250, 250, 0.9);
+      border-radius: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+    }
+    .q-overlay span {
+      color: #9ca3af;
+      font-size: 15px;
+      font-weight: 500;
+    }
+    .q-overlay.hidden { display: none; }
+
+    #q-mount {
+      min-height: 300px;
+      background: #f9fafb;
+      border: 2px dashed #e5e7eb;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #9ca3af;
+      font-size: 14px;
+    }
+
+    /* Action buttons */
+    .actions { display: flex; gap: 10px; margin-top: 12px; }
+    .btn {
+      padding: 10px 24px;
+      border-radius: 8px;
+      border: none;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 500;
+      transition: background 0.2s, opacity 0.2s;
+    }
+    .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .btn-primary { background: #0066ff; color: #fff; }
+    .btn-primary:hover:not(:disabled) { background: #0052cc; }
+    .btn-secondary { background: #f3f4f6; color: #374151; border: 1px solid #e5e7eb; }
+    .btn-secondary:hover:not(:disabled) { background: #e5e7eb; }
+
+    /* Result section */
+    .result-section { display: none; }
+    .result-section.visible { display: block; }
+    .agent-key-box {
+      background: #f0fdf4;
+      border: 1px solid #86efac;
+      border-radius: 8px;
+      padding: 14px 16px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .agent-key-value {
+      font-family: monospace;
+      font-size: 14px;
+      color: #16a34a;
+      word-break: break-all;
+    }
+    .copy-btn {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      padding: 6px 14px;
+      color: #374151;
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: 500;
+      white-space: nowrap;
+      margin-left: 12px;
+      transition: background 0.2s;
+    }
+    .copy-btn:hover { background: #f3f4f6; }
+    .result-hint {
+      color: #9ca3af;
+      font-size: 13px;
+      margin-top: 8px;
+    }
+    .result-hint code {
+      background: #f3f4f6;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 12px;
+    }
+  </style>
+  <!-- Q agent config generator (bundled via esbuild) -->
+  <link rel="stylesheet" href="/vendor/q-bundle.css" />
+</head>
+<body>
+  <script src="/vendor/q-bundle.js"></script>
+  <div class="main-container">
+    <header class="header">
+      <div class="back-link-container">
+        <a href="/" class="back-link">&larr; Back to demos</a>
+      </div>
+      <h1 class="header-title">Create an Agent</h1>
+      <p class="header-subtitle">Configure your agent visually, then register it with one click.</p>
+    </header>
+
+    <!-- 1. API Key -->
+    <div class="section">
+      <h3>1. Enter your API key</h3>
+      <p>This acts as your login and will be used to register the agent.</p>
+      <div class="api-key-row">
+        <input type="password" id="api-key-input" class="api-key-input" placeholder="ozw_your-api-key" />
+        <button id="validate-btn" class="validate-btn">Validate</button>
+      </div>
+      <div id="key-status" class="key-status"></div>
+    </div>
+
+    <!-- 2. Q sandbox -->
+    <div class="section q-section">
+      <h3>2. Configure your agent</h3>
+      <div id="q-overlay" class="q-overlay">
+        <span>Enter your API key above to unlock</span>
+      </div>
+      <div id="q-mount">
+        Q agent config builder will load here
+      </div>
+    </div>
+
+    <!-- 3. Actions -->
+    <div class="section">
+      <h3>3. Create your agent</h3>
+      <p>Submit will generate the YAML and register the agent automatically.</p>
+      <div class="actions">
+        <button id="create-btn" class="btn btn-primary" disabled>Create Agent</button>
+        <button id="download-btn" class="btn btn-secondary" disabled>Download YAML</button>
+      </div>
+    </div>
+
+    <!-- 4. Result -->
+    <div id="result-section" class="section result-section">
+      <h3>Your agent key</h3>
+      <p>Use this key in the widget embed code to connect to your agent.</p>
+      <div class="agent-key-box">
+        <span id="agent-key-value" class="agent-key-value"></span>
+        <button id="copy-btn" class="copy-btn">Copy</button>
+      </div>
+      <p class="result-hint">Paste this as the <code>data-api-key</code> in your widget script tag.</p>
+    </div>
+  </div>
+
+  <script>
+    const referenceBaseUrl = '__REFERENCE_BASE_URL__';
+    const normalizedBase = referenceBaseUrl.replace(/\/$/, '');
+
+    let apiKeyValidated = false;
+    let currentYaml = null;
+
+    const apiKeyInput = document.getElementById('api-key-input');
+    const validateBtn = document.getElementById('validate-btn');
+    const keyStatus = document.getElementById('key-status');
+    const qOverlay = document.getElementById('q-overlay');
+    const createBtn = document.getElementById('create-btn');
+    const downloadBtn = document.getElementById('download-btn');
+    const resultSection = document.getElementById('result-section');
+    const agentKeyValue = document.getElementById('agent-key-value');
+    const copyBtn = document.getElementById('copy-btn');
+
+    // Validate API key
+    validateBtn.addEventListener('click', async () => {
+      const key = apiKeyInput.value.trim();
+      if (!key) { keyStatus.textContent = 'Please enter a key'; keyStatus.className = 'key-status invalid'; return; }
+
+      keyStatus.textContent = 'Validating...';
+      keyStatus.className = 'key-status';
+
+      try {
+        const resp = await fetch(normalizedBase + '/v1/agents', {
+          headers: { 'Authorization': `Bearer ${key}` }
+        });
+        if (resp.ok) {
+          apiKeyValidated = true;
+          keyStatus.textContent = 'Valid key';
+          keyStatus.className = 'key-status valid';
+          qOverlay.classList.add('hidden');
+          createBtn.disabled = false;
+          downloadBtn.disabled = false;
+          mountQ();
+        } else {
+          keyStatus.textContent = 'Invalid key';
+          keyStatus.className = 'key-status invalid';
+        }
+      } catch {
+        keyStatus.textContent = 'Could not reach server';
+        keyStatus.className = 'key-status invalid';
+      }
+    });
+
+    // Ozwell agent schema for Q form builder
+    const ozwellSchema = {
+      schemaType: 'mieforms-v1.0',
+      title: 'Ozwell Agent Configuration',
+      fields: [
+        {
+          id: 'sec-basic', fieldType: 'section', title: 'Basic Info',
+          fields: [
+            { id: 'name', fieldType: 'text', question: 'Agent Name', answer: 'My Agent', required: true },
+            { id: 'instructions', fieldType: 'longtext', question: 'Instructions', answer: 'You are a helpful assistant.', required: true },
+          ],
+        },
+        {
+          id: 'sec-model', fieldType: 'section', title: 'Model Settings',
+          fields: [
+            {
+              id: 'model', fieldType: 'dropdown', question: 'Model', answer: 'qwen2.5-coder:3b', required: false,
+              options: [
+                { id: 'm-gptoss', label: 'gpt-oss:latest', value: 'gpt-oss:latest' },
+                { id: 'm-qwen3b', label: 'qwen2.5-coder:3b', value: 'qwen2.5-coder:3b' },
+                { id: 'm-qwen7b', label: 'qwen2.5-coder:7b', value: 'qwen2.5-coder:7b' },
+                { id: 'm-llama3', label: 'llama3', value: 'llama3' },
+                { id: 'm-llama31', label: 'llama3.1', value: 'llama3.1' },
+              ],
+            },
+            { id: 'temperature', fieldType: 'text', question: 'Temperature (0.0 – 1.0)', answer: '0.7', required: false, configType: 'number' },
+          ],
+        },
+      ],
+    };
+
+    // Convert Q config object to Ozwell agent YAML
+    function configToYaml(config) {
+      const lines = [];
+      if (config.name) lines.push(`name: ${config.name}`);
+      if (config.instructions) lines.push(`instructions: >\n  ${config.instructions.replace(/\n/g, '\n  ')}`);
+      if (config.model) lines.push(`model: ${config.model}`);
+      if (config.temperature != null) lines.push(`temperature: ${config.temperature}`);
+      if (config.tools && config.tools.length) {
+        lines.push('tools:');
+        for (const tool of config.tools) {
+          lines.push(`  - name: ${tool.name}`);
+          if (tool.description) lines.push(`    description: ${tool.description}`);
+          if (tool.inputSchema) lines.push(`    inputSchema: ${JSON.stringify(tool.inputSchema)}`);
+        }
+      }
+      if (config.behavior && config.behavior.greeting) {
+        lines.push('behavior:');
+        lines.push(`  greeting: ${config.behavior.greeting}`);
+      }
+      return lines.join('\n') + '\n';
+    }
+
+    const DEFAULT_YAML = 'name: Test Agent\ninstructions: You are helpful.\n';
+
+    function downloadYaml(content) {
+      const blob = new Blob([content], { type: 'application/yaml' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'agent-config.yaml';
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+
+    // Mount Q after API key validation
+    let qGenerator = null;
+    let isCreating = false;
+
+    function mountQ() {
+      if (qGenerator) return;
+      const mount = document.getElementById('q-mount');
+      mount.textContent = '';
+      mount.style.display = 'block';
+      mount.style.alignItems = '';
+      mount.style.justifyContent = '';
+      mount.style.border = 'none';
+      mount.style.background = 'transparent';
+
+      qGenerator = new window.UniversalAgentConfigGenerator(mount, {
+        schema: ozwellSchema,
+        showEditor: true,
+      });
+
+      mount.addEventListener('config-change', (e) => {
+        currentYaml = configToYaml(e.detail);
+      });
+
+      mount.addEventListener('config-submit', (e) => {
+        currentYaml = e.detail.yaml;
+        createAgent();
+      });
+
+      mount.addEventListener('config-download', (e) => {
+        downloadYaml(e.detail.content);
+      });
+    }
+
+    // Create agent
+    createBtn.addEventListener('click', createAgent);
+
+    async function createAgent() {
+      if (!apiKeyValidated || isCreating) return;
+
+      const yaml = currentYaml || DEFAULT_YAML;
+
+      isCreating = true;
+      createBtn.disabled = true;
+      createBtn.textContent = 'Creating...';
+
+      try {
+        const resp = await fetch(normalizedBase + '/v1/agents', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${apiKeyInput.value.trim()}`,
+            'Content-Type': 'application/yaml',
+          },
+          body: yaml,
+        });
+
+        const data = await resp.json();
+
+        if (resp.ok && data.agent_key) {
+          agentKeyValue.textContent = data.agent_key;
+          resultSection.classList.add('visible');
+        } else {
+          alert('Failed to create agent: ' + (data.error?.message || JSON.stringify(data)));
+        }
+      } catch (e) {
+        alert('Error: ' + e.message);
+      }
+
+      isCreating = false;
+      createBtn.disabled = false;
+      createBtn.textContent = 'Create Agent';
+    }
+
+    // Download YAML
+    downloadBtn.addEventListener('click', () => {
+      downloadYaml(currentYaml || DEFAULT_YAML);
+    });
+
+    // Copy agent key
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(agentKeyValue.textContent);
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500);
+    });
+  </script>
+</body>
+</html>

--- a/landing-page/public/tictactoe.html
+++ b/landing-page/public/tictactoe.html
@@ -74,7 +74,7 @@
     </div>
 
     <footer class="footer">
-      Built with: Fastify • iframe-sync • postMessage • MCP Tools
+      Built with: Fastify • MCP JSON-RPC • postMessage • MCP Tools
     </footer>
   </div>
 

--- a/landing-page/server.js
+++ b/landing-page/server.js
@@ -18,6 +18,10 @@ const showcaseAgentKey = process.env.SHOWCASE_AGENT_KEY || '';
 
 const publicDir = path.join(__dirname, 'public');
 
+// Serve Swagger UI static files (lazy-loaded by integration guide)
+const swaggerUiDir = path.join(__dirname, '..', 'node_modules', '@fastify', 'swagger-ui', 'static');
+app.use('/swagger-ui', express.static(swaggerUiDir));
+
 // Serve static assets from public directory
 app.use('/assets', express.static(publicDir));
 

--- a/landing-page/server.js
+++ b/landing-page/server.js
@@ -24,6 +24,7 @@ app.use('/swagger-ui', express.static(swaggerUiDir));
 
 // Serve static assets from public directory
 app.use('/assets', express.static(publicDir));
+app.use('/vendor', express.static(path.join(publicDir, 'vendor')));
 
 // Serve landing page assets
 app.get('/assets/landing-app.js', (req, res) => {
@@ -66,6 +67,10 @@ app.get('/tictactoe.html', (req, res) => {
 
 app.get('/agent.html', (req, res) => {
   res.type('html').send(renderHtml('agent.html'));
+});
+
+app.get('/register.html', (req, res) => {
+  res.type('html').send(renderHtml('register.html'));
 });
 
 app.get('*', (req, res, next) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,450 @@
       "devDependencies": {
         "@playwright/test": "^1.57.0",
         "@types/node": "^24.10.1",
+        "esbuild": "^0.25.0",
         "typescript": "^5.9.3"
+      }
+    },
+    "landing-page/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "landing-page/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "landing-page/node_modules/@types/node": {
@@ -101,6 +544,48 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "landing-page/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/reference-server/README.md
+++ b/reference-server/README.md
@@ -62,14 +62,11 @@ sequenceDiagram
     Widget->>Widget: Parse tool calls from response
     end
 
-    Widget->>Handler: 4. postMessage: tool_call
+    Widget->>Handler: 4. MCP JSON-RPC: tools/call
     Note over Widget,Handler: Only tool calls cross boundary
     Handler->>Handler: 5. Execute tool (update form)
 
-    Handler-->>Widget: 6. postMessage: tool_result
-
-    Browser->>Widget: 7. iframe-sync: state update
-    Note over Browser,Widget: Widget always has page context
+    Handler-->>Widget: 6. MCP JSON-RPC response
 ```
 
 **Key Components:**
@@ -78,7 +75,7 @@ sequenceDiagram
 - **Ollama Container**: Runs LLM models (qwen2.5-coder:3b, llama3.1:8b, etc.)
 - **Widget**: Embeddable chat UI with iframe isolation
 - **SSE Heartbeat**: Keepalive comments every 25s to prevent 60s nginx timeout
-- **Tool Calls**: Extracted from streamed responses and sent to parent page via postMessage
+- **Tool Calls**: Extracted from streamed responses and sent to parent page via MCP JSON-RPC 2.0 over postMessage
 
 ### Agent Mode (PoC)
 
@@ -137,6 +134,8 @@ sequenceDiagram
 | `GET` | `/v1/agents` | Parent key | List agents under this key |
 | `GET` | `/v1/agents/:id` | Parent key | Get a specific agent |
 | `PUT` | `/v1/agents/:id` | Parent key | Update an agent definition |
+| `DELETE` | `/v1/agents/:id` | Parent key | Delete an agent |
+| `GET` | `/v1/keys/validate` | Any key | Validate an API key (returns 200 or 401) |
 
 #### Agent Definition Schema
 
@@ -551,7 +550,7 @@ src/
 embed/                  # Embeddable chat widget files
 ├── ozwell-loader.js    # Widget loader script to be embedded in parent pages
 ├── ozwell.html         # Widget iframe entry point (minimal HTML loader)
-└── ozwell.js           # Self-contained widget with bundled CSS, HTML, and IframeSyncClient
+└── ozwell.js           # Self-contained widget with bundled CSS, HTML, and MCP JSON-RPC messaging
 ```
 
 ### Adding New Endpoints

--- a/reference-server/embed/README.md
+++ b/reference-server/embed/README.md
@@ -72,46 +72,9 @@ Use the AI to improve text, then get it back with the "Save & Close" button:
 
 **Use cases:** Draft emails, improve notes, generate summaries, rewrite content - anytime you want AI help but don't need MCP tools.
 
-## Providing Page Context
-
-Send page data to the widget so the AI can answer questions about current state:
-
-```html
-<input id="user-name" value="Alice">
-<input id="user-email" value="alice@example.com">
-
-<script>
-  window.OzwellChatConfig = { model: 'llama3' };
-
-  // Send context when inputs change
-  function updateContext() {
-    OzwellChat.updateContext({
-      formData: {
-        name: document.getElementById('user-name').value,
-        email: document.getElementById('user-email').value
-      }
-    });
-  }
-
-  // Wait for widget to load, then send initial context and listen for changes
-  document.addEventListener('DOMContentLoaded', () => {
-    OzwellChat.ready().then(() => {
-      updateContext();
-      document.getElementById('user-name').addEventListener('input', updateContext);
-      document.getElementById('user-email').addEventListener('input', updateContext);
-    });
-  });
-</script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
-```
-
-Now users can ask: "What's my name?" and the AI responds: "Your name is Alice."
-
-**How it works:** Context is included in the system prompt for every message, so the AI always sees current page state.
-
 ## With MCP Tools
 
-Enable page interactions using MCP tools (OpenAI function calling format):
+Enable page interactions using MCP tools (OpenAI function calling format). The loader handles the MCP JSON-RPC protocol — your page listens for `ozwell-tool-call` DOM events:
 
 ```html
 <input id="user-email" type="email" placeholder="Enter email">
@@ -136,25 +99,13 @@ Enable page interactions using MCP tools (OpenAI function calling format):
     ]
   };
 
-  // Handle tool calls from widget
-  window.addEventListener('message', (event) => {
-    const data = event.data;
-    if (!data || data.source !== 'ozwell-chat-widget') return;
+  // Handle tool calls via DOM event (loader handles JSON-RPC automatically)
+  document.addEventListener('ozwell-tool-call', (e) => {
+    const { name, arguments: args, respond } = e.detail;
 
-    if (data.type === 'tool_call') {
-      const { tool, tool_call_id, payload } = data;
-
-      if (tool === 'update_email') {
-        document.getElementById('user-email').value = payload.email;
-
-        // Send result back to widget (MUST include tool_call_id)
-        window.OzwellChat.iframe.contentWindow.postMessage({
-          source: 'ozwell-chat-parent',
-          type: 'tool_result',
-          tool_call_id: tool_call_id,  // Required for OpenAI protocol
-          result: { success: true, message: 'Email updated successfully' }
-        }, '*');
-      }
+    if (name === 'update_email') {
+      document.getElementById('user-email').value = args.email;
+      respond({ success: true, message: 'Email updated successfully' });
     }
   });
 </script>
@@ -194,19 +145,6 @@ OzwellChat.mount({
   containerId: 'chat-container',  // Mount in specific element
   width: 400,                      // Widget width in pixels
   height: 500                      // Widget height in pixels
-});
-```
-
-### OzwellChat.updateContext(data)
-
-Send page state to the widget. Context is included in system prompt for every message.
-
-```javascript
-OzwellChat.updateContext({
-  formData: {
-    name: 'Alice',
-    email: 'alice@example.com'
-  }
 });
 ```
 
@@ -437,30 +375,25 @@ Messages sent from the widget iframe to the parent page. All messages include `s
 | Type | Payload | Description |
 |------|---------|-------------|
 | `ready` | — | Widget fully initialized and ready to receive messages |
-| `tool_call` | `{ tool, tool_call_id, payload }` | Request parent to execute an MCP tool |
-| `assistant_response` | `{ content }` | AI assistant sent a response |
+| `tool_call` | MCP JSON-RPC 2.0 request | Request parent to execute an MCP tool (use `ozwell-tool-call` DOM event instead) |
+| `assistant_response` | `{ hadToolCalls }` | AI assistant finished responding (signal only, no message content) |
 | `insert` | `{ text }` | User clicked "Save & Close" button |
 | `closed` | — | Widget was closed |
 
 #### Listening for Tool Calls
 
+Use the `ozwell-tool-call` DOM event (recommended) instead of raw postMessage:
+
 ```javascript
-window.addEventListener('message', (event) => {
-  // Security: validate origin if widget is hosted on a different domain
-  // if (event.origin !== 'https://your-widget-domain.com') return;
-
-  const data = event.data;
-  if (data?.source !== 'ozwell-chat-widget') return;
-
-  if (data.type === 'tool_call') {
-    const { tool, tool_call_id, payload } = data;
-    console.log(`Tool requested: ${tool}`, payload);
-    // Execute the tool, then send tool_result back
-  }
+document.addEventListener('ozwell-tool-call', (e) => {
+  const { name, arguments: args, respond } = e.detail;
+  console.log(`Tool requested: ${name}`, args);
+  // Execute the tool, then call respond() with the result
+  respond({ success: true });
 });
 ```
 
-> **Security Note:** When hosting the widget on a different domain, always validate `event.origin` to prevent malicious sites from sending fake tool_call messages.
+> **Note:** The loader handles MCP JSON-RPC 2.0 and origin validation automatically. Only use raw `postMessage` listeners if you're not using `ozwell-loader.js`.
 
 #### Listening for Widget Ready
 


### PR DESCRIPTION
## Summary

Closes #83. Implements #82.

Adds a 3-method expandable accordion to the landing page integration guide and a full visual agent builder page:

1. **cURL** — copy-paste curl command in a collapsible section
2. **Interactive API** — lazy-loaded Swagger UI filtered to `POST /v1/agents`
3. **Visual Builder** — links to `/register.html`, a dedicated agent creation page powered by Q

### Register Page (`/register.html`)
- API key validation against the reference server
- Q form builder with Form Builder, Tool Builder, and Config Editor (Monaco) tabs
- One-click agent creation via `POST /v1/agents` with generated YAML
- YAML download for offline use
- Hidden IVR-specific "Skip Patient Confirmation" checkbox (not relevant to Ozwell)

## Quick Review Setup

```bash
gh pr checkout 87

# If you have Ollama running locally, no changes needed.
# Otherwise, update reference-server/.env to use the hosted container:
# OLLAMA_BASE_URL=https://ollama-ozwell-fw.opensource.mieweb.org

# Start both servers (builds TS client, reference server on :3000, landing page on :8080):
./scripts/start.sh
```

### What to test

- **Landing page accordion** — Open http://localhost:8080/. Scroll to the integration guide. Click each of the 3 methods (cURL, Interactive API, Visual Builder) and verify they expand/collapse. Only one should be open at a time.
- **Swagger UI** — Click "Interactive API" in the accordion. Swagger UI should lazy-load and show the `POST /v1/agents` endpoint. Try the "Try it out" button with a valid API key.
- **Register page** — Click "Visual Builder" or go to http://localhost:8080/register.html. Enter `ozw_demo_localhost_key_for_testing` and click Validate. The Q form builder should unlock. Fill in agent name and instructions, pick a model, hit Submit. You should get back an agent key.
- **YAML download** — On the register page, click the download button. Verify the downloaded YAML matches what you configured in the form.

## Changes

- `landing-page/public/landing.html` — accordion UI with 3 methods + "Create an Agent" header link
- `landing-page/public/register.html` — new visual agent builder page
- `landing-page/public/demo.css` — Swagger UI CSS overrides
- `landing-page/server.js` — `/vendor`, `/register.html` routes, Swagger UI static files
- `landing-page/package.json` — esbuild dep + `build:q` script
- `package-lock.json` — updated

## Stacked PR

This is PR 4 of 5 in a linear stack. Merge in this order:

1. #84 — Agent Registration API
2. #86 — MCP Widget + Agent Demos
3. #93 — Reasoning Token Support
4. **#87 — Integration Guide + Visual Builder** (this PR)
5. #74 — Portkey Gateway Integration
