### PR TITLE
feat: reasoning token support with thinking bubble UI and model robustness

### DIFF
--- a/landing-page/public/agent.html
+++ b/landing-page/public/agent.html
@@ -476,7 +476,9 @@
             placeholder: 'Type a question or command...',
             apiKey: '__SHOWCASE_AGENT_KEY__',
             welcomeMessage: "How can I help with your support tickets?",
-            debug: false
+            debug: false,
+            thinkingEnabled: true,
+            thinkingDefaultMode: 2
         };
 
         // Load widget

--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -251,7 +251,9 @@ instructions: >
       welcomeMessage: 'Hi! I can help update your name, address, or zip code. Just ask!',
       // system prompt is now managed by the agent definition (server-side)
       apiKey: '__LANDING_AGENT_KEY__', // injected from LANDING_AGENT_KEY env var
-      debug: true // Shows tool execution pills for developers (set false for production)
+      debug: true, // Shows tool execution pills for developers (set false for production)
+      thinkingEnabled: true, // Show reasoning/thinking tokens from models
+      thinkingDefaultMode: 2 // Expand while thinking, collapse on answer
       // tools are auto-discovered from the agent config via MCP handshake
     };
 

--- a/landing-page/public/landing.js
+++ b/landing-page/public/landing.js
@@ -325,7 +325,7 @@
 
         if (updates.length > 0) {
           logEvent('postmessage', '[Handler] Form data updated', `Updated: ${updates.join(', ')}`);
-          respond({ success: true, message: `Updated: ${updates.join(', ')}` });
+          respond({ success: true, updated: updates });
         } else {
           respond({ success: false, error: 'No fields provided to update' });
         }

--- a/landing-page/public/tictactoe-app.js
+++ b/landing-page/public/tictactoe-app.js
@@ -519,7 +519,7 @@ function handleMakeMove(position, respond) {
 
   // Safety: Only allow make_move when it's X's turn
   if (currentPlayer !== 'X') {
-    respond({ success: false, error: "Not X's turn. Call ai_move instead." });
+    respond({ success: false, error: "It's O's turn, not X's." });
     return;
   }
 
@@ -556,7 +556,7 @@ function handleMakeMove(position, respond) {
 
   // If game continues and it's now O's turn, trigger AI the same way as clicks
   if (!gameEnded && currentPlayer === 'O') {
-    sendUserMessageToWidget(`I placed my X. It's your turn as O.`);
+    sendUserMessageToWidget(`I placed X at ${positionName}. Your turn.`);
   }
 }
 
@@ -590,7 +590,14 @@ document.addEventListener('ozwell-tool-call', (e) => {
 
   logEvent(`Tool call received: ${name}`, 'tool-call');
 
-  if (name === 'make_move') {
+  if (name === 'get_board') {
+    respond({
+      board: boardState.map((v, i) => v || i),
+      currentPlayer: currentPlayer,
+      gameOver: gameOver,
+      winner: winner
+    });
+  } else if (name === 'make_move') {
     handleMakeMove(args.position, respond);
   } else if (name === 'ai_move') {
     handleAiMove(respond);
@@ -646,9 +653,13 @@ function handleUserClick(index) {
   currentPlayer = 'X';
   const gameEnded = placePieceAndCheckWin(index, positionName);
 
-  // If game continues, send message to LLM to trigger its turn
-  if (!gameEnded) {
-    sendUserMessageToWidget(`I placed my X at ${positionName}. It's your turn as O.`);
+  if (gameEnded) {
+    // Tell the LLM the game result so it can respond
+    const result = winner === 'X' ? 'X wins!' : winner === 'draw' ? "It's a draw!" : 'Game over.';
+    sendUserMessageToWidget(`Game over. ${result}`);
+  } else {
+    // Game continues, trigger AI turn
+    sendUserMessageToWidget(`I placed X at ${positionName}. Your turn.`);
   }
 }
 

--- a/landing-page/public/tictactoe-app.js
+++ b/landing-page/public/tictactoe-app.js
@@ -591,11 +591,16 @@ document.addEventListener('ozwell-tool-call', (e) => {
   logEvent(`Tool call received: ${name}`, 'tool-call');
 
   if (name === 'get_board') {
+    const emptySquares = boardState
+      .map((v, i) => v ? null : i)
+      .filter(i => i !== null);
     respond({
       board: boardState.map((v, i) => v || i),
       currentPlayer: currentPlayer,
       gameOver: gameOver,
-      winner: winner
+      winner: winner,
+      difficulty: getAIDifficulty(),
+      availablePositions: emptySquares
     });
   } else if (name === 'make_move') {
     handleMakeMove(args.position, respond);

--- a/landing-page/public/tictactoe.html
+++ b/landing-page/public/tictactoe.html
@@ -88,7 +88,9 @@
       // model and system prompt are managed by the agent definition (server-side)
       apiKey: '__TICTACTOE_AGENT_KEY__', // injected from TICTACTOE_AGENT_KEY env var
       welcomeMessage: 'Click any square to play, or type moves like "play center". I\'m O, you\'re X!',
-      debug: false // Disable debug mode for clean game experience
+      debug: false, // Disable debug mode for clean game experience
+      thinkingEnabled: true,
+      thinkingDefaultMode: 2
       // tools are auto-discovered from the agent config via MCP handshake
     };
 

--- a/reference-server/embed/ozwell-loader.js
+++ b/reference-server/embed/ozwell-loader.js
@@ -50,6 +50,8 @@
     // model is optional - server chooses default if not specified by client
     endpoint: autoDetectedBase ? `${autoDetectedBase}/v1/chat/completions` : '/v1/chat/completions',
     widgetUrl: autoDetectedBase ? `${autoDetectedBase}/embed/ozwell.html` : '/embed/ozwell.html',
+    thinkingEnabled: false, // Display reasoning/thinking tokens from models
+    thinkingDefaultMode: 2, // 0=None, 1=Peek, 2=Smart (expand-then-collapse), 3=Expanded
   };
 
   const state = {

--- a/reference-server/embed/ozwell.js
+++ b/reference-server/embed/ozwell.js
@@ -667,8 +667,9 @@ const REASONING_MODES = ['None', 'Peek', 'Smart', 'Expanded'];
  */
 function initReasoningControls() {
   if (!reasoningControlsEl || !state.config.thinkingEnabled) return;
+  reasoningControlsEl.innerHTML = '';
 
-  const capsule = document.createElement('span');
+  const capsule = document.createElement('button');
   capsule.className = 'reasoning-capsule';
   capsule.title = 'Controls how AI reasoning is displayed';
   capsule.textContent = `Reasoning: ${REASONING_MODES[state.config.thinkingDefaultMode] || 'Smart'}`;
@@ -1182,8 +1183,11 @@ function createThinkingBubble(mode) {
 
   const arrow = document.createElement('span');
   arrow.className = 'thinking-arrow';
-  arrow.textContent = '▾';
+  arrow.textContent = mode === THINKING.PEEK ? '▸' : '▾';
 
+  toggle.setAttribute('role', 'button');
+  toggle.setAttribute('tabindex', '0');
+  toggle.setAttribute('aria-expanded', mode !== THINKING.PEEK ? 'true' : 'false');
   toggle.appendChild(dot);
   toggle.appendChild(label);
   toggle.appendChild(arrow);
@@ -1195,15 +1199,21 @@ function createThinkingBubble(mode) {
     contentEl.classList.add('collapsed');
   }
 
-  toggle.addEventListener('click', () => {
+  const handleToggle = () => {
     const isCollapsed = contentEl.classList.contains('collapsed');
     if (isCollapsed) {
       contentEl.classList.remove('collapsed');
       arrow.textContent = '▾';
+      toggle.setAttribute('aria-expanded', 'true');
     } else {
       contentEl.classList.add('collapsed');
       arrow.textContent = '▸';
+      toggle.setAttribute('aria-expanded', 'false');
     }
+  };
+  toggle.addEventListener('click', handleToggle);
+  toggle.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleToggle(); }
   });
 
   container.appendChild(toggle);

--- a/reference-server/embed/ozwell.js
+++ b/reference-server/embed/ozwell.js
@@ -47,16 +47,21 @@ body {
   flex-direction: column;
 }
 
-.status {
-  padding: 8px 16px;
-  font-size: 12px;
-  background: #f9fafb;
-  color: transparent;
-  border-bottom: 1px solid #e5e7eb;
-  min-height: 32px;
+.status-strip {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
+  padding: 4px 14px;
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+  min-height: 32px;
+}
+
+.status {
+  font-size: 12px;
+  color: transparent;
+  display: flex;
+  align-items: center;
 }
 
 .status.status--processing {
@@ -73,6 +78,61 @@ body {
   0%, 20% { content: '●'; }
   40% { content: '●●'; }
   60%, 100% { content: '●●●'; }
+}
+
+/* Reasoning mode capsule & segmented control */
+.reasoning-capsule {
+  font-size: 11px;
+  color: #6b7280;
+  cursor: pointer;
+  padding: 3px 10px;
+  border-radius: 12px;
+  background: #e5e7eb;
+  user-select: none;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.reasoning-capsule:hover {
+  background: #d1d5db;
+}
+
+.reasoning-seg {
+  display: none;
+  background: #e5e7eb;
+  border-radius: 12px;
+  padding: 2px;
+  gap: 2px;
+  font-size: 11px;
+}
+
+.reasoning-seg.open {
+  display: inline-flex;
+}
+
+.reasoning-seg-btn {
+  padding: 3px 10px;
+  border-radius: 10px;
+  cursor: pointer;
+  color: #6b7280;
+  background: transparent;
+  border: none;
+  font-size: 11px;
+  font-family: inherit;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.reasoning-seg-btn:hover {
+  color: #374151;
+  background: #d1d5db;
+}
+
+.reasoning-seg-btn.active {
+  background: #fff;
+  color: #1f2937;
+  font-weight: 600;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
 }
 
 .messages {
@@ -365,13 +425,89 @@ body {
   max-height: 300px;
   overflow-y: auto;
 }
+
+/* Thinking / Reasoning Bubble */
+.thinking-bubble {
+  align-self: flex-start;
+  max-width: 85%;
+  margin-bottom: 4px;
+}
+
+.thinking-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 11px;
+  background: #f3f0ff;
+  border: 1px solid #e0d8ff;
+  border-radius: 10px;
+  font-size: 11px;
+  color: #8b5cf6;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s;
+}
+
+.thinking-toggle:hover {
+  background: #ede9fe;
+}
+
+.thinking-toggle .thinking-arrow {
+  display: inline-block;
+  transition: transform 0.2s;
+  font-size: 10px;
+}
+
+.thinking-toggle .thinking-arrow.expanded {
+  transform: rotate(180deg);
+}
+
+.thinking-toggle .thinking-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: #8b5cf6;
+  border-radius: 50%;
+  animation: thinkingPulse 1.2s ease-in-out infinite;
+}
+
+@keyframes thinkingPulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+.thinking-content {
+  margin-top: 6px;
+  padding: 10px 14px;
+  background: #fafafa;
+  border-left: 2px solid #c4b5fd;
+  border-radius: 0 10px 10px 0;
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow: hidden;
+  transition: max-height 0.3s ease, opacity 0.3s ease, padding 0.3s ease;
+  max-height: 300px;
+  opacity: 1;
+}
+
+.thinking-content.collapsed {
+  max-height: 0;
+  opacity: 0;
+  padding: 0 14px;
+  margin-top: 0;
+}
   `;
   document.head.appendChild(style);
 
   // Inject HTML structure
   document.body.innerHTML = `
     <div class="chat-container">
-      <div id="status" class="status">Connecting...</div>
+      <div class="status-strip">
+        <div id="status" class="status">Connecting...</div>
+        <div id="reasoning-controls"></div>
+      </div>
       <div id="messages" class="messages"></div>
       <form id="chat-form" class="chat-form">
         <input
@@ -466,6 +602,8 @@ const state = {
     // model is optional - server chooses default if not specified
     endpoint: '/v1/chat/completions',
     debug: false, // Debug mode for developers
+    thinkingEnabled: false, // Show reasoning/thinking tokens from models
+    thinkingDefaultMode: 2, // 0=None, 1=Peek, 2=Smart (expand-then-collapse), 3=Expanded
   },
   messages: [],
   sending: false,
@@ -491,7 +629,7 @@ function trackPendingToolCall(id) {
 // Read OZWELL_CONFIG from window (set by embedding page before widget loads)
 if (typeof window !== 'undefined' && window.OZWELL_CONFIG) {
   const extConf = window.OZWELL_CONFIG;
-  const keys = ['endpoint', 'apiKey', 'openaiApiKey', 'title', 'placeholder', 'model', 'system', 'tools', 'debug', 'welcomeMessage'];
+  const keys = ['endpoint', 'apiKey', 'openaiApiKey', 'title', 'placeholder', 'model', 'system', 'tools', 'debug', 'welcomeMessage', 'thinkingEnabled', 'thinkingDefaultMode'];
   for (const k of keys) {
     if (extConf[k] !== undefined) state.config[k] = extConf[k];
   }
@@ -506,6 +644,8 @@ const messagesEl = document.getElementById('messages');
 const formEl = document.getElementById('chat-form');
 const inputEl = document.getElementById('chat-input');
 const submitButton = document.querySelector('.chat-submit');
+const reasoningControlsEl = document.getElementById('reasoning-controls');
+let lastAssistantMessage = '';
 
 /**
  * Post a message to the parent frame using the pinned origin when available.
@@ -514,6 +654,49 @@ const submitButton = document.querySelector('.chat-submit');
 function postToParent(message) {
   const targetOrigin = state.parentOrigin || '*';
   window.parent.postMessage(message, targetOrigin);
+}
+
+// Reasoning mode labels: index maps to thinkingDefaultMode values
+const REASONING_MODES = ['None', 'Peek', 'Smart', 'Expanded'];
+
+/**
+ * Build the reasoning capsule + segmented control in the status strip.
+ * Only shown when thinkingEnabled is true.
+ */
+function initReasoningControls() {
+  if (!reasoningControlsEl || !state.config.thinkingEnabled) return;
+
+  const capsule = document.createElement('span');
+  capsule.className = 'reasoning-capsule';
+  capsule.title = 'Controls how AI reasoning is displayed';
+  capsule.textContent = `Reasoning: ${REASONING_MODES[state.config.thinkingDefaultMode] || 'Smart'}`;
+
+  const seg = document.createElement('div');
+  seg.className = 'reasoning-seg';
+
+  REASONING_MODES.forEach((label, idx) => {
+    const btn = document.createElement('button');
+    btn.className = 'reasoning-seg-btn' + (idx === state.config.thinkingDefaultMode ? ' active' : '');
+    btn.textContent = label;
+    btn.addEventListener('click', () => {
+      seg.querySelectorAll('.reasoning-seg-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      state.config.thinkingDefaultMode = idx;
+      capsule.textContent = `Reasoning: ${label}`;
+      seg.classList.remove('open');
+      capsule.style.display = '';
+      console.log(`[widget.js] Reasoning mode changed to: ${label} (${idx})`);
+    });
+    seg.appendChild(btn);
+  });
+
+  capsule.addEventListener('click', () => {
+    capsule.style.display = 'none';
+    seg.classList.add('open');
+  });
+
+  reasoningControlsEl.appendChild(capsule);
+  reasoningControlsEl.appendChild(seg);
 }
 
 function setStatus(text, processing = false) {
@@ -710,6 +893,9 @@ function applyConfig(config) {
   }
 
   setStatus('', false);
+
+  // Initialize reasoning controls if thinking is enabled
+  initReasoningControls();
 }
 
 function buildMessages() {
@@ -946,6 +1132,84 @@ function updateToolExecutionResult(toolCallId, result) {
       }
     }
   }
+}
+
+/**
+ * Create a thinking bubble element for displaying reasoning tokens.
+ * @param {number} mode - Display mode (0=hide, 1=collapsed, 2=expand-then-collapse, 3=always-expanded)
+ * @returns {{ container: HTMLElement, contentEl: HTMLElement, update: Function, finish: Function }}
+ */
+function createThinkingBubble(mode) {
+  const container = document.createElement('div');
+  container.className = 'thinking-bubble';
+  const startTime = Date.now();
+
+  const toggle = document.createElement('div');
+  toggle.className = 'thinking-toggle';
+
+  const dot = document.createElement('span');
+  dot.className = 'thinking-dot';
+
+  const label = document.createElement('span');
+  label.textContent = 'Thinking';
+
+  const arrow = document.createElement('span');
+  arrow.className = 'thinking-arrow';
+  arrow.textContent = '▾';
+
+  toggle.appendChild(dot);
+  toggle.appendChild(label);
+  toggle.appendChild(arrow);
+
+  const contentEl = document.createElement('div');
+  contentEl.className = 'thinking-content';
+  // Start collapsed or expanded based on mode
+  if (mode === 1) {
+    // Peek: collapsed pill only
+    contentEl.classList.add('collapsed');
+  } else if (mode === 2 || mode === 3) {
+    // Smart & Expanded: start expanded while thinking
+    // arrow already points down (▾) which is correct for expanded
+  }
+
+  toggle.addEventListener('click', () => {
+    const isCollapsed = contentEl.classList.contains('collapsed');
+    if (isCollapsed) {
+      contentEl.classList.remove('collapsed');
+      arrow.textContent = '▾';
+    } else {
+      contentEl.classList.add('collapsed');
+      arrow.textContent = '▸';
+    }
+  });
+
+  container.appendChild(toggle);
+  container.appendChild(contentEl);
+
+  return {
+    container,
+    contentEl,
+    update(text) {
+      contentEl.textContent = text;
+    },
+    finish() {
+      // Calculate duration
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      const durationText = elapsed > 0 ? ` for ${elapsed}s` : '';
+
+      // Stop the pulsing dot
+      dot.remove();
+      label.textContent = `Thought${durationText}`;
+
+      // Smart (mode 2): collapse on answer arrival
+      if (mode === 2) {
+        contentEl.classList.add('collapsed');
+        arrow.textContent = '▸';
+      }
+      // Expanded (mode 3): stays expanded, arrow stays ▾
+      // Peek (mode 1): was already collapsed, stays collapsed
+    }
+  };
 }
 
 async function sendMessage(text) {
@@ -1250,7 +1514,11 @@ async function sendMessageStreaming(text, tools) {
     const decoder = new TextDecoder();
     let buffer = '';
     let fullContent = '';
+    let fullThinking = '';
     let accumulatedToolCalls = []; // Accumulate tool calls from deltas
+    let thinkingBubble = null; // Thinking bubble UI (created on first thinking token)
+    // Capture mode at stream start so mid-stream toggle doesn't cause inconsistency
+    const thinkingMode = state.config.thinkingDefaultMode ?? 2;
 
     while (true) {
       const { done, value } = await reader.read();
@@ -1271,11 +1539,31 @@ async function sendMessageStreaming(text, tools) {
 
             if (!delta) continue;
 
+            // Handle thinking/reasoning tokens
+            if (delta.thinking && state.config.thinkingEnabled && thinkingMode !== 0) {
+              fullThinking += delta.thinking;
+
+              // Create thinking bubble on first token
+              if (!thinkingBubble) {
+                thinkingBubble = createThinkingBubble(thinkingMode);
+                // Insert thinking bubble before the assistant message element
+                messagesEl?.insertBefore(thinkingBubble.container, assistantMsgEl);
+              }
+              thinkingBubble.update(fullThinking);
+              messagesEl.scrollTop = messagesEl.scrollHeight;
+            }
+
             // Handle text content (streaming)
             if (delta.content) {
               fullContent += delta.content;
               assistantMsgEl.textContent = fullContent;
               messagesEl.scrollTop = messagesEl.scrollHeight;
+
+              // Finish thinking bubble when content starts arriving
+              if (thinkingBubble) {
+                thinkingBubble.finish();
+                thinkingBubble = null;
+              }
             }
 
             // Handle tool calls (accumulate from deltas)
@@ -1316,6 +1604,12 @@ async function sendMessageStreaming(text, tools) {
           }
         }
       }
+    }
+
+    // Finish thinking bubble if stream ended without content arriving
+    if (thinkingBubble) {
+      thinkingBubble.finish();
+      thinkingBubble = null;
     }
 
     // Check if we have tool calls from deltas
@@ -1398,15 +1692,26 @@ async function sendMessageStreaming(text, tools) {
       // Skip notification - tool execution flow will notify when complete
     } else {
       // No tool calls, just text response
+      // Never-blank contract: if only thinking tokens arrived with no content, show explicit message
+      let displayContent = fullContent;
+      if (!fullContent.trim() && fullThinking.trim()) {
+        displayContent = 'The model produced reasoning but no final answer. Please try again.';
+      }
+
       const assistantMessage = {
         role: 'assistant',
-        content: fullContent || '(no response)',
+        content: displayContent || '(no response)',
+        ...(fullThinking ? { thinking: fullThinking } : {}),
       };
       state.messages.push(assistantMessage);
+      lastAssistantMessage = displayContent;
 
       // Update placeholder if empty
-      if (!fullContent.trim()) {
+      if (!displayContent.trim()) {
         assistantMsgEl.textContent = '(no response)';
+      } else if (!fullContent.trim() && fullThinking.trim()) {
+        // Thinking-only case: update the placeholder with the explicit message
+        assistantMsgEl.textContent = displayContent;
       }
 
       // Notify parent of assistant response (signal only — no message content)

--- a/reference-server/embed/ozwell.js
+++ b/reference-server/embed/ozwell.js
@@ -713,15 +713,18 @@ function applyThinkingModeToExisting(mode) {
     } else {
       bubble.style.display = '';
       const content = bubble.querySelector('.thinking-content');
-      const arrow = bubble.querySelector('.thinking-arrow');
       if (!content) return;
+      const arrow = bubble.querySelector('.thinking-arrow');
+      const toggle = bubble.querySelector('[aria-expanded]');
       if (mode === THINKING.EXPANDED) {
         content.classList.remove('collapsed');
         if (arrow) arrow.textContent = '▾';
+        if (toggle) toggle.setAttribute('aria-expanded', 'true');
       } else {
         // Peek or Smart: collapse
         content.classList.add('collapsed');
         if (arrow) arrow.textContent = '▸';
+        if (toggle) toggle.setAttribute('aria-expanded', 'false');
       }
     }
   });

--- a/reference-server/embed/ozwell.js
+++ b/reference-server/embed/ozwell.js
@@ -656,6 +656,8 @@ function postToParent(message) {
   window.parent.postMessage(message, targetOrigin);
 }
 
+// Thinking mode constants — used for thinkingDefaultMode config value
+const THINKING = { NONE: 0, PEEK: 1, SMART: 2, EXPANDED: 3 };
 // Reasoning mode labels: index maps to thinkingDefaultMode values
 const REASONING_MODES = ['None', 'Peek', 'Smart', 'Expanded'];
 
@@ -685,6 +687,7 @@ function initReasoningControls() {
       capsule.textContent = `Reasoning: ${label}`;
       seg.classList.remove('open');
       capsule.style.display = '';
+      applyThinkingModeToExisting(idx);
       console.log(`[widget.js] Reasoning mode changed to: ${label} (${idx})`);
     });
     seg.appendChild(btn);
@@ -697,6 +700,30 @@ function initReasoningControls() {
 
   reasoningControlsEl.appendChild(capsule);
   reasoningControlsEl.appendChild(seg);
+}
+
+/** Apply a mode change to all existing thinking bubbles in the chat */
+function applyThinkingModeToExisting(mode) {
+  if (!messagesEl) return;
+  const bubbles = messagesEl.querySelectorAll('.thinking-bubble');
+  bubbles.forEach(bubble => {
+    if (mode === THINKING.NONE) {
+      bubble.style.display = 'none';
+    } else {
+      bubble.style.display = '';
+      const content = bubble.querySelector('.thinking-content');
+      const arrow = bubble.querySelector('.thinking-arrow');
+      if (!content) return;
+      if (mode === THINKING.EXPANDED) {
+        content.classList.remove('collapsed');
+        if (arrow) arrow.textContent = '▾';
+      } else {
+        // Peek or Smart: collapse
+        content.classList.add('collapsed');
+        if (arrow) arrow.textContent = '▸';
+      }
+    }
+  });
 }
 
 function setStatus(text, processing = false) {
@@ -899,8 +926,8 @@ function applyConfig(config) {
 }
 
 function buildMessages() {
-  // Just return message history - system prompt is handled by buildSystemPrompt()
-  return [...state.messages];
+  // Strip thinking field — it's for UI display only, not re-sent to the model
+  return state.messages.map(({ thinking, ...rest }) => rest);
 }
 
 function buildSystemPrompt() {
@@ -1164,12 +1191,8 @@ function createThinkingBubble(mode) {
   const contentEl = document.createElement('div');
   contentEl.className = 'thinking-content';
   // Start collapsed or expanded based on mode
-  if (mode === 1) {
-    // Peek: collapsed pill only
+  if (mode === THINKING.PEEK) {
     contentEl.classList.add('collapsed');
-  } else if (mode === 2 || mode === 3) {
-    // Smart & Expanded: start expanded while thinking
-    // arrow already points down (▾) which is correct for expanded
   }
 
   toggle.addEventListener('click', () => {
@@ -1189,8 +1212,9 @@ function createThinkingBubble(mode) {
   return {
     container,
     contentEl,
-    update(text) {
-      contentEl.textContent = text;
+    update(newText) {
+      // Use direct textContent — thinking content replaces fully since it accumulates
+      contentEl.textContent = newText;
     },
     finish() {
       // Calculate duration
@@ -1201,15 +1225,24 @@ function createThinkingBubble(mode) {
       dot.remove();
       label.textContent = `Thought${durationText}`;
 
-      // Smart (mode 2): collapse on answer arrival
-      if (mode === 2) {
+      // Smart: collapse on answer arrival
+      if (mode === THINKING.SMART) {
         contentEl.classList.add('collapsed');
         arrow.textContent = '▸';
       }
-      // Expanded (mode 3): stays expanded, arrow stays ▾
-      // Peek (mode 1): was already collapsed, stays collapsed
     }
   };
+}
+
+// Debounced scroll-to-bottom using rAF to avoid per-chunk reflows
+let _scrollRafPending = false;
+function scrollToBottom() {
+  if (_scrollRafPending) return;
+  _scrollRafPending = true;
+  requestAnimationFrame(() => {
+    if (messagesEl) messagesEl.scrollTop = messagesEl.scrollHeight;
+    _scrollRafPending = false;
+  });
 }
 
 async function sendMessage(text) {
@@ -1455,10 +1488,12 @@ function parseToolCallsFromContent(content) {
   }
 }
 
-async function sendMessageStreaming(text, tools) {
+async function sendMessageStreaming(text, tools, _thinkingRetryCount = 0) {
   setStatus('Processing...', true);
   state.sending = true;
   formEl?.classList.add('is-sending');
+  lastAssistantMessage = '';
+  let _needsThinkingRetry = false;
 
   // Build system prompt
   const systemPrompt = buildSystemPrompt();
@@ -1518,7 +1553,7 @@ async function sendMessageStreaming(text, tools) {
     let accumulatedToolCalls = []; // Accumulate tool calls from deltas
     let thinkingBubble = null; // Thinking bubble UI (created on first thinking token)
     // Capture mode at stream start so mid-stream toggle doesn't cause inconsistency
-    const thinkingMode = state.config.thinkingDefaultMode ?? 2;
+    const thinkingMode = state.config.thinkingDefaultMode ?? THINKING.SMART;
 
     while (true) {
       const { done, value } = await reader.read();
@@ -1540,7 +1575,7 @@ async function sendMessageStreaming(text, tools) {
             if (!delta) continue;
 
             // Handle thinking/reasoning tokens
-            if (delta.thinking && state.config.thinkingEnabled && thinkingMode !== 0) {
+            if (delta.thinking && state.config.thinkingEnabled && thinkingMode !== THINKING.NONE) {
               fullThinking += delta.thinking;
 
               // Create thinking bubble on first token
@@ -1550,14 +1585,14 @@ async function sendMessageStreaming(text, tools) {
                 messagesEl?.insertBefore(thinkingBubble.container, assistantMsgEl);
               }
               thinkingBubble.update(fullThinking);
-              messagesEl.scrollTop = messagesEl.scrollHeight;
+              scrollToBottom();
             }
 
             // Handle text content (streaming)
             if (delta.content) {
               fullContent += delta.content;
               assistantMsgEl.textContent = fullContent;
-              messagesEl.scrollTop = messagesEl.scrollHeight;
+              scrollToBottom();
 
               // Finish thinking bubble when content starts arriving
               if (thinkingBubble) {
@@ -1692,39 +1727,58 @@ async function sendMessageStreaming(text, tools) {
       // Skip notification - tool execution flow will notify when complete
     } else {
       // No tool calls, just text response
-      // Never-blank contract: if only thinking tokens arrived with no content, show explicit message
       let displayContent = fullContent;
-      if (!fullContent.trim() && fullThinking.trim()) {
-        displayContent = 'The model produced reasoning but no final answer. Please try again.';
-      }
+      const trimmedContent = displayContent.trim();
+      const trimmedThinking = fullThinking.trim();
 
-      const assistantMessage = {
-        role: 'assistant',
-        content: displayContent || '(no response)',
-        ...(fullThinking ? { thinking: fullThinking } : {}),
-      };
-      state.messages.push(assistantMessage);
-      lastAssistantMessage = displayContent;
+      // Thinking-only response (no content, no tool calls) — retry with a cap
+      if (!trimmedContent && trimmedThinking) {
+        const MAX_THINKING_RETRIES = 3;
+        assistantMsgEl?.remove();
+        // Also remove the orphaned thinking bubble
+        const lastThinking = messagesEl?.querySelector('.thinking-bubble:last-of-type');
+        if (lastThinking) lastThinking.remove();
 
-      // Update placeholder if empty
-      if (!displayContent.trim()) {
+        if (_thinkingRetryCount < MAX_THINKING_RETRIES) {
+          console.log(`[widget.js] Thinking-only response, retrying (${_thinkingRetryCount + 1}/${MAX_THINKING_RETRIES})`);
+          // Flag retry — handled after finally to avoid state.sending race
+          _needsThinkingRetry = true;
+        } else {
+          // Exhausted retries — show user-friendly message
+          console.warn('[widget.js] Thinking-only responses exhausted retries');
+          addMessage('assistant', 'The model is not responding right now. Please try again or refresh the page.');
+          lastAssistantMessage = '';
+        }
+      } else if (!trimmedContent) {
         assistantMsgEl.textContent = '(no response)';
-      } else if (!fullContent.trim() && fullThinking.trim()) {
-        // Thinking-only case: update the placeholder with the explicit message
-        assistantMsgEl.textContent = displayContent;
+        lastAssistantMessage = '';
+      } else {
+        lastAssistantMessage = displayContent;
       }
 
-      // Notify parent of assistant response (signal only — no message content)
-      postToParent({
-        source: 'ozwell-chat-widget',
-        type: 'assistant_response',
-        hadToolCalls: false
-      });
+      if (!_needsThinkingRetry) {
+        // Only push to history if we have actual content
+        if (trimmedContent) {
+          const assistantMessage = {
+            role: 'assistant',
+            content: displayContent,
+            ...(trimmedThinking ? { thinking: fullThinking } : {}),
+          };
+          state.messages.push(assistantMessage);
+        }
 
-      // Send any queued message now that LLM is done (no tool calls pending)
-      if (state.queuedMessage) {
-        // Use setTimeout to let the UI update first
-        setTimeout(() => sendQueuedMessage(), 100);
+        // Notify parent of assistant response (signal only — no message content)
+        postToParent({
+          source: 'ozwell-chat-widget',
+          type: 'assistant_response',
+          hadToolCalls: false
+        });
+
+        // Send any queued message now that LLM is done (no tool calls pending)
+        if (state.queuedMessage) {
+          // Use setTimeout to let the UI update first
+          setTimeout(() => sendQueuedMessage(), 100);
+        }
       }
     }
 
@@ -1740,6 +1794,11 @@ async function sendMessageStreaming(text, tools) {
   } finally {
     state.sending = false;
     formEl?.classList.remove('is-sending');
+  }
+
+  // Retry after finally so state.sending is properly cleaned up first
+  if (_needsThinkingRetry) {
+    return sendMessageStreaming('', tools, _thinkingRetryCount + 1);
   }
 }
 
@@ -1895,12 +1954,9 @@ function handleParentMessage(event) {
       if (state.queuedMessage) {
         sendQueuedMessage();
       }
-    } else if (result.error) {
-      // Error case
-      addMessage('system', `Error: ${result.error}`);
     } else {
-      // Get tool - raw data returned, need to send back to LLM for final answer
-      console.log('[widget.js] Raw data tool result detected, continuing conversation with LLM');
+      // No display message — send tool result back to LLM for continuation
+      console.log('[widget.js] Sending tool result to LLM');
 
       // Get tool_call_id from parent response (required for OpenAI protocol)
       if (!toolCallId) {

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -47,6 +47,8 @@ type StreamingChoice = {
   index?: number;
   delta?: {
     content?: string;
+    thinking?: string;
+    reasoning_content?: string;
     finish_reason?: string;
   };
   finish_reason?: string;
@@ -130,6 +132,119 @@ function tryExtractToolCallsFromContent(content: string | undefined, tools?: Too
     // not JSON or not recognized
   }
   return null;
+}
+
+// Helper: extract thinking tokens from content that uses <think>...</think> tags (Ollama/Qwen)
+// Returns { thinking, content } — thinking is the extracted text, content is the remainder.
+function extractThinkTagsFromContent(text: string): { thinking: string; content: string } {
+  // Match <think>...</think> blocks (greedy within, but non-greedy across multiple blocks)
+  const thinkRegex = /<think>([\s\S]*?)<\/think>/g;
+  let thinking = '';
+  let match;
+  while ((match = thinkRegex.exec(text)) !== null) {
+    thinking += match[1];
+  }
+  // Strip all <think>...</think> blocks from content (preserve spacing for token integrity)
+  const content = text.replace(thinkRegex, '');
+  return { thinking, content };
+}
+
+// Normalize a streaming chunk: extract thinking tokens into delta.thinking
+// Handles:
+//   - Ollama/Qwen: <think>...</think> tags inside delta.content
+//   - DeepSeek: delta.reasoning_content field
+//   - Anthropic: already separate (future — passthrough)
+// Mutates and returns the chunk for forwarding.
+function normalizeChunkThinking(chunk: Record<string, unknown>, thinkBuffer: { partial: string }): Record<string, unknown> {
+  const choices = chunk.choices as Array<Record<string, unknown>> | undefined;
+  if (!choices || choices.length === 0) return chunk;
+
+  const choice = choices[0];
+  const delta = choice.delta as Record<string, unknown> | undefined;
+  if (!delta) return chunk;
+
+  // --- Ollama/Qwen3: reasoning field (separate from content) ---
+  if (delta.reasoning && typeof delta.reasoning === 'string') {
+    delta.thinking = delta.reasoning;
+    delete delta.reasoning;
+    // Also clean up empty content strings that Ollama sends alongside reasoning
+    if (delta.content === '') delete delta.content;
+    return chunk;
+  }
+
+  // --- DeepSeek: reasoning_content field ---
+  if (delta.reasoning_content && typeof delta.reasoning_content === 'string') {
+    delta.thinking = delta.reasoning_content;
+    delete delta.reasoning_content;
+    return chunk;
+  }
+
+  // --- Ollama/Qwen (older): <think> tags in content ---
+  // Only enter this branch if content might contain <think> tags or we have a partial buffer
+  if (delta.content && typeof delta.content === 'string') {
+    const raw = thinkBuffer.partial + delta.content;
+
+    // Fast path: no <think> tags and no buffered partial — pass through unchanged
+    if (!thinkBuffer.partial && !raw.includes('<think')) {
+      return chunk;
+    }
+
+    // Check for partial/open <think> tag at the end (tag not yet closed)
+    const lastOpenIdx = raw.lastIndexOf('<think>');
+    const lastCloseIdx = raw.lastIndexOf('</think>');
+
+    if (lastOpenIdx !== -1 && (lastCloseIdx === -1 || lastCloseIdx < lastOpenIdx)) {
+      // We're inside an unclosed <think> block — buffer everything after the last <think>
+      const before = raw.substring(0, lastOpenIdx);
+      thinkBuffer.partial = raw.substring(lastOpenIdx);
+
+      // Extract any completed <think>...</think> pairs from the "before" portion
+      const { thinking, content } = extractThinkTagsFromContent(before);
+      delta.content = content || undefined;
+      if (thinking) {
+        delta.thinking = thinking;
+      }
+      // Remove empty content to avoid sending blank deltas
+      if (!delta.content) delete delta.content;
+      return chunk;
+    }
+
+    // No unclosed tag — flush buffer and extract
+    thinkBuffer.partial = '';
+    const { thinking, content } = extractThinkTagsFromContent(raw);
+    delta.content = content || undefined;
+    if (thinking) {
+      delta.thinking = thinking;
+    }
+    if (!delta.content) delete delta.content;
+    return chunk;
+  }
+
+  return chunk;
+}
+
+// Normalize a non-streaming response message: extract thinking from content
+function normalizeMessageThinking(message: Record<string, unknown>): void {
+  // Ollama/Qwen3: reasoning field (separate from content)
+  if (message.reasoning && typeof message.reasoning === 'string') {
+    message.thinking = message.reasoning;
+    delete message.reasoning;
+  }
+
+  // DeepSeek: reasoning_content field on message
+  if (message.reasoning_content && typeof message.reasoning_content === 'string') {
+    message.thinking = message.reasoning_content;
+    delete message.reasoning_content;
+  }
+
+  // Ollama/Qwen (older): <think> tags in content
+  if (message.content && typeof message.content === 'string') {
+    const { thinking, content } = extractThinkTagsFromContent(message.content as string);
+    if (thinking) {
+      message.thinking = thinking;
+      message.content = content;
+    }
+  }
 }
 
 const chatRoute: FastifyPluginAsync = async (fastify) => {
@@ -436,23 +551,28 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
 
             // Buffer map for accumulating assistant content per chat id
             const buffers: Record<string, string> = {};
+            // Buffer for partial <think> tags that span multiple chunks
+            const thinkBuffer = { partial: '' };
 
             for await (const chunk of streamResponse) {
               try {
                 const id = chunk.id as string;
-                const choice = chunk.choices?.[0];
-                const delta = choice?.delta;
+
+                // Normalize thinking tokens before forwarding
+                const normalized = normalizeChunkThinking(chunk as unknown as Record<string, unknown>, thinkBuffer);
+                const choice = (normalized.choices as Array<Record<string, unknown>>)?.[0];
+                const delta = choice?.delta as Record<string, unknown> | undefined;
 
                 // Initialize buffer
                 if (!buffers[id]) buffers[id] = '';
 
                 // Accumulate content deltas for parsing when the stream finishes
                 if (delta?.content) {
-                  buffers[id] += delta.content;
+                  buffers[id] += delta.content as string;
                 }
 
-                // Forward original chunk unchanged
-                reply.raw.write(`data: ${JSON.stringify(chunk)}\n\n`);
+                // Forward normalized chunk (thinking extracted into delta.thinking)
+                reply.raw.write(`data: ${JSON.stringify(normalized)}\n\n`);
 
                 // If model finished this message, attempt to parse as tool call and emit tool_calls
                 const finishReason = (choice as StreamingChoice)?.finish_reason || (delta as StreamingChoice)?.finish_reason;
@@ -524,15 +644,21 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
             stream: false,
           };
           const response = await ollamaClient.createChatCompletion(requestForClientNonStream as unknown as ClientChatCompletionRequest);
-          // If the model returned plain JSON as assistant content, try to convert it to tool_calls
+          // Normalize thinking tokens and extract tool calls from non-streaming response
           try {
             if (response && Array.isArray(response.choices)) {
               for (const choice of response.choices) {
                 const msg = choice.message as ChatMessage;
-                if (msg && !msg.tool_calls && typeof msg.content === 'string') {
-                  const extracted = tryExtractToolCallsFromContent(msg.content, requestOptions.tools as ToolDef[] | undefined);
-                  if (extracted && extracted.length > 0) {
-                    msg.tool_calls = extracted;
+                if (msg) {
+                  // Extract thinking tokens (e.g. <think> tags, reasoning_content)
+                  normalizeMessageThinking(msg as Record<string, unknown>);
+
+                  // Try to convert plain JSON content to tool_calls
+                  if (!msg.tool_calls && typeof msg.content === 'string') {
+                    const extracted = tryExtractToolCallsFromContent(msg.content, requestOptions.tools as ToolDef[] | undefined);
+                    if (extracted && extracted.length > 0) {
+                      msg.tool_calls = extracted;
+                    }
                   }
                 }
               }

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -134,26 +134,44 @@ function tryExtractToolCallsFromContent(content: string | undefined, tools?: Too
   return null;
 }
 
+// Cached regex for <think>...</think> extraction (used in hot streaming path)
+const THINK_TAG_REGEX = /<think>([\s\S]*?)<\/think>/g;
+
 // Helper: extract thinking tokens from content that uses <think>...</think> tags (Ollama/Qwen)
 // Returns { thinking, content } — thinking is the extracted text, content is the remainder.
 function extractThinkTagsFromContent(text: string): { thinking: string; content: string } {
-  // Match <think>...</think> blocks (greedy within, but non-greedy across multiple blocks)
-  const thinkRegex = /<think>([\s\S]*?)<\/think>/g;
-  let thinking = '';
-  let match;
-  while ((match = thinkRegex.exec(text)) !== null) {
-    thinking += match[1];
-  }
-  // Strip all <think>...</think> blocks from content (preserve spacing for token integrity)
-  const content = text.replace(thinkRegex, '');
-  return { thinking, content };
+  THINK_TAG_REGEX.lastIndex = 0;
+  const thinkParts: string[] = [];
+  // Single pass: collect thinking parts and strip tags via replace callback
+  const content = text.replace(THINK_TAG_REGEX, (_, inner) => {
+    thinkParts.push(inner);
+    return '';
+  });
+  return { thinking: thinkParts.join(''), content };
 }
 
+// Rename vendor-specific reasoning fields to the canonical `thinking` field.
+// Handles Ollama/Qwen3 `reasoning` and DeepSeek `reasoning_content`.
+// Returns true if a field was renamed (caller can skip further processing).
+function renameReasoningField(obj: Record<string, unknown>): boolean {
+  if (obj.reasoning && typeof obj.reasoning === 'string') {
+    obj.thinking = obj.reasoning;
+    delete obj.reasoning;
+    return true;
+  }
+  if (obj.reasoning_content && typeof obj.reasoning_content === 'string') {
+    obj.thinking = obj.reasoning_content;
+    delete obj.reasoning_content;
+    return true;
+  }
+  return false;
+}
+
+// Max partial buffer size to prevent unbounded growth on truncated streams
+const MAX_THINK_BUFFER = 64 * 1024;
+
 // Normalize a streaming chunk: extract thinking tokens into delta.thinking
-// Handles:
-//   - Ollama/Qwen: <think>...</think> tags inside delta.content
-//   - DeepSeek: delta.reasoning_content field
-//   - Anthropic: already separate (future — passthrough)
+// Handles Ollama/Qwen, DeepSeek, and <think> tags in content.
 // Mutates and returns the chunk for forwarding.
 function normalizeChunkThinking(chunk: Record<string, unknown>, thinkBuffer: { partial: string }): Record<string, unknown> {
   const choices = chunk.choices as Array<Record<string, unknown>> | undefined;
@@ -163,24 +181,13 @@ function normalizeChunkThinking(chunk: Record<string, unknown>, thinkBuffer: { p
   const delta = choice.delta as Record<string, unknown> | undefined;
   if (!delta) return chunk;
 
-  // --- Ollama/Qwen3: reasoning field (separate from content) ---
-  if (delta.reasoning && typeof delta.reasoning === 'string') {
-    delta.thinking = delta.reasoning;
-    delete delta.reasoning;
-    // Also clean up empty content strings that Ollama sends alongside reasoning
+  // --- Ollama/Qwen3 & DeepSeek: named reasoning fields ---
+  if (renameReasoningField(delta)) {
     if (delta.content === '') delete delta.content;
     return chunk;
   }
 
-  // --- DeepSeek: reasoning_content field ---
-  if (delta.reasoning_content && typeof delta.reasoning_content === 'string') {
-    delta.thinking = delta.reasoning_content;
-    delete delta.reasoning_content;
-    return chunk;
-  }
-
   // --- Ollama/Qwen (older): <think> tags in content ---
-  // Only enter this branch if content might contain <think> tags or we have a partial buffer
   if (delta.content && typeof delta.content === 'string') {
     const raw = thinkBuffer.partial + delta.content;
 
@@ -189,22 +196,23 @@ function normalizeChunkThinking(chunk: Record<string, unknown>, thinkBuffer: { p
       return chunk;
     }
 
+    // Safety: cap buffer to prevent unbounded growth on truncated streams
+    if (raw.length > MAX_THINK_BUFFER) {
+      thinkBuffer.partial = '';
+      return chunk;
+    }
+
     // Check for partial/open <think> tag at the end (tag not yet closed)
     const lastOpenIdx = raw.lastIndexOf('<think>');
     const lastCloseIdx = raw.lastIndexOf('</think>');
 
     if (lastOpenIdx !== -1 && (lastCloseIdx === -1 || lastCloseIdx < lastOpenIdx)) {
-      // We're inside an unclosed <think> block — buffer everything after the last <think>
       const before = raw.substring(0, lastOpenIdx);
       thinkBuffer.partial = raw.substring(lastOpenIdx);
 
-      // Extract any completed <think>...</think> pairs from the "before" portion
       const { thinking, content } = extractThinkTagsFromContent(before);
       delta.content = content || undefined;
-      if (thinking) {
-        delta.thinking = thinking;
-      }
-      // Remove empty content to avoid sending blank deltas
+      if (thinking) delta.thinking = thinking;
       if (!delta.content) delete delta.content;
       return chunk;
     }
@@ -213,9 +221,7 @@ function normalizeChunkThinking(chunk: Record<string, unknown>, thinkBuffer: { p
     thinkBuffer.partial = '';
     const { thinking, content } = extractThinkTagsFromContent(raw);
     delta.content = content || undefined;
-    if (thinking) {
-      delta.thinking = thinking;
-    }
+    if (thinking) delta.thinking = thinking;
     if (!delta.content) delete delta.content;
     return chunk;
   }
@@ -225,21 +231,11 @@ function normalizeChunkThinking(chunk: Record<string, unknown>, thinkBuffer: { p
 
 // Normalize a non-streaming response message: extract thinking from content
 function normalizeMessageThinking(message: Record<string, unknown>): void {
-  // Ollama/Qwen3: reasoning field (separate from content)
-  if (message.reasoning && typeof message.reasoning === 'string') {
-    message.thinking = message.reasoning;
-    delete message.reasoning;
-  }
-
-  // DeepSeek: reasoning_content field on message
-  if (message.reasoning_content && typeof message.reasoning_content === 'string') {
-    message.thinking = message.reasoning_content;
-    delete message.reasoning_content;
-  }
+  renameReasoningField(message);
 
   // Ollama/Qwen (older): <think> tags in content
-  if (message.content && typeof message.content === 'string') {
-    const { thinking, content } = extractThinkTagsFromContent(message.content as string);
+  if (!message.thinking && message.content && typeof message.content === 'string') {
+    const { thinking, content } = extractThinkTagsFromContent(message.content);
     if (thinking) {
       message.thinking = thinking;
       message.content = content;

--- a/reference-server/src/util/index.ts
+++ b/reference-server/src/util/index.ts
@@ -241,7 +241,7 @@ export async function isOllamaAvailable(): Promise<boolean> {
   
   try {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 2000);
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
     
     const response = await fetch(`${ollamaUrl}/api/tags`, {
       signal: controller.signal


### PR DESCRIPTION
**TL;DR:** Adds reasoning/thinking token support for local LLMs (thinking bubbles, mode toggle, retry logic) and fixes tictactoe game flow.

## Quick Review Setup
```bash
gh pr checkout 93

# Update the Ollama URL in reference-server/.env:
# OLLAMA_BASE_URL=https://ollama-ozwell-fw.opensource.mieweb.org
# This container has reasoning-capable models (gpt-oss, qwen3) pre-installed.
# Local Ollama may not have these models, so using the hosted container is recommended.

# Start both servers (builds TS client, reference server on :3000, landing page on :8080):
./scripts/start.sh
```

Then open the demo pages at http://localhost:8080:

### What's new to test (this PR)

- **Thinking bubbles** — Open any demo page. If the model supports reasoning (gpt-oss, qwen3), you'll see a thinking bubble expand before the AI responds.
- **Reasoning mode toggle** — Click the "Reasoning: Smart" dropdown in the widget header. Switch between None (no thinking shown), Peek (collapsed), Smart (auto-expand on long thinks), and Expanded (always open). Verify each mode displays differently.
- **Tictactoe game-over** — Play http://localhost:8080/tictactoe.html to completion. The AI should call `get_board` before each move and announce the result (win/draw) at the end.
- **Silent retry** — If using a reasoning model that sometimes returns only thinking with no content, the widget retries up to 3 times silently. You can observe this in the browser Network tab (multiple streaming requests for one user message).

## Summary
- Reasoning/thinking token support for Ollama, Qwen, DeepSeek models (server-side normalization + client-side UI)
- Thinking bubble UI with mode toggle (None/Peek/Smart/Expanded) in the widget status strip
- Silent retry (up to 3x) when model produces thinking-only responses with no content
- Simplified tool result routing: all non-display results go back to LLM for natural responses
- Tictactoe: added `get_board` tool, game-over messaging, and clearer system prompt
- Performance: single-pass regex, cached trims, strip thinking from conversation history before re-sending

## Creating Your First Agent

See [PR #84](https://github.com/mieweb/ozwellai-api/pull/84) for the full agent creation guide — YAML format, curl examples, field reference, and tips for writing good instructions.

## Stacked PR

This is PR 3 of 5 in a linear stack. Merge in this order:

1. #84 — Agent Registration API
2. #86 — MCP Widget + Agent Demos
3. **#93 — Reasoning Token Support** (this PR)
4. #87 — Integration Guide + Visual Builder
5. #74 — Portkey Gateway Integration

Closes #90
Ref #89
