### PR TITLE
feat: agent CRUD UI + YAML-blob storage

### DIFF
--- a/landing-page/public/register.html
+++ b/landing-page/public/register.html
@@ -228,6 +228,44 @@
       border-radius: 4px;
     }
     .delete-icon-btn:hover { background: #fee2e2; }
+    .show-key-btn, .rotate-icon-btn {
+      background: none;
+      border: 1px solid #e5e7eb;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 12px;
+      padding: 2px 8px;
+      color: #374151;
+    }
+    .show-key-btn:hover { background: #f3f4f6; }
+    .rotate-icon-btn { color: #b45309; border-color: #fde68a; }
+    .rotate-icon-btn:hover { background: #fef3c7; }
+    .agent-list-key.revealed {
+      color: #16a34a;
+      background: #f0fdf4;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+    .copy-inline-btn {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 4px;
+      padding: 2px 8px;
+      cursor: pointer;
+      font-size: 12px;
+    }
+    .copy-inline-btn:hover { background: #f3f4f6; }
+    .result-warning {
+      background: #fef3c7;
+      border: 1px solid #fde68a;
+      color: #92400e;
+      border-radius: 6px;
+      padding: 8px 12px;
+      margin-bottom: 10px;
+      font-size: 13px;
+      font-weight: 500;
+    }
+    .result-warning.hidden { display: none; }
     .agents-empty {
       color: #9ca3af;
       font-size: 13px;
@@ -295,11 +333,14 @@
     <div id="result-section" class="section result-section">
       <h3 id="result-title">Your agent key</h3>
       <p id="result-sub">Use this key in the widget embed code to connect to your agent.</p>
-      <div class="agent-key-box">
+      <div id="result-warning" class="result-warning hidden">
+        Copy this key for your widget embed. You can re-reveal it any time from the agent list, or rotate it to generate a new one.
+      </div>
+      <div id="agent-key-box" class="agent-key-box">
         <span id="agent-key-value" class="agent-key-value"></span>
         <button id="copy-btn" class="copy-btn">Copy</button>
       </div>
-      <p class="result-hint">Paste this as the <code>data-api-key</code> in your widget script tag.</p>
+      <p id="result-hint" class="result-hint">Paste this as the <code>data-api-key</code> in your widget script tag.</p>
     </div>
   </div>
 
@@ -327,12 +368,6 @@
     const newAgentBtn = document.getElementById('new-agent-btn');
     const editingBanner = document.getElementById('editing-banner');
     const qSectionTitle = document.getElementById('q-section-title');
-
-    function maskKey(key) {
-      if (!key) return '';
-      const last4 = key.slice(-4);
-      return '••••' + last4;
-    }
 
     function authHeaders(extra) {
       return { 'Authorization': `Bearer ${apiKeyInput.value.trim()}`, ...(extra || {}) };
@@ -528,7 +563,7 @@
           if (!resp.ok) {
             alert('Failed to save: ' + (data.error?.message || JSON.stringify(data)));
           } else {
-            showResult(data.agent_key, 'saved');
+            showResult(null, 'saved');
             await loadAgents();
           }
         } else {
@@ -555,16 +590,34 @@
       isCreating = false;
     }
 
+    const resultWarning = document.getElementById('result-warning');
+    const agentKeyBox = document.getElementById('agent-key-box');
+    const resultHint = document.getElementById('result-hint');
+
     function showResult(key, mode) {
-      agentKeyValue.textContent = key;
       if (mode === 'saved') {
         resultTitle.textContent = 'Saved';
-        resultSub.textContent = 'Agent updated. The agent key stays the same.';
+        resultSub.textContent = 'Agent updated. The agent key is unchanged.';
+        agentKeyBox.style.display = 'none';
+        resultWarning.classList.add('hidden');
+        resultHint.style.display = 'none';
+      } else if (mode === 'rotated') {
+        agentKeyValue.textContent = key;
+        resultTitle.textContent = 'New agent key';
+        resultSub.textContent = 'The previous key is now invalid. Update embedded widgets with this new key. You can re-reveal it any time from the agent list.';
+        agentKeyBox.style.display = 'flex';
+        resultWarning.classList.remove('hidden');
+        resultHint.style.display = 'block';
       } else {
+        agentKeyValue.textContent = key;
         resultTitle.textContent = 'Your agent key';
         resultSub.textContent = 'Use this key in the widget embed code to connect to your agent.';
+        agentKeyBox.style.display = 'flex';
+        resultWarning.classList.remove('hidden');
+        resultHint.style.display = 'block';
       }
       resultSection.classList.add('visible');
+      resultSection.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
 
     async function loadAgents() {
@@ -577,6 +630,28 @@
       } catch {
         agents = [];
         renderAgentList();
+      }
+    }
+
+    const revealTimers = new Map(); // agentId -> setTimeout handle
+
+    async function rotateAgentKey(agentId, agentName) {
+      const ok = confirm('Rotate key for "' + (agentName || 'this agent') + '"? The current key will stop working immediately. Embedded widgets using the old key will need to be updated.');
+      if (!ok) return;
+      try {
+        const resp = await fetch(normalizedBase + '/v1/agents/' + encodeURIComponent(agentId) + '/rotate-key', {
+          method: 'POST',
+          headers: authHeaders(),
+        });
+        const data = await resp.json();
+        if (!resp.ok || !data.agent_key) {
+          alert('Failed to rotate key: ' + (data.error?.message || 'unknown'));
+          return;
+        }
+        showResult(data.agent_key, 'rotated');
+        await loadAgents();
+      } catch (e) {
+        alert('Rotate failed: ' + e.message);
       }
     }
 
@@ -599,9 +674,75 @@
 
         const right = document.createElement('div');
         right.className = 'agent-list-row-actions';
+
         const keySpan = document.createElement('span');
         keySpan.className = 'agent-list-key';
-        keySpan.textContent = maskKey(a.agent_key);
+        keySpan.textContent = a.key_hint || '—';
+
+        const copyBtn = document.createElement('button');
+        copyBtn.className = 'copy-inline-btn';
+        copyBtn.textContent = 'Copy';
+        copyBtn.style.display = 'none';
+
+        const showBtn = document.createElement('button');
+        showBtn.className = 'show-key-btn';
+        showBtn.textContent = 'Show';
+
+        const hintText = a.key_hint || '—';
+        let revealedKey = null;
+
+        const hide = () => {
+          keySpan.textContent = hintText;
+          keySpan.classList.remove('revealed');
+          copyBtn.style.display = 'none';
+          showBtn.textContent = 'Show';
+          revealedKey = null;
+          const t = revealTimers.get(a.id);
+          if (t) { clearTimeout(t); revealTimers.delete(a.id); }
+        };
+
+        const reveal = async () => {
+          try {
+            const resp = await fetch(normalizedBase + '/v1/agents/' + encodeURIComponent(a.id) + '/reveal-key', {
+              method: 'POST', headers: authHeaders(),
+            });
+            const data = await resp.json();
+            if (!resp.ok || !data.agent_key) {
+              alert('Failed to reveal key: ' + (data.error?.message || 'unknown'));
+              return;
+            }
+            revealedKey = data.agent_key;
+            keySpan.textContent = revealedKey;
+            keySpan.classList.add('revealed');
+            copyBtn.style.display = 'inline-block';
+            showBtn.textContent = 'Hide';
+            revealTimers.set(a.id, setTimeout(hide, 30000));
+          } catch (err) {
+            alert('Reveal failed: ' + err.message);
+          }
+        };
+
+        showBtn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          if (revealedKey) hide(); else reveal();
+        });
+
+        copyBtn.addEventListener('click', async (e) => {
+          e.stopPropagation();
+          if (!revealedKey) return;
+          try { await navigator.clipboard.writeText(revealedKey); } catch { /* clipboard blocked */ }
+          copyBtn.textContent = 'Copied';
+          setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500);
+        });
+
+        const rot = document.createElement('button');
+        rot.className = 'rotate-icon-btn';
+        rot.textContent = 'Rotate';
+        rot.addEventListener('click', (e) => {
+          e.stopPropagation();
+          rotateAgentKey(a.id, a.name);
+        });
+
         const del = document.createElement('button');
         del.className = 'delete-icon-btn';
         del.textContent = 'Delete';
@@ -609,7 +750,11 @@
           e.stopPropagation();
           deleteAgent(a.id, a.name);
         });
+
         right.appendChild(keySpan);
+        right.appendChild(copyBtn);
+        right.appendChild(showBtn);
+        right.appendChild(rot);
         right.appendChild(del);
 
         li.appendChild(left);

--- a/landing-page/public/register.html
+++ b/landing-page/public/register.html
@@ -168,6 +168,81 @@
       border-radius: 4px;
       font-size: 12px;
     }
+
+    /* Agents list */
+    .agents-section { display: none; }
+    .agents-section.visible { display: block; }
+    .agents-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 12px;
+    }
+    .new-agent-btn {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      padding: 6px 12px;
+      color: #374151;
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: 500;
+    }
+    .new-agent-btn:hover { background: #f3f4f6; }
+    .new-agent-btn:disabled { opacity: 0.5; cursor: default; }
+    .agent-list { list-style: none; }
+    .agent-list li {
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 10px 14px;
+      margin-bottom: 6px;
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .agent-list li:hover { background: #f9fafb; }
+    .agent-list li.active {
+      border-color: #0066ff;
+      background: #eff6ff;
+    }
+    .agent-list-name {
+      font-size: 14px;
+      font-weight: 600;
+      color: #1a1a1a;
+    }
+    .agent-list-key {
+      font-family: monospace;
+      font-size: 12px;
+      color: #6b7280;
+    }
+    .agent-list-row-actions { display: flex; gap: 8px; align-items: center; }
+    .delete-icon-btn {
+      background: none;
+      border: none;
+      color: #dc2626;
+      cursor: pointer;
+      font-size: 13px;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+    .delete-icon-btn:hover { background: #fee2e2; }
+    .agents-empty {
+      color: #9ca3af;
+      font-size: 13px;
+      padding: 8px 0;
+    }
+    .editing-banner {
+      background: #eff6ff;
+      border: 1px solid #bfdbfe;
+      border-radius: 6px;
+      padding: 8px 12px;
+      margin-bottom: 12px;
+      font-size: 13px;
+      color: #1e40af;
+    }
+    .editing-banner.hidden { display: none; }
   </style>
   <!-- Q agent config generator (bundled via esbuild) -->
   <link rel="stylesheet" href="/vendor/q-bundle.css" />
@@ -179,8 +254,8 @@
       <div class="back-link-container">
         <a href="/" class="back-link">&larr; Back to demos</a>
       </div>
-      <h1 class="header-title">Create an Agent</h1>
-      <p class="header-subtitle">Configure your agent visually, then hit Submit to register.</p>
+      <h1 class="header-title">Agents</h1>
+      <p class="header-subtitle">Create a new agent or edit an existing one.</p>
     </header>
 
     <!-- 1. API Key -->
@@ -194,9 +269,20 @@
       <div id="key-status" class="key-status"></div>
     </div>
 
-    <!-- 2. Q sandbox -->
+    <!-- 2. Existing agents -->
+    <div id="agents-section" class="section agents-section">
+      <div class="agents-header">
+        <h3 style="margin:0;">Your agents</h3>
+        <button id="new-agent-btn" class="new-agent-btn" disabled>+ New agent</button>
+      </div>
+      <ul id="agent-list" class="agent-list"></ul>
+      <div id="agents-empty" class="agents-empty" style="display:none;">No agents yet. The form below creates a new one.</div>
+    </div>
+
+    <!-- 3. Q sandbox -->
     <div class="section q-section">
-      <h3>2. Configure your agent</h3>
+      <h3 id="q-section-title">Configure your agent</h3>
+      <div id="editing-banner" class="editing-banner hidden"></div>
       <div id="q-overlay" class="q-overlay">
         <span>Enter your API key above to unlock</span>
       </div>
@@ -205,10 +291,10 @@
       </div>
     </div>
 
-    <!-- 3. Result -->
+    <!-- 4. Result -->
     <div id="result-section" class="section result-section">
-      <h3>Your agent key</h3>
-      <p>Use this key in the widget embed code to connect to your agent.</p>
+      <h3 id="result-title">Your agent key</h3>
+      <p id="result-sub">Use this key in the widget embed code to connect to your agent.</p>
       <div class="agent-key-box">
         <span id="agent-key-value" class="agent-key-value"></span>
         <button id="copy-btn" class="copy-btn">Copy</button>
@@ -223,14 +309,34 @@
 
     let apiKeyValidated = false;
     let currentYaml = null;
+    let editingAgentId = null; // null = create mode; string = editing that agent
+    let agents = [];
 
     const apiKeyInput = document.getElementById('api-key-input');
     const validateBtn = document.getElementById('validate-btn');
     const keyStatus = document.getElementById('key-status');
     const qOverlay = document.getElementById('q-overlay');
     const resultSection = document.getElementById('result-section');
+    const resultTitle = document.getElementById('result-title');
+    const resultSub = document.getElementById('result-sub');
     const agentKeyValue = document.getElementById('agent-key-value');
     const copyBtn = document.getElementById('copy-btn');
+    const agentsSection = document.getElementById('agents-section');
+    const agentList = document.getElementById('agent-list');
+    const agentsEmpty = document.getElementById('agents-empty');
+    const newAgentBtn = document.getElementById('new-agent-btn');
+    const editingBanner = document.getElementById('editing-banner');
+    const qSectionTitle = document.getElementById('q-section-title');
+
+    function maskKey(key) {
+      if (!key) return '';
+      const last4 = key.slice(-4);
+      return '••••' + last4;
+    }
+
+    function authHeaders(extra) {
+      return { 'Authorization': `Bearer ${apiKeyInput.value.trim()}`, ...(extra || {}) };
+    }
 
     // Reset validated state if key is edited after validation
     apiKeyInput.addEventListener('input', () => {
@@ -256,6 +362,9 @@
           keyStatus.textContent = 'Valid key';
           keyStatus.className = 'key-status valid';
           qOverlay.classList.add('hidden');
+          agentsSection.classList.add('visible');
+          newAgentBtn.disabled = false;
+          await loadAgents();
           mountQ();
         } else {
           keyStatus.textContent = 'Invalid key';
@@ -344,7 +453,15 @@
     let qGenerator = null;
     let isCreating = false;
 
-    async function mountQ() {
+    async function remountQ(extraOpts) {
+      if (qGenerator) {
+        try { qGenerator.destroy(); } catch { /* ignore */ }
+        qGenerator = null;
+      }
+      await mountQ(extraOpts);
+    }
+
+    async function mountQ(extraOpts) {
       if (qGenerator) return;
       const mount = document.getElementById('q-mount');
       mount.textContent = '';
@@ -356,9 +473,7 @@
 
       // Fetch available models from the server and update schema
       try {
-        const modelsResp = await fetch(normalizedBase + '/v1/models', {
-          headers: { 'Authorization': `Bearer ${apiKeyInput.value.trim()}` }
-        });
+        const modelsResp = await fetch(normalizedBase + '/v1/models', { headers: authHeaders() });
         if (modelsResp.ok) {
           const modelsData = await modelsResp.json();
           const models = modelsData.data || [];
@@ -379,6 +494,7 @@
       qGenerator = new window.UniversalAgentConfigGenerator(mount, {
         schema: ozwellSchema,
         showEditor: true,
+        ...(extraOpts || {}),
       });
 
       mount.addEventListener('config-change', (e) => {
@@ -399,26 +515,38 @@
       if (!apiKeyValidated || isCreating) return;
 
       const yaml = currentYaml || DEFAULT_YAML;
-
       isCreating = true;
 
       try {
-        const resp = await fetch(normalizedBase + '/v1/agents', {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${apiKeyInput.value.trim()}`,
-            'Content-Type': 'application/yaml',
-          },
-          body: yaml,
-        });
-
-        const data = await resp.json();
-
-        if (resp.ok && data.agent_key) {
-          agentKeyValue.textContent = data.agent_key;
-          resultSection.classList.add('visible');
+        if (editingAgentId) {
+          const resp = await fetch(normalizedBase + '/v1/agents/' + encodeURIComponent(editingAgentId), {
+            method: 'PUT',
+            headers: authHeaders({ 'Content-Type': 'application/yaml' }),
+            body: yaml,
+          });
+          const data = await resp.json();
+          if (!resp.ok) {
+            alert('Failed to save: ' + (data.error?.message || JSON.stringify(data)));
+          } else {
+            showResult(data.agent_key, 'saved');
+            await loadAgents();
+          }
         } else {
-          alert('Failed to create agent: ' + (data.error?.message || JSON.stringify(data)));
+          const resp = await fetch(normalizedBase + '/v1/agents', {
+            method: 'POST',
+            headers: authHeaders({ 'Content-Type': 'application/yaml' }),
+            body: yaml,
+          });
+          const data = await resp.json();
+          if (resp.ok && data.agent_key) {
+            showResult(data.agent_key, 'created');
+            // Switch into edit mode for the just-created agent
+            editingAgentId = data.agent_id;
+            await loadAgents();
+            renderEditingUI();
+          } else {
+            alert('Failed to create agent: ' + (data.error?.message || JSON.stringify(data)));
+          }
         }
       } catch (e) {
         alert('Error: ' + e.message);
@@ -426,6 +554,140 @@
 
       isCreating = false;
     }
+
+    function showResult(key, mode) {
+      agentKeyValue.textContent = key;
+      if (mode === 'saved') {
+        resultTitle.textContent = 'Saved';
+        resultSub.textContent = 'Agent updated. The agent key stays the same.';
+      } else {
+        resultTitle.textContent = 'Your agent key';
+        resultSub.textContent = 'Use this key in the widget embed code to connect to your agent.';
+      }
+      resultSection.classList.add('visible');
+    }
+
+    async function loadAgents() {
+      try {
+        const resp = await fetch(normalizedBase + '/v1/agents', { headers: authHeaders() });
+        if (!resp.ok) throw new Error('list failed');
+        const data = await resp.json();
+        agents = data.data || [];
+        renderAgentList();
+      } catch {
+        agents = [];
+        renderAgentList();
+      }
+    }
+
+    function renderAgentList() {
+      agentList.innerHTML = '';
+      if (!agents.length) {
+        agentsEmpty.style.display = 'block';
+        return;
+      }
+      agentsEmpty.style.display = 'none';
+      for (const a of agents) {
+        const li = document.createElement('li');
+        if (a.id === editingAgentId) li.classList.add('active');
+
+        const left = document.createElement('div');
+        const name = document.createElement('div');
+        name.className = 'agent-list-name';
+        name.textContent = a.name || '(unnamed)';
+        left.appendChild(name);
+
+        const right = document.createElement('div');
+        right.className = 'agent-list-row-actions';
+        const keySpan = document.createElement('span');
+        keySpan.className = 'agent-list-key';
+        keySpan.textContent = maskKey(a.agent_key);
+        const del = document.createElement('button');
+        del.className = 'delete-icon-btn';
+        del.textContent = 'Delete';
+        del.addEventListener('click', (e) => {
+          e.stopPropagation();
+          deleteAgent(a.id, a.name);
+        });
+        right.appendChild(keySpan);
+        right.appendChild(del);
+
+        li.appendChild(left);
+        li.appendChild(right);
+        li.addEventListener('click', () => loadAgentIntoForm(a.id));
+        agentList.appendChild(li);
+      }
+    }
+
+    async function loadAgentIntoForm(id) {
+      try {
+        const resp = await fetch(normalizedBase + '/v1/agents/' + encodeURIComponent(id), { headers: authHeaders() });
+        if (!resp.ok) throw new Error('load failed');
+        const data = await resp.json();
+
+        editingAgentId = id;
+        currentYaml = data.yaml || null;
+
+        const initialConfig = {
+          name: data.name,
+          instructions: data.instructions,
+          model: data.model,
+          temperature: data.temperature,
+          tools: data.tools,
+          behavior: data.behavior,
+        };
+
+        await remountQ({ initialConfig });
+
+        renderAgentList();
+        renderEditingUI();
+        resultSection.classList.remove('visible');
+      } catch (e) {
+        alert('Failed to load agent: ' + e.message);
+      }
+    }
+
+    async function deleteAgent(id, name) {
+      if (!confirm(`Delete agent "${name || id}"? This cannot be undone.`)) return;
+      try {
+        const resp = await fetch(normalizedBase + '/v1/agents/' + encodeURIComponent(id), {
+          method: 'DELETE',
+          headers: authHeaders()
+        });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          alert('Failed to delete: ' + (data.error?.message || resp.status));
+          return;
+        }
+        if (editingAgentId === id) resetToCreateMode();
+        await loadAgents();
+      } catch (e) {
+        alert('Error: ' + e.message);
+      }
+    }
+
+    async function resetToCreateMode() {
+      editingAgentId = null;
+      currentYaml = null;
+      await remountQ();
+      renderEditingUI();
+      renderAgentList();
+      resultSection.classList.remove('visible');
+    }
+
+    function renderEditingUI() {
+      if (editingAgentId) {
+        const a = agents.find(x => x.id === editingAgentId);
+        editingBanner.textContent = `Editing "${a?.name || editingAgentId}" — submit to save changes. Agent key stays the same.`;
+        editingBanner.classList.remove('hidden');
+        qSectionTitle.textContent = 'Edit agent';
+      } else {
+        editingBanner.classList.add('hidden');
+        qSectionTitle.textContent = 'Configure your agent';
+      }
+    }
+
+    newAgentBtn.addEventListener('click', resetToCreateMode);
 
     // Copy agent key
     copyBtn.addEventListener('click', async () => {

--- a/reference-server/package.json
+++ b/reference-server/package.json
@@ -10,8 +10,8 @@
     "spec": "node scripts/write-spec.js",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
-    "test": "node --test test/server.test.js",
-    "test:watch": "node --test --watch test/server.test.js",
+    "test": "node --test test/*.test.js",
+    "test:watch": "node --test --watch test/*.test.js",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/reference-server/src/routes/agents.ts
+++ b/reference-server/src/routes/agents.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
-import { createError, generateId, isValidApiKey, extractToken, isAgentKey, AGENT_KEY_PREFIX } from '../util';
+import { createError, generateId, isValidApiKey, extractToken, isAgentKey, AGENT_KEY_PREFIX, formatAgentKeyHint } from '../util';
 import * as yaml from 'yaml';
 import { agentStore, Agent } from '../storage/agents';
 
@@ -112,13 +112,16 @@ function parseAndValidate(
     return { parsed, error: null };
 }
 
-/** Build a JSON-friendly view of an agent row (parses YAML for convenience fields). */
+/**
+ * Build a JSON-friendly view of an agent row (parses YAML for convenience fields).
+ * Throws on malformed stored YAML — callers wrap in try/catch returning 500.
+ * Should not happen in practice: writes validate via parseAndValidate before insert.
+ */
 function toAgentView(agent: Agent) {
-    let parsed: ParsedAgentFields = {};
-    try { parsed = parseAgentYaml(agent.yaml); } catch { /* leave empty */ }
+    const parsed = parseAgentYaml(agent.yaml);
     return {
         agent_id: agent.id,
-        agent_key: agent.agent_key,
+        key_hint: formatAgentKeyHint(agent.agent_key),
         created_at: agent.created_at,
         yaml: agent.yaml,
         name: parsed.name,
@@ -221,9 +224,11 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
             });
 
             reply.code(201);
+            reply.header('Cache-Control', 'no-store');
             return {
                 agent_id: agent.id,
                 agent_key: agent.agent_key,
+                key_hint: formatAgentKeyHint(agent.agent_key),
                 created_at: agent.created_at,
             };
         } catch (error) {
@@ -249,14 +254,19 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
             return createError('Agent not found', 'invalid_request_error', null, 'not_found');
         }
 
-        let parsed: ParsedAgentFields = {};
-        try { parsed = parseAgentYaml(agent.yaml); } catch { /* leave empty */ }
-        return {
-            id: agent.id,
-            name: parsed.name,
-            model: parsed.model,
-            tools: normalizeTools(parsed.tools),
-        };
+        try {
+            const parsed = parseAgentYaml(agent.yaml);
+            return {
+                id: agent.id,
+                name: parsed.name,
+                model: parsed.model,
+                tools: normalizeTools(parsed.tools),
+            };
+        } catch (error) {
+            fastify.log.error({ err: error, agentId: agent.id }, 'agent yaml parse failed');
+            reply.code(500);
+            return createError('Failed to parse agent', 'server_error');
+        }
     });
 
     // GET /v1/agents (list agents)
@@ -274,7 +284,7 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
                     const view = toAgentView(a);
                     return {
                         id: view.agent_id,
-                        agent_key: view.agent_key,
+                        key_hint: view.key_hint,
                         name: view.name,
                         model: view.model,
                         tools: view.tools,
@@ -342,6 +352,54 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
             reply.code(500);
             return createError('Agent update failed', 'server_error');
         }
+    });
+
+    // POST /v1/agents/:agent_id/reveal-key (return full agent_key — explicit user action)
+    fastify.post<{ Params: { agent_id: string } }>('/v1/agents/:agent_id/reveal-key', {
+        schema: { headers: authHeaders, params: agentIdParam, tags: ['Agents'], summary: 'Reveal full agent key (parent key auth required)' },
+        preHandler: apiKeyAuth
+    }, async (request, reply) => {
+        const parentKey = request.apiKey!.id;
+        const { agent_id } = request.params;
+
+        const agent = agentStore.getOwned(agent_id, parentKey);
+        if (!agent) {
+            reply.code(404);
+            return createError('Agent not found', 'invalid_request_error');
+        }
+
+        reply.header('Cache-Control', 'no-store');
+        fastify.log.info({ agentId: agent_id, parentKeyId: request.apiKey!.id }, 'agent_key revealed');
+        return {
+            agent_id: agent.id,
+            agent_key: agent.agent_key,
+            key_hint: formatAgentKeyHint(agent.agent_key),
+        };
+    });
+
+    // POST /v1/agents/:agent_id/rotate-key (generate new key, invalidate old)
+    fastify.post<{ Params: { agent_id: string } }>('/v1/agents/:agent_id/rotate-key', {
+        schema: { headers: authHeaders, params: agentIdParam, tags: ['Agents'], summary: 'Rotate agent key (invalidates old key)' },
+        preHandler: apiKeyAuth
+    }, async (request, reply) => {
+        const parentKey = request.apiKey!.id;
+        const { agent_id } = request.params;
+
+        const newKey = generateAgentKey();
+        const updated = agentStore.rotateKey(agent_id, parentKey, newKey);
+        if (!updated) {
+            reply.code(404);
+            return createError('Agent not found', 'invalid_request_error');
+        }
+
+        reply.header('Cache-Control', 'no-store');
+        fastify.log.info({ agentId: agent_id, parentKeyId: request.apiKey!.id }, 'agent_key rotated');
+        return {
+            agent_id: updated.id,
+            agent_key: newKey,
+            key_hint: formatAgentKeyHint(newKey),
+            rotated_at: Math.floor(Date.now() / 1000),
+        };
     });
 
     // DELETE /v1/agents/:agent_id (delete agent)

--- a/reference-server/src/routes/agents.ts
+++ b/reference-server/src/routes/agents.ts
@@ -1,7 +1,7 @@
 import { FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
 import { createError, generateId, isValidApiKey, extractToken, isAgentKey, AGENT_KEY_PREFIX } from '../util';
 import * as yaml from 'yaml';
-import { agentStore } from '../storage/agents';
+import { agentStore, Agent } from '../storage/agents';
 
 // Extend FastifyRequest to include auth data
 declare module 'fastify' {
@@ -55,51 +55,79 @@ function generateAgentKey(): string {
 }
 
 /** Normalize tools: plain strings become { name } objects */
-function normalizeTools(tools: unknown[] | undefined): { name: string; [k: string]: unknown }[] {
-    if (!tools) return [];
+function normalizeTools(tools: unknown): { name: string; [k: string]: unknown }[] {
+    if (!Array.isArray(tools)) return [];
     return tools.map(t => typeof t === 'string' ? { name: t } : t as { name: string });
 }
 
-/** Extract and validate YAML input from request body */
+/** Extract YAML string from request body (string or {yaml} wrapper). Returns null if empty. */
 function extractYamlInput(body: string | { yaml: string }): string | null {
     const raw = typeof body === 'string' ? body : body?.yaml;
-    return raw?.trim() || null;
+    if (typeof raw !== 'string' || !raw.trim()) return null;
+    return raw;
 }
 
-// Parse YAML input into structured fields (returns undefined for missing fields — caller validates)
-function parseYamlInput(yamlInput: string) {
+interface ParsedAgentFields {
+    name?: string;
+    instructions?: string;
+    model?: string;
+    temperature?: number;
+    tools?: unknown;
+    behavior?: Record<string, unknown>;
+    [k: string]: unknown;
+}
+
+/** Parse YAML into a loose object. Throws on invalid YAML. */
+function parseAgentYaml(yamlInput: string): ParsedAgentFields {
     const parsed = yaml.parse(yamlInput);
-    const name = (parsed.name as string | undefined)?.trim() || undefined;
-    const instructions = (parsed.instructions as string | undefined)?.trim() || undefined;
-    const model = parsed.model as string | undefined;
-    const temperature = parsed.temperature as number | undefined;
-    const tools = parsed.tools as (string | { name: string; description?: string; inputSchema?: Record<string, unknown>; parameters?: Record<string, unknown> })[] | undefined;
-    const behavior = parsed.behavior as Record<string, unknown> | undefined;
-    const pageTools = parsePageTools(parsed.pageTools);
-
-    return { name, instructions, model, temperature, tools, behavior, pageTools };
+    if (!parsed || typeof parsed !== 'object') {
+        throw new Error('YAML must parse to an object');
+    }
+    return parsed as ParsedAgentFields;
 }
 
-/** Validate and normalize the pageTools YAML field.
- *  Accepted forms:
- *    pageTools: all                          → 'all'
- *    pageTools: { restricted: [tool1, …] }   → { restricted: [...] }
- *    pageTools: { blocked: [tool1, …] }      → { blocked: [...] }
- *    (omitted / undefined)                   → undefined  (treated as 'all')
+/**
+ * Parse YAML and enforce required fields. On failure, set reply.code and
+ * return an error payload. On success, return the parsed fields.
  */
-function parsePageTools(raw: unknown): import('../storage/agents.js').PageToolsPolicy | undefined {
-    if (raw === undefined || raw === null) return undefined;
-    if (raw === 'all') return 'all';
-    if (typeof raw === 'object' && raw !== null) {
-        const obj = raw as Record<string, unknown>;
-        if (Array.isArray(obj.restricted)) {
-            return { restricted: obj.restricted.filter((s): s is string => typeof s === 'string') };
-        }
-        if (Array.isArray(obj.blocked)) {
-            return { blocked: obj.blocked.filter((s): s is string => typeof s === 'string') };
-        }
+function parseAndValidate(
+    yamlInput: string,
+    reply: FastifyReply
+): { parsed: ParsedAgentFields; error: null } | { parsed: null; error: ReturnType<typeof createError> } {
+    let parsed: ParsedAgentFields;
+    try {
+        parsed = parseAgentYaml(yamlInput);
+    } catch {
+        reply.code(400);
+        return { parsed: null, error: createError('Invalid YAML format', 'invalid_request_error') };
     }
-    return undefined;
+    if (!parsed.name || typeof parsed.name !== 'string' || !parsed.name.trim()) {
+        reply.code(400);
+        return { parsed: null, error: createError("'name' is required", 'invalid_request_error') };
+    }
+    if (!parsed.instructions || typeof parsed.instructions !== 'string' || !parsed.instructions.trim()) {
+        reply.code(400);
+        return { parsed: null, error: createError("'instructions' is required", 'invalid_request_error') };
+    }
+    return { parsed, error: null };
+}
+
+/** Build a JSON-friendly view of an agent row (parses YAML for convenience fields). */
+function toAgentView(agent: Agent) {
+    let parsed: ParsedAgentFields = {};
+    try { parsed = parseAgentYaml(agent.yaml); } catch { /* leave empty */ }
+    return {
+        agent_id: agent.id,
+        agent_key: agent.agent_key,
+        created_at: agent.created_at,
+        yaml: agent.yaml,
+        name: parsed.name,
+        instructions: parsed.instructions,
+        model: parsed.model,
+        temperature: parsed.temperature,
+        tools: parsed.tools,
+        behavior: parsed.behavior,
+    };
 }
 
 const agentsRoute: FastifyPluginAsync = async (fastify) => {
@@ -182,34 +210,15 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
                 return createError("'yaml' field is required", 'invalid_request_error');
             }
 
-            let agent;
-            try {
-                const fields = parseYamlInput(yamlInput);
+            const validation = parseAndValidate(yamlInput, reply);
+            if (validation.error) return validation.error;
 
-                if (!fields.name) {
-                    reply.code(400);
-                    return createError("'name' is required", 'invalid_request_error');
-                }
-                if (!fields.instructions) {
-                    reply.code(400);
-                    return createError("'instructions' is required", 'invalid_request_error');
-                }
-
-                const agentId = generateId('agent');
-                const agentKey = generateAgentKey();
-
-                agent = agentStore.createAgent({
-                    id: agentId,
-                    agent_key: agentKey,
-                    parent_key: parentKey,
-                    ...fields,
-                    name: fields.name,
-                    instructions: fields.instructions,
-                });
-            } catch {
-                reply.code(400);
-                return createError('Invalid YAML format', 'invalid_request_error');
-            }
+            const agent = agentStore.createAgent({
+                id: generateId('agent'),
+                agent_key: generateAgentKey(),
+                parent_key: parentKey,
+                yaml: yamlInput,
+            });
 
             reply.code(201);
             return {
@@ -240,12 +249,13 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
             return createError('Agent not found', 'invalid_request_error', null, 'not_found');
         }
 
+        let parsed: ParsedAgentFields = {};
+        try { parsed = parseAgentYaml(agent.yaml); } catch { /* leave empty */ }
         return {
             id: agent.id,
-            name: agent.name,
-            model: agent.model,
-            tools: normalizeTools(agent.tools),
-            pageTools: agent.pageTools,
+            name: parsed.name,
+            model: parsed.model,
+            tools: normalizeTools(parsed.tools),
         };
     });
 
@@ -257,20 +267,21 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
         const parentKey = request.apiKey!.id;
 
         try {
-            const agentRows = agentStore.listByParent(parentKey);
-
+            const agents = agentStore.listByParent(parentKey);
             return {
                 object: 'list',
-                data: agentRows.map(a => ({
-                    id: a.id,
-                    agent_key: a.agent_key,
-                    name: a.name,
-                    model: a.model,
-                    tools: a.tools,
-                    behavior: a.behavior,
-                    pageTools: a.pageTools,
-                    created_at: a.created_at,
-                })),
+                data: agents.map(a => {
+                    const view = toAgentView(a);
+                    return {
+                        id: view.agent_id,
+                        agent_key: view.agent_key,
+                        name: view.name,
+                        model: view.model,
+                        tools: view.tools,
+                        behavior: view.behavior,
+                        created_at: view.created_at,
+                    };
+                }),
             };
         } catch (error) {
             fastify.log.error(error);
@@ -289,23 +300,11 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
 
         try {
             const agent = agentStore.getOwned(agent_id, parentKey);
-
             if (!agent) {
                 reply.code(404);
                 return createError('Agent not found', 'invalid_request_error');
             }
-
-            return {
-                agent_id: agent.id,
-                created_at: agent.created_at,
-                name: agent.name,
-                instructions: agent.instructions,
-                model: agent.model,
-                temperature: agent.temperature,
-                tools: agent.tools,
-                behavior: agent.behavior,
-                pageTools: agent.pageTools,
-            };
+            return toAgentView(agent);
         } catch (error) {
             fastify.log.error(error);
             reply.code(500);
@@ -328,30 +327,16 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
                 return createError("'yaml' field is required", 'invalid_request_error');
             }
 
-            let updated;
-            try {
-                const fields = parseYamlInput(yamlInput);
-                updated = agentStore.updateAgent(agent_id, parentKey, fields);
-            } catch {
-                reply.code(400);
-                return createError('Invalid YAML format', 'invalid_request_error');
-            }
+            const validation = parseAndValidate(yamlInput, reply);
+            if (validation.error) return validation.error;
 
+            const updated = agentStore.updateAgent(agent_id, parentKey, yamlInput);
             if (!updated) {
                 reply.code(404);
                 return createError('Agent not found', 'invalid_request_error');
             }
 
-            return {
-                agent_id: updated.id,
-                agent_key: updated.agent_key,
-                name: updated.name,
-                model: updated.model,
-                tools: updated.tools,
-                behavior: updated.behavior,
-                pageTools: updated.pageTools,
-                updated: true,
-            };
+            return { ...toAgentView(updated), updated: true };
         } catch (error) {
             fastify.log.error(error);
             reply.code(500);

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -1,6 +1,7 @@
 import { FastifyPluginAsync } from 'fastify';
 import { validateAuth, createError, SimpleTextGenerator, generateId, countTokens, isOllamaAvailable, getOllamaDefaultModel, isAgentKey, extractToken, isLLMBackendConfigured } from '../util';
 import { agentStore, type PageToolsPolicy } from '../storage/agents';
+import * as yaml from 'yaml';
 import OzwellAI from 'ozwellai';
 import type { ChatCompletionRequest as ClientChatCompletionRequest } from 'ozwellai';
 import type { ChatCompletionRequest, Message } from '../../../spec/index';
@@ -367,14 +368,24 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
         return createError(`Agent key not found: ...${agentKey.slice(-4)}. Verify the key exists and the server has the agent database.`, 'invalid_request_error');
       }
 
+      // Parse the YAML blob once — the source of truth for agent config
+      let parsed: Record<string, unknown> = {};
+      try {
+        const p = yaml.parse(agent.yaml);
+        if (p && typeof p === 'object') parsed = p as Record<string, unknown>;
+      } catch (err) {
+        request.log.warn({ err, agentId: agent.id }, 'Failed to parse agent YAML');
+      }
+
       // Use agent instructions as the system prompt
-      let systemPrompt = agent.instructions || '';
+      let systemPrompt = (parsed.instructions as string | undefined) || '';
 
       // Append behavior metadata (tone, language, rules) as a structured
       // supplement AFTER the instructions so they don't dilute or compete
       // with the primary prompt.
-      if (agent.behavior && typeof agent.behavior === 'object') {
-        const b = agent.behavior as Record<string, unknown>;
+      const behavior = parsed.behavior;
+      if (behavior && typeof behavior === 'object') {
+        const b = behavior as Record<string, unknown>;
         const extras: string[] = [];
         if (b.tone) extras.push(`- Respond with a ${b.tone} tone.`);
         if (b.language && b.language !== 'en') extras.push(`- Respond in ${b.language}.`);
@@ -388,14 +399,15 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
         }
       }
 
+      const tools = parsed.tools;
       agentConfig = {
         systemPrompt,
-        allowedTools: agent.tools && Array.isArray(agent.tools) && agent.tools.length > 0
-          ? agent.tools.map(t => typeof t === 'string' ? t : t.name)
+        allowedTools: Array.isArray(tools) && tools.length > 0
+          ? (tools as unknown[]).map((t) => typeof t === 'string' ? t : (t as { name: string }).name)
           : null,
-        pageTools: agent.pageTools ?? 'all',
-        model: agent.model || null,
-        temperature: agent.temperature ?? null,
+        pageTools: (parsed.pageTools as PageToolsPolicy) ?? 'all',
+        model: (parsed.model as string | undefined) || null,
+        temperature: (parsed.temperature as number | undefined) ?? null,
       };
     }
 

--- a/reference-server/src/routes/models.ts
+++ b/reference-server/src/routes/models.ts
@@ -48,7 +48,9 @@ const modelsRoute: FastifyPluginAsync = async (fastify) => {
           const data = await resp.json() as { object: string; data: unknown[] };
           return data;
         }
-      } catch {}
+      } catch {
+        // Gateway unavailable, fall through to next provider
+      }
     }
 
     if (process.env.OLLAMA_BASE_URL) {
@@ -66,7 +68,9 @@ const modelsRoute: FastifyPluginAsync = async (fastify) => {
             })),
           };
         }
-      } catch {}
+      } catch {
+        // Ollama unavailable, fall through to fallback list
+      }
     }
 
     return { object: 'list' as const, data: FALLBACK_MODELS };

--- a/reference-server/src/server.ts
+++ b/reference-server/src/server.ts
@@ -30,6 +30,7 @@ async function buildServer() {
   await fastify.register(cors, {
     origin: true,
     credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   });
 
   // Register multipart for file uploads

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -6,13 +6,7 @@ interface DbAgentRow {
     id: string;
     agent_key: string;
     parent_key: string;
-    name: string;
-    instructions: string;
-    model: string | null;
-    temperature: number | null;
-    tools: string | null;
-    behavior: string | null;
-    page_tools: string | null;
+    yaml: string;
     created_at: number;
 }
 
@@ -68,34 +62,25 @@ export function seedDemoData(db: Database.Database): void {
 
 // ── Agent model ─────────────────────────────────────────────────────
 
+/**
+ * pageTools policy gates the postMessage:-prefixed tools an agent may call.
+ * Stored inside the agent YAML blob; chat.ts reads it after parsing.
+ */
 export type PageToolsPolicy =
     | 'all'                           // allow all page tools (default)
     | { restricted: string[] }        // only these page tools
     | { blocked: string[] };          // all page tools except these
 
-export interface ToolDefinition {
-    name: string;
-    description?: string;
-    inputSchema?: Record<string, unknown>;
-}
-
 export interface Agent {
     id: string;
     agent_key: string;
     parent_key: string;
-    name: string;
-    instructions: string;
-    model?: string;
-    temperature?: number;
-    tools?: (string | ToolDefinition)[];
-    behavior?: Record<string, unknown>;
-    pageTools?: PageToolsPolicy;
+    yaml: string;
     created_at: number;
 }
 
 export class AgentStore {
     private db: Database.Database;
-    // Cached prepared statements
     private stmtInsert: Database.Statement;
     private stmtGetByKey: Database.Statement;
     private stmtGetById: Database.Statement;
@@ -112,15 +97,14 @@ export class AgentStore {
         this.initTable();
 
         this.stmtInsert = this.db.prepare(`
-          INSERT INTO agents (id, agent_key, parent_key, name, instructions, model, temperature, tools, behavior, page_tools, created_at)
-          VALUES (@id, @agent_key, @parent_key, @name, @instructions, @model, @temperature, @tools, @behavior, @page_tools, @created_at)
+          INSERT INTO agents (id, agent_key, parent_key, yaml, created_at)
+          VALUES (@id, @agent_key, @parent_key, @yaml, @created_at)
         `);
         this.stmtGetByKey = this.db.prepare('SELECT * FROM agents WHERE agent_key = ?');
         this.stmtGetById = this.db.prepare('SELECT * FROM agents WHERE id = ?');
         this.stmtListByParent = this.db.prepare('SELECT * FROM agents WHERE parent_key = ?');
         this.stmtUpdate = this.db.prepare(`
-          UPDATE agents SET name = @name, instructions = @instructions, model = @model,
-            temperature = @temperature, tools = @tools, behavior = @behavior, page_tools = @page_tools
+          UPDATE agents SET yaml = @yaml
           WHERE id = @id AND parent_key = @parent_key
         `);
         this.stmtDeleteOwned = this.db.prepare('DELETE FROM agents WHERE id = ? AND parent_key = ?');
@@ -133,24 +117,12 @@ export class AgentStore {
         id TEXT PRIMARY KEY,
         agent_key TEXT UNIQUE NOT NULL,
         parent_key TEXT NOT NULL,
-        name TEXT NOT NULL,
-        instructions TEXT NOT NULL,
-        model TEXT,
-        temperature REAL,
-        tools TEXT,
-        behavior TEXT,
-        page_tools TEXT,
+        yaml TEXT NOT NULL,
         created_at INTEGER NOT NULL
       );
       CREATE INDEX IF NOT EXISTS idx_agents_agent_key ON agents(agent_key);
       CREATE INDEX IF NOT EXISTS idx_agents_parent_key ON agents(parent_key);
     `);
-        // Migration: add page_tools column if missing (existing DBs)
-        try {
-            this.db.exec('ALTER TABLE agents ADD COLUMN page_tools TEXT');
-        } catch {
-            // Column already exists — ignore
-        }
     }
 
     /** Check if a token is a valid parent or agent key (single query) */
@@ -174,77 +146,38 @@ export class AgentStore {
         return this._stmtLookupApiKey.get(key) as { id: string; name: string } | undefined;
     }
 
-    createAgent(agent: Omit<Agent, 'created_at'>): Agent {
+    createAgent(params: { id: string; agent_key: string; parent_key: string; yaml: string }): Agent {
         const created_at = Math.floor(Date.now() / 1000);
-
-        this.stmtInsert.run({
-            id: agent.id,
-            agent_key: agent.agent_key,
-            parent_key: agent.parent_key,
-            name: agent.name,
-            instructions: agent.instructions,
-            model: agent.model || null,
-            temperature: agent.temperature ?? null,
-            tools: agent.tools ? JSON.stringify(agent.tools) : null,
-            behavior: agent.behavior ? JSON.stringify(agent.behavior) : null,
-            page_tools: agent.pageTools ? JSON.stringify(agent.pageTools) : null,
-            created_at
-        });
-
-        return { ...agent, created_at };
+        this.stmtInsert.run({ ...params, created_at });
+        return { ...params, created_at };
     }
 
     getByKey(agentKey: string): Agent | null {
         const row = this.stmtGetByKey.get(agentKey) as DbAgentRow | undefined;
-        return row ? this.deserialize(row) : null;
+        return row ?? null;
     }
 
     getById(agentId: string): Agent | null {
         const row = this.stmtGetById.get(agentId) as DbAgentRow | undefined;
-        return row ? this.deserialize(row) : null;
+        return row ?? null;
     }
 
     /** Get agent only if owned by parentKey */
     getOwned(agentId: string, parentKey: string): Agent | null {
         const row = this.stmtGetOwned.get(agentId, parentKey) as DbAgentRow | undefined;
-        return row ? this.deserialize(row) : null;
+        return row ?? null;
     }
 
     listByParent(parentKey: string): Agent[] {
-        const rows = this.stmtListByParent.all(parentKey) as DbAgentRow[];
-        return rows.map(row => this.deserialize(row));
+        return this.stmtListByParent.all(parentKey) as DbAgentRow[];
     }
 
-    updateAgent(agentId: string, parentKey: string, updates: Partial<Pick<Agent, 'name' | 'instructions' | 'model' | 'temperature' | 'tools' | 'behavior' | 'pageTools'>>): Agent | null {
+    /** Replace the YAML blob of an owned agent. Returns updated row or null. */
+    updateAgent(agentId: string, parentKey: string, yaml: string): Agent | null {
         const existing = this.getOwned(agentId, parentKey);
         if (!existing) return null;
-
-        const merged = {
-            name: updates.name ?? existing.name,
-            instructions: updates.instructions ?? existing.instructions,
-            model: updates.model ?? existing.model,
-            temperature: updates.temperature ?? existing.temperature,
-            tools: updates.tools ?? existing.tools,
-            behavior: updates.behavior ?? existing.behavior,
-            pageTools: updates.pageTools ?? existing.pageTools,
-        };
-
-        this.stmtUpdate.run({
-            id: agentId,
-            parent_key: parentKey,
-            name: merged.name,
-            instructions: merged.instructions,
-            model: merged.model || null,
-            temperature: merged.temperature ?? null,
-            tools: merged.tools ? JSON.stringify(merged.tools) : null,
-            behavior: merged.behavior ? JSON.stringify(merged.behavior) : null,
-            page_tools: merged.pageTools ? JSON.stringify(merged.pageTools) : null,
-        });
-
-        return {
-            ...existing,
-            ...merged,
-        };
+        this.stmtUpdate.run({ id: agentId, parent_key: parentKey, yaml });
+        return { ...existing, yaml };
     }
 
     /** Delete agent only if owned by parentKey. Returns true if deleted. */
@@ -252,23 +185,6 @@ export class AgentStore {
         const result = this.stmtDeleteOwned.run(agentId, parentKey);
         return result.changes > 0;
     }
-
-    private deserialize(row: DbAgentRow): Agent {
-        return {
-            id: row.id,
-            agent_key: row.agent_key,
-            parent_key: row.parent_key,
-            name: row.name,
-            instructions: row.instructions,
-            model: row.model ?? undefined,
-            temperature: row.temperature ?? undefined,
-            tools: row.tools ? JSON.parse(row.tools) : undefined,
-            behavior: row.behavior ? JSON.parse(row.behavior) : undefined,
-            pageTools: row.page_tools ? JSON.parse(row.page_tools) : undefined,
-            created_at: row.created_at
-        };
-    }
-
 }
 
 // Singleton instance

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -86,6 +86,7 @@ export class AgentStore {
     private stmtGetById: Database.Statement;
     private stmtListByParent: Database.Statement;
     private stmtUpdate: Database.Statement;
+    private stmtRotateKey: Database.Statement;
     private stmtDeleteOwned: Database.Statement;
     private stmtGetOwned: Database.Statement;
     // Lazy-prepared: api_keys table is created after import by initializeAuthTables()
@@ -105,6 +106,10 @@ export class AgentStore {
         this.stmtListByParent = this.db.prepare('SELECT * FROM agents WHERE parent_key = ?');
         this.stmtUpdate = this.db.prepare(`
           UPDATE agents SET yaml = @yaml
+          WHERE id = @id AND parent_key = @parent_key
+        `);
+        this.stmtRotateKey = this.db.prepare(`
+          UPDATE agents SET agent_key = @new_key
           WHERE id = @id AND parent_key = @parent_key
         `);
         this.stmtDeleteOwned = this.db.prepare('DELETE FROM agents WHERE id = ? AND parent_key = ?');
@@ -178,6 +183,14 @@ export class AgentStore {
         if (!existing) return null;
         this.stmtUpdate.run({ id: agentId, parent_key: parentKey, yaml });
         return { ...existing, yaml };
+    }
+
+    /** Replace the agent_key of an owned agent. Returns updated row or null. */
+    rotateKey(agentId: string, parentKey: string, newKey: string): Agent | null {
+        const existing = this.getOwned(agentId, parentKey);
+        if (!existing) return null;
+        this.stmtRotateKey.run({ id: agentId, parent_key: parentKey, new_key: newKey });
+        return { ...existing, agent_key: newKey };
     }
 
     /** Delete agent only if owned by parentKey. Returns true if deleted. */

--- a/reference-server/src/util/index.ts
+++ b/reference-server/src/util/index.ts
@@ -9,6 +9,11 @@ export function getKeyHint(key: string): string {
   return key.slice(-4);
 }
 
+/** Format an agent key as a display hint: agnt_key-...XXXX */
+export function formatAgentKeyHint(key: string): string {
+  return `${AGENT_KEY_PREFIX}key-...${getKeyHint(key)}`;
+}
+
 /** Check if a key has a valid parent key prefix */
 export function isValidApiKey(key: string): boolean {
   return key.startsWith(KEY_PREFIX);

--- a/reference-server/test/agents-yaml-blob.test.js
+++ b/reference-server/test/agents-yaml-blob.test.js
@@ -1,0 +1,200 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const DEMO_KEY = 'ozw_demo_localhost_key_for_testing';
+const PORT = 3333;
+const BASE = `http://localhost:${PORT}`;
+
+async function waitForReady(maxMs = 10_000) {
+    const start = Date.now();
+    while (Date.now() - start < maxMs) {
+        try {
+            const r = await fetch(`${BASE}/health`);
+            if (r.status === 200) return;
+        } catch { /* not ready */ }
+        await delay(200);
+    }
+    throw new Error('server never became ready');
+}
+
+function startServer() {
+    const tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-test-'));
+    const dbPath = path.join(tmp, 'ozwell.db');
+    const server = spawn('npm', ['run', 'dev'], {
+        cwd: process.cwd(),
+        stdio: 'pipe',
+        detached: true,
+        env: { ...process.env, PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development' }
+    });
+    return { server, tmp };
+}
+
+function stopServer(server, tmp) {
+    try { process.kill(-server.pid, 'SIGKILL'); } catch { /* ignore */ }
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+const H_JSON = { 'Content-Type': 'application/json', 'Authorization': `Bearer ${DEMO_KEY}` };
+const H_YAML = { 'Content-Type': 'application/yaml', 'Authorization': `Bearer ${DEMO_KEY}` };
+
+test('agents route — YAML blob round-trip preserves comments and ordering', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+
+        const yamlInput = `# This comment must survive the round-trip
+name: Pirate Bot
+instructions: |
+  Yo ho ho! Speak like a pirate.
+model: gpt-4o-mini
+temperature: 0.7
+tools:
+  - show_map
+  - steer_ship
+behavior:
+  tone: swashbuckling
+  rules:
+    - Never break character
+custom_unknown_field: 42
+`;
+
+        // Create
+        const createRes = await fetch(`${BASE}/v1/agents`, {
+            method: 'POST',
+            headers: H_YAML,
+            body: yamlInput
+        });
+        assert.equal(createRes.status, 201, 'create should return 201');
+        const created = await createRes.json();
+        assert.ok(created.agent_id);
+        assert.ok(created.agent_key);
+
+        // Fetch
+        const getRes = await fetch(`${BASE}/v1/agents/${created.agent_id}`, {
+            headers: { 'Authorization': `Bearer ${DEMO_KEY}` }
+        });
+        assert.equal(getRes.status, 200);
+        const fetched = await getRes.json();
+
+        // YAML must come back byte-identical
+        assert.equal(fetched.yaml, yamlInput, 'yaml round-trip byte-identical');
+        assert.equal(fetched.name, 'Pirate Bot');
+        assert.equal(fetched.model, 'gpt-4o-mini');
+        assert.deepEqual(fetched.tools, ['show_map', 'steer_ship']);
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('agents route — PUT preserves custom YAML verbatim', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+
+        const yaml1 = `name: Bot
+instructions: First version
+model: gpt-4o-mini
+`;
+        const create = await fetch(`${BASE}/v1/agents`, { method: 'POST', headers: H_YAML, body: yaml1 });
+        const { agent_id } = await create.json();
+
+        const yaml2 = `# Second revision with a comment
+name: Bot
+instructions: |
+  Updated instructions
+  with multiple lines.
+model: gpt-4o
+extra_future_field: still_here
+`;
+        const put = await fetch(`${BASE}/v1/agents/${agent_id}`, {
+            method: 'PUT', headers: H_YAML, body: yaml2
+        });
+        assert.equal(put.status, 200);
+
+        const get = await fetch(`${BASE}/v1/agents/${agent_id}`, {
+            headers: { 'Authorization': `Bearer ${DEMO_KEY}` }
+        });
+        const body = await get.json();
+        assert.equal(body.yaml, yaml2, 'updated yaml byte-identical');
+        assert.equal(body.model, 'gpt-4o');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('agents route — list + delete flow', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+
+        const yamlInput = `name: Disposable\ninstructions: Go away\n`;
+        const create = await fetch(`${BASE}/v1/agents`, { method: 'POST', headers: H_YAML, body: yamlInput });
+        const { agent_id } = await create.json();
+
+        const list = await fetch(`${BASE}/v1/agents`, { headers: { 'Authorization': `Bearer ${DEMO_KEY}` } });
+        const listBody = await list.json();
+        assert.ok(listBody.data.some(a => a.id === agent_id), 'agent appears in list');
+
+        const del = await fetch(`${BASE}/v1/agents/${agent_id}`, {
+            method: 'DELETE', headers: { 'Authorization': `Bearer ${DEMO_KEY}` }
+        });
+        assert.equal(del.status, 200);
+
+        const listAfter = await fetch(`${BASE}/v1/agents`, { headers: { 'Authorization': `Bearer ${DEMO_KEY}` } });
+        const listAfterBody = await listAfter.json();
+        assert.ok(!listAfterBody.data.some(a => a.id === agent_id), 'agent gone after delete');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('agents route — invalid YAML rejected', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+
+        const res = await fetch(`${BASE}/v1/agents`, {
+            method: 'POST', headers: H_YAML, body: 'not: : valid: yaml: ::'
+        });
+        assert.equal(res.status, 400);
+
+        const noName = await fetch(`${BASE}/v1/agents`, {
+            method: 'POST', headers: H_YAML, body: 'instructions: hi\n'
+        });
+        assert.equal(noName.status, 400);
+
+        const noInstr = await fetch(`${BASE}/v1/agents`, {
+            method: 'POST', headers: H_YAML, body: 'name: x\n'
+        });
+        assert.equal(noInstr.status, 400);
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('agents route — JSON wrapper {yaml: "..."} works too', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+
+        const yamlInput = `name: Wrap\ninstructions: test\n`;
+        const res = await fetch(`${BASE}/v1/agents`, {
+            method: 'POST', headers: H_JSON, body: JSON.stringify({ yaml: yamlInput })
+        });
+        assert.equal(res.status, 201);
+        const { agent_id } = await res.json();
+
+        const get = await fetch(`${BASE}/v1/agents/${agent_id}`, {
+            headers: { 'Authorization': `Bearer ${DEMO_KEY}` }
+        });
+        const body = await get.json();
+        assert.equal(body.yaml, yamlInput);
+    } finally {
+        stopServer(server, tmp);
+    }
+});

--- a/reference-server/test/agents-yaml-blob.test.js
+++ b/reference-server/test/agents-yaml-blob.test.js
@@ -5,6 +5,9 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 const DEMO_KEY = 'ozw_demo_localhost_key_for_testing';
 const PORT = 3333;
@@ -194,6 +197,159 @@ test('agents route — JSON wrapper {yaml: "..."} works too', async () => {
         });
         const body = await get.json();
         assert.equal(body.yaml, yamlInput);
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+const HINT_PATTERN = /^agnt_key-\.\.\.[a-z0-9]{4}$/;
+
+test('agents route — create returns full key + hint, list masks key', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+        const create = await fetch(`${BASE}/v1/agents`, {
+            method: 'POST', headers: H_YAML, body: 'name: K1\ninstructions: hi\n'
+        });
+        assert.equal(create.status, 201);
+        const created = await create.json();
+        assert.match(created.agent_key, /^agnt_key-/, 'create returns full key');
+        assert.match(created.key_hint, HINT_PATTERN, 'create returns hint');
+        assert.equal(created.key_hint, `agnt_key-...${created.agent_key.slice(-4)}`);
+
+        const list = await fetch(`${BASE}/v1/agents`, { headers: { 'Authorization': `Bearer ${DEMO_KEY}` } });
+        const body = await list.json();
+        const row = body.data.find(a => a.id === created.agent_id);
+        assert.ok(row, 'agent in list');
+        assert.equal(row.agent_key, undefined, 'list response has no agent_key');
+        assert.match(row.key_hint, HINT_PATTERN, 'list row has key_hint');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('agents route — GET :id and PUT :id mask key', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+        const create = await fetch(`${BASE}/v1/agents`, {
+            method: 'POST', headers: H_YAML, body: 'name: K2\ninstructions: hi\n'
+        });
+        const { agent_id } = await create.json();
+
+        const get = await fetch(`${BASE}/v1/agents/${agent_id}`, {
+            headers: { 'Authorization': `Bearer ${DEMO_KEY}` }
+        });
+        const getBody = await get.json();
+        assert.equal(getBody.agent_key, undefined, 'GET :id has no agent_key');
+        assert.match(getBody.key_hint, HINT_PATTERN, 'GET :id has key_hint');
+
+        const put = await fetch(`${BASE}/v1/agents/${agent_id}`, {
+            method: 'PUT', headers: H_YAML, body: 'name: K2 updated\ninstructions: hi2\n'
+        });
+        const putBody = await put.json();
+        assert.equal(putBody.agent_key, undefined, 'PUT :id has no agent_key');
+        assert.match(putBody.key_hint, HINT_PATTERN, 'PUT :id has key_hint');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('agents route — reveal-key returns full key with parent auth', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+        const create = await fetch(`${BASE}/v1/agents`, {
+            method: 'POST', headers: H_YAML, body: 'name: R1\ninstructions: hi\n'
+        });
+        const { agent_id, agent_key: originalKey } = await create.json();
+
+        const reveal = await fetch(`${BASE}/v1/agents/${agent_id}/reveal-key`, {
+            method: 'POST', headers: { 'Authorization': `Bearer ${DEMO_KEY}` }
+        });
+        assert.equal(reveal.status, 200);
+        assert.match(reveal.headers.get('cache-control') || '', /no-store/, 'no-store header set');
+        const revealBody = await reveal.json();
+        assert.equal(revealBody.agent_key, originalKey, 'reveal returns same key as create');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('agents route — reveal-key rejects agent key auth', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+        const create = await fetch(`${BASE}/v1/agents`, {
+            method: 'POST', headers: H_YAML, body: 'name: R2\ninstructions: hi\n'
+        });
+        const { agent_id, agent_key } = await create.json();
+
+        const reveal = await fetch(`${BASE}/v1/agents/${agent_id}/reveal-key`, {
+            method: 'POST', headers: { 'Authorization': `Bearer ${agent_key}` }
+        });
+        assert.equal(reveal.status, 401, 'agent key cannot reveal');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('agents route — rotate-key invalidates old, new key validates', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+        const create = await fetch(`${BASE}/v1/agents`, {
+            method: 'POST', headers: H_YAML, body: 'name: Rot\ninstructions: hi\n'
+        });
+        const { agent_id, agent_key: oldKey } = await create.json();
+
+        const rotate = await fetch(`${BASE}/v1/agents/${agent_id}/rotate-key`, {
+            method: 'POST', headers: { 'Authorization': `Bearer ${DEMO_KEY}` }
+        });
+        assert.equal(rotate.status, 200);
+        assert.match(rotate.headers.get('cache-control') || '', /no-store/);
+        const rotateBody = await rotate.json();
+        assert.match(rotateBody.agent_key, /^agnt_key-/);
+        assert.notEqual(rotateBody.agent_key, oldKey, 'new key differs from old');
+        assert.match(rotateBody.key_hint, HINT_PATTERN);
+        assert.ok(typeof rotateBody.rotated_at === 'number');
+
+        // Old key no longer validates
+        const oldValidate = await fetch(`${BASE}/v1/keys/validate`, {
+            headers: { 'Authorization': `Bearer ${oldKey}` }
+        });
+        assert.equal(oldValidate.status, 401, 'old key invalid after rotate');
+
+        // New key validates
+        const newValidate = await fetch(`${BASE}/v1/keys/validate`, {
+            headers: { 'Authorization': `Bearer ${rotateBody.agent_key}` }
+        });
+        assert.equal(newValidate.status, 200, 'new key validates');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('agents route — corrupt stored YAML returns 500 (Aaron fix)', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+        const create = await fetch(`${BASE}/v1/agents`, {
+            method: 'POST', headers: H_YAML, body: 'name: Doomed\ninstructions: hi\n'
+        });
+        const { agent_id } = await create.json();
+
+        // Corrupt the row directly via sqlite (bypasses server validation)
+        const Database = require('better-sqlite3');
+        const dbPath = path.join(tmp, 'ozwell.db');
+        const db = new Database(dbPath);
+        db.prepare('UPDATE agents SET yaml = ? WHERE id = ?').run('[unclosed: bracket', agent_id);
+        db.close();
+
+        const get = await fetch(`${BASE}/v1/agents/${agent_id}`, {
+            headers: { 'Authorization': `Bearer ${DEMO_KEY}` }
+        });
+        assert.equal(get.status, 500, 'corrupt YAML surfaces as 500');
     } finally {
         stopServer(server, tmp);
     }


### PR DESCRIPTION
Closes #118.

## Summary
- Store agents as a single YAML blob plus routing columns (`id`, `agent_key`, `parent_key`, `yaml`, `created_at`). YAML is source of truth, round-trips byte-identical on create/read/update.
- Register page lists existing agents under the API key. Click to edit in-place (PUT preserves agent_key), delete w/ confirm, \"+ New agent\" resets form. Rows show name + masked key (`••••last4`).
- Chat route parses YAML once at request start; existing behavior unchanged.
- Widen CORS `methods` to include PUT/DELETE for the new flows.
- Drive-by: fix lint debt in `routes/models.ts` (2 empty `} catch {}` blocks introduced by #74, only fix existed in #107).

## Live Demo

- Landing page: https://ozwelldemo.os.mieweb.org
- API server: https://ozwellapi.os.mieweb.org

## Stack
Rebased directly onto `main`. PR #107 dropped from stack — its lockfile / Fastify-5 / eslint-8 churn is not blocking this PR. Branch contains exactly **1 commit** on top of main.

## Verification
- `npm test` in reference-server — 7/7 pass. New `test/agents-yaml-blob.test.js` covers YAML round-trip (comments + unknown keys preserved), PUT verbatim, list/delete, invalid YAML rejection, `{yaml: "..."}` JSON wrapper body.
- `act` runs locally (all relevant workflows): `reference-server-ci` ✅ (lint/build/test/smoke green), `landing-page-e2e` ✅ (15 Playwright tests), `typescript-client-ci` ✅ (6 matrix), `typescript-client` ✅ (8 matrix). `docs-site` + `deploy-*` build steps green; only `upload-artifact` fails locally — known act limitation (`ACTIONS_RUNTIME_TOKEN`), real GHA unaffected.
- Manual E2E (Chrome DevTools): list → edit (key preserved `••••a5ae`) → create (auto-switch to edit) → delete → \"+ New agent\" reset.
- pageTools regression check: created agent YAML with `pageTools: { restricted: [...] }`, fetched back — YAML byte-identical, `chat.ts` PM_PREFIX filter logic preserved verbatim from main, reads `parsed.pageTools`.
- **Dev container (ozwell-dev2) deployed 2026-04-28**: 8 agents migrated from decomposed schema → YAML blob via `migrate-agents-yaml.js`. Build + PM2 restart clean. Smoke test + Chrome DevTools E2E on `ozwelldemo.os.mieweb.org/register.html` — all 4 demo-key agents load, edit form works.

## Migration
Uncommitted one-shot script (`reference-server/migrate-agents-yaml.js`) rebuilds YAML from the old decomposed columns. Run per env:
1. Stop PM2
2. Backup DB
3. Run script (idempotent — no-op if `yaml` column already present)
4. Deploy new code

**Deploy invariant:** migrate DB first, then deploy code. Reversed order breaks the app because new code reads `yaml` col and old DB lacks it.

## Prereq for
PR 2 (#119): MCP + per-agent secret vault.
