### PR TITLE
security: prevent widget iframe from leaking private data

### DIFF
--- a/packages/react/src/OzwellChat.tsx
+++ b/packages/react/src/OzwellChat.tsx
@@ -40,7 +40,6 @@ export function OzwellChat(props: OzwellChatProps) {
     openaiApiKey,
     headers,
     widgetUrl,
-    context,
     autoOpenOnReply,
 
     // Future props (not yet implemented in vanilla widget)
@@ -56,7 +55,6 @@ export function OzwellChat(props: OzwellChatProps) {
     onReady,
     onOpen,
     onClose,
-    onInsert,
     onToolCall,
     onUserShare,
     onError,
@@ -236,19 +234,6 @@ export function OzwellChat(props: OzwellChatProps) {
     onError,
   ]);
 
-  // Update context when it changes
-  useEffect(() => {
-    if (!isWidgetReady || !window.OzwellChat || !context) {
-      return;
-    }
-
-    try {
-      window.OzwellChat.updateContext(context);
-    } catch (error) {
-      console.error('[OzwellChat] Failed to update context:', error);
-    }
-  }, [isWidgetReady, context]);
-
   // Listen for widget events via postMessage (single listener for all events)
   useEffect(() => {
     if (!isWidgetReady) {
@@ -269,10 +254,6 @@ export function OzwellChat(props: OzwellChatProps) {
       }
 
       switch (data.type) {
-        case 'insert':
-          onInsert?.(data.payload);
-          break;
-
         case 'closed':
           onClose?.();
           break;
@@ -325,7 +306,7 @@ export function OzwellChat(props: OzwellChatProps) {
     return () => {
       window.removeEventListener('message', handleMessage);
     };
-  }, [isWidgetReady, onInsert, onClose, onOpen, onUserShare, onError, onToolCall]);
+  }, [isWidgetReady, onClose, onOpen, onUserShare, onError, onToolCall]);
 
   // Render container div (only if not using default UI)
   if (defaultUI) {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -25,6 +25,7 @@ export type {
   OzwellError,
   OzwellChatAPI,
   OzwellWidgetMessage,
+  OzwellAssistantResponseMessage,
   OzwellParentMessage,
   OzwellToolCallMessage,
   OzwellToolResultMessage,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -281,8 +281,18 @@ export type ScriptLoadStatus = 'idle' | 'loading' | 'ready' | 'error';
  */
 export interface OzwellWidgetMessage {
   source: 'ozwell-chat-widget';
-  type: 'ready' | 'request-config' | 'closed' | 'opened' | 'tool_call' | 'user-share' | 'error';
+  type: 'ready' | 'request-config' | 'closed' | 'opened' | 'tool_call' | 'assistant_response' | 'user-share' | 'error';
   payload?: unknown;
+}
+
+/**
+ * Assistant response notification from widget (signal only, no message content)
+ */
+export interface OzwellAssistantResponseMessage {
+  source: 'ozwell-chat-widget';
+  type: 'assistant_response';
+  /** Whether the response included tool calls */
+  hadToolCalls: boolean;
 }
 
 /**

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -120,9 +120,6 @@ export interface OzwellChatProps extends Omit<OzwellConfig, 'autoMount'> {
   /** Widget height (CSS value or number in pixels) */
   height?: number | string;
 
-  /** Context data to send to the widget */
-  context?: Record<string, unknown>;
-
   // Event Callbacks
 
   /** Called when widget is ready */
@@ -133,9 +130,6 @@ export interface OzwellChatProps extends Omit<OzwellConfig, 'autoMount'> {
 
   /** Called when chat is closed */
   onClose?: () => void;
-
-  /** Called when user inserts text to parent page */
-  onInsert?: (data: { text: string; close: boolean }) => void;
 
   /**
    * Called when the AI requests a tool call.
@@ -211,9 +205,6 @@ export interface UseOzwellReturn {
   /** Send a message programmatically */
   sendMessage: (content: string) => void;
 
-  /** Update context data */
-  setContext: (context: Record<string, unknown>) => void;
-
   /** Access the underlying iframe element */
   iframe: HTMLIFrameElement | null;
 }
@@ -247,8 +238,6 @@ export interface OzwellChatAPI {
   }) => HTMLIFrameElement;
 
   configure: (config: Partial<OzwellConfig>) => void;
-
-  updateContext: (data: Record<string, unknown>) => void;
 
   ready: () => Promise<void>;
 
@@ -292,7 +281,7 @@ export type ScriptLoadStatus = 'idle' | 'loading' | 'ready' | 'error';
  */
 export interface OzwellWidgetMessage {
   source: 'ozwell-chat-widget';
-  type: 'ready' | 'request-config' | 'insert' | 'closed' | 'opened' | 'tool_call' | 'user-share' | 'error';
+  type: 'ready' | 'request-config' | 'closed' | 'opened' | 'tool_call' | 'user-share' | 'error';
   payload?: unknown;
 }
 

--- a/packages/react/src/useOzwell.ts
+++ b/packages/react/src/useOzwell.ts
@@ -154,28 +154,6 @@ export function useOzwell(): UseOzwellReturn {
     // window.OzwellChat?.sendMessage?.(content);
   }, [isReady]);
 
-  /**
-   * Update context data
-   * Uses window.OzwellChat.updateContext() from vanilla widget
-   */
-  const setContext = useCallback((context: Record<string, unknown>) => {
-    if (!isReady) {
-      console.warn('[useOzwell] Widget not ready yet');
-      return;
-    }
-
-    if (!context || typeof context !== 'object') {
-      console.warn('[useOzwell] setContext requires an object');
-      return;
-    }
-
-    try {
-      window.OzwellChat?.updateContext(context);
-    } catch (error) {
-      console.error('[useOzwell] Failed to update context:', error);
-    }
-  }, [isReady]);
-
   return {
     isReady,
     isOpen,
@@ -184,7 +162,6 @@ export function useOzwell(): UseOzwellReturn {
     close,
     toggle,
     sendMessage,
-    setContext,
     iframe,
   };
 }

--- a/reference-server/embed/ozwell-loader.js
+++ b/reference-server/embed/ozwell-loader.js
@@ -219,8 +219,12 @@
       showUnreadNotification();
     }
 
-    // Dispatch custom event for external listeners (signal only, no message content)
-    document.dispatchEvent(new CustomEvent('ozwell-chat-unread'));
+    // Dispatch custom event for external listeners (signal only, no message content).
+    // Disabled by default to honor privacy guidance; integrators
+    // must explicitly opt in via config.exposeUnreadEvent === true.
+    if (config.exposeUnreadEvent === true) {
+      document.dispatchEvent(new CustomEvent('ozwell-chat-unread'));
+    }
   }
 
   /**

--- a/reference-server/embed/ozwell-loader.js
+++ b/reference-server/embed/ozwell-loader.js
@@ -1,254 +1,19 @@
 /**
  * ============================================
- * IFRAME-SYNC LIBRARY (Bundled - Internal Use)
- * ============================================
- *
- * This library provides state synchronization between parent pages and iframes
- * using the postMessage API. It's bundled here for convenience and kept private.
- *
- * DO NOT use IframeSyncBroker/IframeSyncClient directly - use OzwellChat.updateContext() instead.
- *
- * Architecture:
- * - IframeSyncBroker: Lives in parent page, manages state and broadcasts to clients
- * - IframeSyncClient: Lives in iframes, receives state updates from broker
- *
- * Communication Flow:
- * 1. Parent calls broker.stateChange({ data }) or OzwellChat.updateContext({ data })
- * 2. Broker broadcasts state to all registered iframe clients via postMessage
- * 3. Each client receives state update and calls their callback function
- *
- * Why bundled: Simplifies integration - one script tag instead of two.
- * Why private: Clean API - developers use OzwellChat.updateContext() instead.
- */
-
-/**
- * Class representing an IframeSyncClient.
- * Browser iframes that want to participate in state synchronization should instantiate this class.
- *
- * This is used internally by the Ozwell widget to receive context updates from the parent page.
- */
-class IframeSyncClient {
-    #channel;
-    #recv;
-    #clientName;
-
-    /**
-     * Create an IframeSyncClient.
-     * @param {string} [clientName] - A unique client name. If not provided, one will be generated randomly.
-     * @param {function} recv - A callback function to receive state updates.
-     */
-    constructor(clientName, recv) {
-        this.#recv = recv;
-        this.#channel = 'IframeSync';
-        this.#clientName = clientName || [...Array(16)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
-
-        if (!window) {
-          return;
-        }
-        window.addEventListener('message', (event) => {
-            if (!event.data || event.data.channel !== this.#channel) {
-                return;
-            }
-
-            const isOwnMessage = event.data.sourceClientName === this.#clientName;
-            const isReadyReceived = event.data.type === 'readyReceived';
-
-            if (['syncState', 'readyReceived'].includes(event.data.type) && typeof this.#recv === 'function') {
-                this.#recv(event.data.payload, isOwnMessage, isReadyReceived);
-            }
-        });
-    }
-
-    /**
-     * Notify the parent window that this client is ready to receive state updates.
-     */
-    ready() {
-        if (!window || !window.parent) {
-          return;
-        }
-        window.parent.postMessage({
-            channel: this.#channel,
-            type: 'ready',
-            sourceClientName: this.#clientName
-        }, '*');
-    }
-
-    /**
-     * Send a state update to the broker, which will broadcast it to all other clients.
-     * Partial updates are OK, as the broker will merge the update into the current state.
-     * @param {Object} update - The state update to send.
-     */
-    stateChange(update) {
-        if (!window || !window.parent) {
-          return;
-        }
-        window.parent.postMessage({
-            channel: this.#channel,
-            type: 'stateChange',
-            sourceClientName: this.#clientName,
-            payload: update
-        }, '*');
-    }
-}
-
-/**
- * Class representing an IframeSyncBroker.
- *
- * This manages state in the parent page and broadcasts updates to all iframe clients.
- * The Ozwell widget uses this internally - parent pages should use OzwellChat.updateContext() instead.
- */
-class IframeSyncBroker {
-    #channel;
-    #state;
-    #clientIframes;
-    #debugMode;
-
-    /**
-     * Create an IframeSyncBroker.
-     */
-    constructor() {
-        this.#channel = 'IframeSync';
-        this.#state = {};
-        this.#clientIframes = new Set();
-        this.#debugMode = false;
-
-        if (!window) {
-          return;
-        }
-        window.addEventListener('message', (event) => this.#handleMessage(event));
-    }
-
-    /**
-     * Handle incoming messages from iframe clients.
-     * @param {MessageEvent} event - The message event.
-     * @private
-     */
-    #handleMessage(event) {
-        const { data, source: clientIframe } = event;
-        if (!data || data.channel !== this.#channel) {
-            return;
-        }
-
-        if (data.type === 'ready') {
-            this.#clientIframes.add(clientIframe);
-            this.#sendReadyReceived(clientIframe);
-        } else if (data.type === 'stateChange' && data.payload) {
-            this.#updateState(data.payload, data.sourceClientName);
-        }
-    }
-
-    /**
-     * Update the state with the provided update and broadcast to all clients.
-     * @param {Object} update - The state update.
-     * @param {string} sourceClientName - The name of the client that sent the update.
-     * @private
-     */
-    #updateState(update, sourceClientName) {
-        const prevState = JSON.stringify(this.#state);
-        Object.assign(this.#state, update);
-        const newState = JSON.stringify(this.#state);
-
-        if (prevState !== newState) {
-            this.#debug();
-            this.#broadcastState(sourceClientName);
-        }
-    }
-
-    /**
-     * Send the current state to a specific client iframe.
-     * @param {Window} clientIframe - The client iframe to send the state to.
-     * @param {string} sourceClientName - The name of the client that requested the state.
-     * @private
-     */
-    #sendSyncState(clientIframe, sourceClientName) {
-        if (clientIframe && typeof clientIframe.postMessage === 'function') {
-            clientIframe.postMessage({
-                channel: this.#channel,
-                type: 'syncState',
-                sourceClientName: sourceClientName, // Pass through the source
-                payload: this.#state,
-            }, '*');
-        }
-    }
-
-    /**
-     * Notify a client that it has been registered and send initial state.
-     * @param {Window} clientIframe - The client iframe to notify.
-     * @private
-     */
-    #sendReadyReceived(clientIframe) {
-        if (clientIframe && typeof clientIframe.postMessage === 'function') {
-            clientIframe.postMessage({
-                channel: this.#channel,
-                type: 'readyReceived',
-                payload: this.#state,
-            }, '*');
-        }
-    }
-
-    /**
-     * Broadcast the current state to all client iframes.
-     * @param {string} sourceClientName - The name of the client that sent the update.
-     * @private
-     */
-    #broadcastState(sourceClientName) {
-        this.#clientIframes.forEach((clientIframe) =>
-            this.#sendSyncState(clientIframe, sourceClientName)
-        );
-    }
-
-    /**
-     * Log a debug message (internal debugging tool).
-     * @private
-     */
-    #debug() {
-        if (this.#debugMode === false) {
-            return; // noop by default
-        }
-
-        const stateJson = JSON.stringify(this.#state, null, 2);
-        if (this.#debugMode === true) {
-            console.log('IframeSyncBroker state change', stateJson);
-        } else if (typeof this.#debugMode === 'function') {
-            this.#debugMode(stateJson);
-        } else if (this.#debugMode instanceof HTMLElement) {
-            this.#debugMode.innerText = stateJson;
-        }
-    }
-
-    /**
-     * Control debug behavior.
-     * @param {boolean|Function|HTMLElement} mode - The debug mode.
-     *   * false (default): no debug
-     *   * true: console.log
-     *   * function: call a provided function
-     *   * HTML element: set the text of an element
-     */
-    setDebugMode(mode) {
-        this.#debugMode = mode;
-    }
-
-    /**
-     * Manually trigger a state update.
-     * This is the main API for parent pages to send context to the widget.
-     * @param {Object} update - State update to broadcast to all iframe clients.
-     */
-    stateChange(update) {
-        this.#updateState(update, 'parent');
-    }
-}
-
-/**
- * ============================================
  * OZWELL CHAT WIDGET LOADER
  * ============================================
  *
  * Main API for embedding the Ozwell chat widget.
  *
+ * Communication with widget iframe uses postMessage only:
+ * - Lifecycle: ready, closed (signals only, no private data)
+ * - MCP tools: tool_call, tool_result (by design)
+ * - Config: config, request-config
+ * - Notifications: assistant_response (signal only, no message text)
+ *
  * Usage:
  *   1. Configure: window.OzwellChatConfig = { endpoint: '/v1/chat/completions', tools: [...] }
  *   2. Mount: OzwellChat.mount()
- *   3. Update context (optional): OzwellChat.updateContext({ formData: {...} })
  */
 (function () {
   // Inject viewport meta tag if not present (required for mobile-native behavior)
@@ -292,7 +57,6 @@ class IframeSyncBroker {
     ready: false,
     pendingMessages: [],
     runtimeConfig: {},
-    broker: null, // Internal iframe-sync broker for state updates
     hasUnread: false, // Track unread messages when chat is closed
     chatOpen: false, // Track if chat window is currently open
   };
@@ -404,14 +168,6 @@ class IframeSyncBroker {
       case 'request-config':
         sendConfig();
         break;
-      case 'insert': {
-        const detail = {
-          text: data.payload?.text || '',
-          close: Boolean(data.payload?.close),
-        };
-        document.dispatchEvent(new CustomEvent('ozwell-chat-insert', { detail }));
-        break;
-      }
       case 'closed':
         document.dispatchEvent(new CustomEvent('ozwell-chat-closed'));
         break;
@@ -428,7 +184,7 @@ class IframeSyncBroker {
    * Handle assistant response notification.
    * Shows wiggle animation and badge when chat is closed, or auto-opens if configured.
    *
-   * @param {Object} data - Message data with { message, hadToolCalls }
+   * @param {Object} data - Message data with { hadToolCalls }
    */
   function handleAssistantResponse(data) {
     // Skip notifications for tool calls - only notify on actual text responses
@@ -463,10 +219,8 @@ class IframeSyncBroker {
       showUnreadNotification();
     }
 
-    // Dispatch custom event for external listeners
-    document.dispatchEvent(new CustomEvent('ozwell-chat-unread', {
-      detail: { message: data.message }
-    }));
+    // Dispatch custom event for external listeners (signal only, no message content)
+    document.dispatchEvent(new CustomEvent('ozwell-chat-unread'));
   }
 
   /**
@@ -889,7 +643,7 @@ class IframeSyncBroker {
 
   /**
    * Mount the Ozwell chat widget iframe.
-   * Creates the iframe element and initializes the internal state sync broker.
+   * Creates the iframe element.
    *
    * @param {Object} options - Mounting options
    * @param {string} [options.containerId] - DOM element ID to mount in (defaults to body)
@@ -917,13 +671,6 @@ class IframeSyncBroker {
       // Widget notifies us when it is ready.
     });
 
-    // Initialize iframe-sync broker for real-time state updates
-    // This allows parent page to send context to widget via updateContext()
-    if (!state.broker) {
-      state.broker = new IframeSyncBroker();
-      console.log('[OzwellChat] State sync broker initialized');
-    }
-
     return iframe;
   }
 
@@ -945,52 +692,13 @@ class IframeSyncBroker {
     }
   }
 
-  /**
-   * Update the widget's context/state in real-time.
-   * Sends data to the widget iframe via iframe-sync, which the widget can use
-   * to provide context-aware responses.
-   *
-   * Example: Send form data to widget so it knows current values
-   *
-   * @param {Object} data - Context data to send to widget
-   * @example
-   * // Update form context
-   * OzwellChat.updateContext({
-   *   formData: {
-   *     name: 'John Doe',
-   *     address: '123 Main St',
-   *     zipCode: '12345'
-   *   }
-   * });
-   *
-   * @example
-   * // Update ticket context (TimeHarbor)
-   * OzwellChat.updateContext({
-   *   ticketForm: {
-   *     title: 'Fix bug',
-   *     description: 'Auth issue',
-   *     timeSpent: '2h 30m'
-   *   }
-   * });
-   */
-  function updateContext(data) {
-    if (!state.broker) {
-      console.warn('[OzwellChat] Broker not initialized. Call mount() before updateContext()');
-      return;
-    }
-
-    // Send context update to widget via iframe-sync
-    state.broker.stateChange(data);
-  }
-
   window.addEventListener('message', handleWidgetMessage);
 
   const api = {
     mount,
     configure,
-    updateContext, // New API for real-time context updates
-    open: openChat, // Programmatically open the chat window
-    close: closeChat, // Programmatically close the chat window
+    open: openChat,
+    close: closeChat,
     get iframe() {
       return state.iframe;
     },
@@ -1012,8 +720,7 @@ class IframeSyncBroker {
     },
   };
 
-  // Export API for manual initialization
-  // Note: IframeSyncBroker/Client are NOT exposed - use updateContext() instead
+  // Export API
   window.OzwellChat = api;
 
   // Auto-mount widget unless explicitly disabled

--- a/reference-server/embed/ozwell.js
+++ b/reference-server/embed/ozwell.js
@@ -4,74 +4,18 @@
  * ============================================
  *
  * This file bundles everything needed for the widget:
- * - IframeSyncClient (for state synchronization)
  * - CSS styles (inlined)
  * - HTML structure (dynamically injected)
  * - Widget logic
  *
- * No separate HTML or CSS files needed!
- */
-
-/**
- * ============================================
- * IFRAME-SYNC CLIENT (Bundled)
- * ============================================
+ * Communication with parent page uses postMessage only:
+ * - Lifecycle: ready, closed (signals only, no data)
+ * - MCP tools: tool_call, tool_result (by design)
+ * - Config: config, request-config
+ * - Notifications: assistant_response (signal only)
  *
- * IframeSyncClient allows this widget iframe to receive state updates from the parent page.
- * This is bundled here to eliminate the need for a separate iframe-sync.js script tag.
- *
- * The parent page uses IframeSyncBroker (bundled in ozwell-loader.js) to send updates.
+ * No private chat data crosses the iframe boundary.
  */
-class IframeSyncClient {
-  #channel;
-  #recv;
-  #clientName;
-
-  constructor(clientName, recv) {
-    this.#recv = recv;
-    this.#channel = 'IframeSync';
-    this.#clientName = clientName || [...Array(16)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
-
-    if (!window) {
-      return;
-    }
-    window.addEventListener('message', (event) => {
-      if (!event.data || event.data.channel !== this.#channel) {
-        return;
-      }
-
-      const isOwnMessage = event.data.sourceClientName === this.#clientName;
-      const isReadyReceived = event.data.type === 'readyReceived';
-
-      if (['syncState', 'readyReceived'].includes(event.data.type) && typeof this.#recv === 'function') {
-        this.#recv(event.data.payload, isOwnMessage, isReadyReceived);
-      }
-    });
-  }
-
-  ready() {
-    if (!window || !window.parent) {
-      return;
-    }
-    window.parent.postMessage({
-      channel: this.#channel,
-      type: 'ready',
-      sourceClientName: this.#clientName
-    }, '*');
-  }
-
-  stateChange(update) {
-    if (!window || !window.parent) {
-      return;
-    }
-    window.parent.postMessage({
-      channel: this.#channel,
-      type: 'stateChange',
-      sourceClientName: this.#clientName,
-      payload: update
-    }, '*');
-  }
-}
 
 /**
  * ============================================
@@ -319,10 +263,6 @@ body {
   cursor: not-allowed;
 }
 
-.chat-save {
-  display: none;
-}
-
 .chat-footer {
   text-align: center;
   padding: 8px;
@@ -443,7 +383,6 @@ body {
         />
         <button type="submit" class="chat-submit">Send</button>
       </form>
-      <button type="button" id="save-button" class="chat-save" disabled>Save & Close</button>
       <div class="chat-footer">Powered by Ozwell</div>
     </div>
   `;
@@ -530,7 +469,6 @@ const state = {
   },
   messages: [],
   sending: false,
-  formData: null, // Form context from parent page
   activeToolCalls: {}, // Track tool_call_id by tool name for OpenAI protocol
   toolExecutions: [], // Track tool executions for debug mode: { id, messageIndex, toolName, arguments, result, timestamp }
   expandedTools: new Set(), // Track which tool pills are expanded
@@ -547,9 +485,6 @@ const messagesEl = document.getElementById('messages');
 const formEl = document.getElementById('chat-form');
 const inputEl = document.getElementById('chat-input');
 const submitButton = document.querySelector('.chat-submit');
-const saveButton = document.getElementById('save-button');
-
-let lastAssistantMessage = '';
 
 function setStatus(text, processing = false) {
   if (statusEl) {
@@ -755,12 +690,6 @@ function buildMessages() {
 function buildSystemPrompt() {
   // Start with custom system prompt from parent config
   let systemPrompt = state.config.system || 'You are a helpful assistant.';
-
-  // APPEND form context if available (don't replace!)
-  if (state.formData) {
-    console.log('[widget.js] Including form context in system prompt:', state.formData);
-    systemPrompt += `\n\nCurrent page context:\n${JSON.stringify(state.formData, null, 2)}`;
-  }
 
   // Add generic tool usage guidance if tools are available
   if (state.config.tools && state.config.tools.length > 0) {
@@ -1011,10 +940,8 @@ async function sendMessageNonStreaming(text, tools) {
   setStatus('Processing...', true);
   state.sending = true;
   formEl?.classList.add('is-sending');
-  saveButton?.setAttribute('disabled', 'true');
-  lastAssistantMessage = '';
 
-  // Build system prompt (handles custom prompts and form context)
+  // Build system prompt
   const systemPrompt = buildSystemPrompt();
 
   try {
@@ -1131,7 +1058,6 @@ async function sendMessageNonStreaming(text, tools) {
 
       // Display text content in UI if present and not hidden (parsed/structured tool calls should hide the raw JSON)
       if (!shouldHideContent && assistantContent && assistantContent.trim()) {
-        lastAssistantMessage = assistantContent;
         addMessage('assistant', assistantContent);
       }
     } else {
@@ -1141,14 +1067,10 @@ async function sendMessageNonStreaming(text, tools) {
         content: assistantContent || '(no response)',
       };
       state.messages.push(assistantMessage);
-      lastAssistantMessage = assistantContent;
       addMessage('assistant', assistantContent || '(no response)');
     }
 
     setStatus('', false);
-    if (lastAssistantMessage.trim()) {
-      saveButton?.removeAttribute('disabled');
-    }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unexpected error';
     addMessage('system', `Error: ${message}`);
@@ -1156,9 +1078,6 @@ async function sendMessageNonStreaming(text, tools) {
   } finally {
     state.sending = false;
     formEl?.classList.remove('is-sending');
-    if (!lastAssistantMessage.trim()) {
-      saveButton?.setAttribute('disabled', 'true');
-    }
   }
 }
 
@@ -1248,8 +1167,6 @@ async function sendMessageStreaming(text, tools) {
   setStatus('Processing...', true);
   state.sending = true;
   formEl?.classList.add('is-sending');
-  saveButton?.setAttribute('disabled', 'true');
-  lastAssistantMessage = '';
 
   // Build system prompt
   const systemPrompt = buildSystemPrompt();
@@ -1469,7 +1386,6 @@ async function sendMessageStreaming(text, tools) {
 
       // Display text content only if it shouldn't be hidden (i.e., not JSON)
       if (!shouldHideContent && fullContent && fullContent.trim()) {
-        lastAssistantMessage = fullContent;
         addMessage('assistant', fullContent);
       }
       // Skip notification - tool execution flow will notify when complete
@@ -1480,18 +1396,16 @@ async function sendMessageStreaming(text, tools) {
         content: fullContent || '(no response)',
       };
       state.messages.push(assistantMessage);
-      lastAssistantMessage = fullContent;
 
       // Update placeholder if empty
       if (!fullContent.trim()) {
         assistantMsgEl.textContent = '(no response)';
       }
 
-      // Notify parent of assistant response (for notification system)
+      // Notify parent of assistant response (signal only — no message content)
       window.parent.postMessage({
         source: 'ozwell-chat-widget',
         type: 'assistant_response',
-        message: fullContent || '(no response)',
         hadToolCalls: false
       }, '*');
 
@@ -1503,9 +1417,6 @@ async function sendMessageStreaming(text, tools) {
     }
 
     setStatus('', false);
-    if (lastAssistantMessage.trim()) {
-      saveButton?.removeAttribute('disabled');
-    }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unexpected error';
     // Remove placeholder on error
@@ -1517,9 +1428,6 @@ async function sendMessageStreaming(text, tools) {
   } finally {
     state.sending = false;
     formEl?.classList.remove('is-sending');
-    if (!lastAssistantMessage.trim()) {
-      saveButton?.setAttribute('disabled', 'true');
-    }
   }
 }
 
@@ -1538,7 +1446,6 @@ async function continueConversationWithToolResult(result) {
   setStatus('Processing...', true);
   state.sending = true;
   formEl?.classList.add('is-sending');
-  saveButton?.setAttribute('disabled', 'true');
 
   // Build MCP tools from parent config (same as sendMessage)
   let tools = [];
@@ -1630,21 +1537,16 @@ async function continueConversationWithToolResult(result) {
       content: assistantContent || '(no response)',
     };
     state.messages.push(assistantMessage);
-    lastAssistantMessage = assistantContent;
     addMessage('assistant', assistantContent || '(no response)');
 
-    // Notify parent of assistant response
+    // Notify parent of assistant response (signal only — no message content)
     window.parent.postMessage({
       source: 'ozwell-chat-widget',
       type: 'assistant_response',
-      message: assistantContent || '(no response)',
       hadToolCalls: false
     }, '*');
 
     setStatus('', false);
-    if (lastAssistantMessage.trim()) {
-      saveButton?.removeAttribute('disabled');
-    }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unexpected error';
     addMessage('system', `Error: ${message}`);
@@ -1652,9 +1554,6 @@ async function continueConversationWithToolResult(result) {
   } finally {
     state.sending = false;
     formEl?.classList.remove('is-sending');
-    if (!lastAssistantMessage.trim()) {
-      saveButton?.setAttribute('disabled', 'true');
-    }
   }
 }
 
@@ -1670,17 +1569,6 @@ function handleSubmit(event) {
 function handleParentMessage(event) {
   const data = event.data;
   if (!data || typeof data !== 'object') return;
-
-  // Handle state updates from parent page (app.js)
-  if (data.type === 'STATE_UPDATE' && data.state) {
-    console.log('[widget.js] Received state update from parent:', data.state);
-
-    if (data.state.formData) {
-      state.formData = data.state.formData;
-      console.log('[widget.js] Form data stored:', state.formData);
-    }
-    return;
-  }
 
   // Handle tool results from parent (OpenAI function calling protocol)
   if (data.source === 'ozwell-chat-parent' && data.type === 'tool_result') {
@@ -1698,15 +1586,12 @@ function handleParentMessage(event) {
     if (result.success && result.message) {
       // Update tool - just display the message (no LLM continuation needed)
       addMessage('assistant', result.message);
-      lastAssistantMessage = result.message;
-      saveButton?.removeAttribute('disabled');
 
-      // Notify parent of assistant response (for notification system)
+      // Notify parent of assistant response (signal only — no message content)
       window.parent.postMessage({
         source: 'ozwell-chat-widget',
         type: 'assistant_response',
-        message: result.message,
-        hadToolCalls: false  // This is the final response after tool execution
+        hadToolCalls: false
       }, '*');
 
       // After displaying the tool result message, send any queued user message (if present)
@@ -1774,61 +1659,17 @@ function handleParentMessage(event) {
 }
 
 function notifyReady() {
-  // Send IFRAME_READY to register with app.js StateBroker
-  window.parent.postMessage({
-    type: 'IFRAME_READY',
-  }, '*');
-
-  console.log('[widget.js] Sent IFRAME_READY to parent');
-
-  // Also send legacy ready message for embed system
   window.parent.postMessage({
     source: 'ozwell-chat-widget',
     type: 'ready',
   }, '*');
 }
 
-function handleSave() {
-  if (!lastAssistantMessage.trim()) return;
-
-  window.parent.postMessage({
-    source: 'ozwell-chat-widget',
-    type: 'insert',
-    payload: {
-      text: lastAssistantMessage,
-      close: true,
-    },
-  }, '*');
-
-  setStatus('', false);
-}
-
 window.addEventListener('message', handleParentMessage);
 formEl?.addEventListener('submit', handleSubmit);
-saveButton?.addEventListener('click', handleSave);
 
 // Don't show initial system message - keep it clean
 setStatus('', false);
 
-// Initialize IframeSyncClient
-if (typeof IframeSyncClient !== 'undefined') {
-  console.log('[widget.js] Initializing IframeSyncClient...');
-
-  const iframeClient = new IframeSyncClient('ozwell-widget', function (payload, isOwnMessage, isReadyReceived) {
-    console.log('[widget.js] Received state from broker:', { payload, isOwnMessage, isReadyReceived });
-
-    if (payload && payload.formData) {
-      state.formData = payload.formData;
-      console.log('[widget.js] Form data updated:', state.formData);
-    }
-  });
-
-  // Register with broker
-  iframeClient.ready();
-  console.log('[widget.js] IframeSyncClient registered with broker');
-} else {
-  console.warn('[widget.js] IframeSyncClient not available');
-}
-
-// Legacy ready notification for embed system
+// Notify parent that widget is ready
 notifyReady();

--- a/reference-server/embed/ozwell.js
+++ b/reference-server/embed/ozwell.js
@@ -475,6 +475,7 @@ const state = {
   queuedMessage: null, // Message queued while LLM is responding
   queuedMessageEl: null, // DOM element for queued message bubble
   isEditingQueued: false, // Whether user is editing the queued message
+  parentOrigin: null, // Pinned parent origin from first validated config message
 };
 
 console.log('[widget.js] Widget initializing...');
@@ -485,6 +486,15 @@ const messagesEl = document.getElementById('messages');
 const formEl = document.getElementById('chat-form');
 const inputEl = document.getElementById('chat-input');
 const submitButton = document.querySelector('.chat-submit');
+
+/**
+ * Post a message to the parent frame using the pinned origin when available.
+ * Falls back to '*' only before the first config handshake completes.
+ */
+function postToParent(message) {
+  const targetOrigin = state.parentOrigin || '*';
+  window.parent.postMessage(message, targetOrigin);
+}
 
 function setStatus(text, processing = false) {
   if (statusEl) {
@@ -1040,13 +1050,13 @@ async function sendMessageNonStreaming(text, tools) {
             console.log(`[widget.js] Executing tool '${toolName}' with args:`, args);
 
             // Send tool call to parent via postMessage
-            window.parent.postMessage({
+            postToParent({
               source: 'ozwell-chat-widget',
               type: 'tool_call',
               tool: toolName,
               payload: args,
               tool_call_id: toolCall.id
-            }, '*');
+            });
 
             // No system messages - tools are invisible to end users
           } catch (error) {
@@ -1370,13 +1380,13 @@ async function sendMessageStreaming(text, tools) {
             state.activeToolCalls[toolName] = toolCall.id;
 
             // Send tool call to parent via postMessage
-            window.parent.postMessage({
+            postToParent({
               source: 'ozwell-chat-widget',
               type: 'tool_call',
               tool: toolName,
               tool_call_id: toolCall.id,  // Include ID for parent logging/tracking
               payload: args
-            }, '*');
+            });
           } catch (error) {
             console.error('[widget.js] Error parsing tool arguments:', error);
             // Errors are logged to console, not shown to user unless debug mode
@@ -1403,11 +1413,11 @@ async function sendMessageStreaming(text, tools) {
       }
 
       // Notify parent of assistant response (signal only — no message content)
-      window.parent.postMessage({
+      postToParent({
         source: 'ozwell-chat-widget',
         type: 'assistant_response',
         hadToolCalls: false
-      }, '*');
+      });
 
       // Send any queued message now that LLM is done (no tool calls pending)
       if (state.queuedMessage) {
@@ -1540,11 +1550,11 @@ async function continueConversationWithToolResult(result) {
     addMessage('assistant', assistantContent || '(no response)');
 
     // Notify parent of assistant response (signal only — no message content)
-    window.parent.postMessage({
+    postToParent({
       source: 'ozwell-chat-widget',
       type: 'assistant_response',
       hadToolCalls: false
-    }, '*');
+    });
 
     setStatus('', false);
   } catch (error) {
@@ -1567,6 +1577,8 @@ function handleSubmit(event) {
 }
 
 function handleParentMessage(event) {
+  // Only accept messages from the parent frame
+  if (event.source !== window.parent) return;
   const data = event.data;
   if (!data || typeof data !== 'object') return;
 
@@ -1588,11 +1600,11 @@ function handleParentMessage(event) {
       addMessage('assistant', result.message);
 
       // Notify parent of assistant response (signal only — no message content)
-      window.parent.postMessage({
+      postToParent({
         source: 'ozwell-chat-widget',
         type: 'assistant_response',
         hadToolCalls: false
-      }, '*');
+      });
 
       // After displaying the tool result message, send any queued user message (if present)
       if (state.queuedMessage) {
@@ -1647,22 +1659,27 @@ function handleParentMessage(event) {
   if (data.source !== 'ozwell-chat-parent') return;
 
   if (data.type === 'config' && data.payload?.config) {
+    // Pin the parent origin from the first validated config message
+    if (!state.parentOrigin && event.origin) {
+      state.parentOrigin = event.origin;
+      console.log('[widget.js] Pinned parent origin:', state.parentOrigin);
+    }
     applyConfig(data.payload.config);
   }
 
   if (data.type === 'close') {
-    window.parent.postMessage({
+    postToParent({
       source: 'ozwell-chat-widget',
       type: 'closed',
-    }, '*');
+    });
   }
 }
 
 function notifyReady() {
-  window.parent.postMessage({
+  postToParent({
     source: 'ozwell-chat-widget',
     type: 'ready',
-  }, '*');
+  });
 }
 
 window.addEventListener('message', handleParentMessage);


### PR DESCRIPTION
**TL;DR:** The widget iframe was leaking private chat data to the parent page. This PR seals the boundary — only lifecycle signals and MCP tool calls cross it now.

## Quick Review Setup
```bash
gh pr checkout 96

# If you don't have Ollama locally, update the URL in reference-server/.env:
# OLLAMA_BASE_URL=https://ollama-ozwell.opensource.mieweb.org

# Start both servers (builds TS client, reference server on :3000, landing page on :8080):
./scripts/start.sh
```

Then open the landing page at http://localhost:8080 and:
1. Open the chat widget, send a message — AI should respond normally
2. Open DevTools → Console, filter for `postMessage` — confirm `assistant_response` messages have **no message text**
3. Confirm the Save & Close button is **gone** from the widget
4. Try `window.OzwellChat.updateContext` in the console — should be `undefined`
5. Test tool calls: ask "change my name to Bob" — form should update normally

## What was leaking
- `assistant_response.message` — full AI reply text was sent to the parent on every response
- Save & Close button — sent `lastAssistantMessage` to parent via `insert` postMessage
- `IframeSyncBroker` / `IframeSyncClient` — entire state sync system that broadcast form data and context between parent and iframe (replaced by MCP tools)
- `state.formData` — injected directly into the system prompt from parent-provided context

## What changed
- Removed `IframeSyncClient` and `IframeSyncBroker` classes from both `ozwell.js` and `ozwell-loader.js`
- Removed Save & Close button (HTML, CSS, handler, all references)
- Stripped `message` field from `assistant_response` postMessages (signal only now)
- Removed `state.formData` and its system prompt injection
- Removed dead code: `STATE_UPDATE` handler, `IFRAME_READY` message, `insert` handler
- Cleaned up React package: removed `context`, `onInsert`, `setContext`, `updateContext`

## What still crosses the boundary (by design)
| Message | Direction | Data |
|---------|-----------|------|
| `ready` / `closed` | widget → parent | No data (lifecycle signal) |
| `assistant_response` | widget → parent | `hadToolCalls` only (no message text) |
| `tool_call` | widget → parent | Tool name + args (MCP protocol) |
| `tool_result` | parent → widget | Tool result (MCP protocol) |
| `config` / `request-config` | both | Widget configuration |

Closes #95