### PR TITLE
feat(agents): seeded mock agent for deterministic API testing

### DIFF
--- a/reference-server/README.md
+++ b/reference-server/README.md
@@ -521,6 +521,23 @@ The server auto-detects which backend to use at startup:
 
 Only one backend is active at a time. Setting both `LLM_BASE_URL` and `OLLAMA_BASE_URL` is fine — LLM takes priority.
 
+### Mock response labeling
+
+Every mock response — whether from a `type: mock` agent or a fallback path — includes a `warning` field on the JSON body (non-stream) or an SSE `event: warning` chunk emitted before content (stream), so callers can always detect the response did not come from a real LLM:
+
+```json
+{
+  "type": "mock_response",
+  "reason": "mock_agent" | "no_backend" | "llm_error",
+  "model": "<model>",
+  "message": "..."
+}
+```
+
+- `mock_agent` — agent YAML declares `type: mock`. Intentional, no LLM ever called.
+- `no_backend` — no LLM configured and Ollama unreachable. Dev/demo fallback.
+- `llm_error` — configured LLM errored after retry. Mock served so the client always gets a valid response, but the warning surfaces the failure (the chat widget shows a toast so end-users can report it).
+
 **Ollama auto-detection:** When `OLLAMA_MODEL` is not set, the server queries Ollama for installed models and picks the best available one, preferring in order:
 
 - `llama3.2:latest`

--- a/reference-server/embed/ozwell.js
+++ b/reference-server/embed/ozwell.js
@@ -1405,8 +1405,8 @@ async function sendMessageNonStreaming(text, tools) {
     const payload = await response.json();
     console.log('[widget.js] API response:', payload);
 
-    // Show toast for model fallback warnings
-    if (payload.warning && payload.warning.type === 'model_fallback') {
+    // Show toast for model fallback / mock-response warnings
+    if (payload.warning && (payload.warning.type === 'model_fallback' || payload.warning.type === 'mock_response')) {
       showToast(payload.warning.message);
     }
 
@@ -1651,7 +1651,7 @@ async function sendMessageStreaming(text, tools, _thinkingRetryCount = 0) {
           if (currentEventType === 'warning') {
             try {
               const warning = JSON.parse(data);
-              if (warning.type === 'model_fallback') {
+              if (warning.type === 'model_fallback' || warning.type === 'mock_response') {
                 showToast(warning.message);
               }
             } catch (e) { /* ignore malformed warning */ }

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -1,10 +1,11 @@
-import { FastifyPluginAsync } from 'fastify';
-import { validateAuth, createError, SimpleTextGenerator, generateId, countTokens, isOllamaAvailable, getOllamaDefaultModel, isAgentKey, extractToken, isLLMBackendConfigured } from '../util';
+import { FastifyPluginAsync, FastifyReply } from 'fastify';
+import { validateAuth, createError, generateId, countTokens, isOllamaAvailable, getOllamaDefaultModel, isAgentKey, extractToken, isLLMBackendConfigured } from '../util';
 import { agentStore, type PageToolsPolicy } from '../storage/agents';
 import * as yaml from 'yaml';
 import OzwellAI from 'ozwellai';
 import type { ChatCompletionRequest as ClientChatCompletionRequest } from 'ozwellai';
 import type { ChatCompletionRequest, Message } from '../../../spec/index';
+import { generateMockResponse, extractUserMessage, hasToolResult, extractToolResult, type ChatMessage as MockChatMessage } from './mock-chat';
 
 // SSE Heartbeat Configuration
 // Send keepalive every 25s to prevent 60s Nginx timeout
@@ -285,6 +286,77 @@ const ollamaClient = new OzwellAI({
   timeout: 120000,
 });
 
+// Mock dispatch — handles `type: mock` agents and the no-backend fallback.
+// Returns a non-streaming completion body, or writes SSE chunks to reply and returns void.
+async function dispatchMock(
+  messages: NonNullableMessage[],
+  model: string,
+  stream: boolean,
+  reply: FastifyReply,
+  origin: string | undefined,
+): Promise<unknown> {
+  const userMsg = extractUserMessage(messages as MockChatMessage[]);
+  const hasResult = hasToolResult(messages as MockChatMessage[]);
+  const toolResult = hasResult ? extractToolResult(messages as MockChatMessage[]) : null;
+  const assistantMsg = generateMockResponse(userMsg, hasResult, toolResult);
+
+  const id = generateId('chatcmpl');
+  const created = Math.floor(Date.now() / 1000);
+
+  if (!stream) {
+    const promptText = messages.map((m) => m.content).join(' ');
+    const completionText = assistantMsg.content || JSON.stringify(assistantMsg.tool_calls || []);
+    const promptTokens = countTokens(promptText);
+    const completionTokens = countTokens(completionText);
+    return {
+      id,
+      object: 'chat.completion' as const,
+      created,
+      model,
+      choices: [{ index: 0, message: assistantMsg, finish_reason: 'stop' as const }],
+      usage: {
+        prompt_tokens: promptTokens,
+        completion_tokens: completionTokens,
+        total_tokens: promptTokens + completionTokens,
+      },
+    };
+  }
+
+  reply.raw.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    'connection': 'keep-alive',
+    'access-control-allow-origin': origin || '*',
+    'access-control-allow-credentials': 'true',
+  });
+
+  const writeChunk = (delta: Record<string, unknown>, finishReason: string | null = null) => {
+    reply.raw.write(`data: ${JSON.stringify({
+      id, object: 'chat.completion.chunk', created, model,
+      choices: [{ index: 0, delta, finish_reason: finishReason }],
+    })}\n\n`);
+  };
+
+  writeChunk({ role: 'assistant' });
+
+  if (assistantMsg.content) {
+    const CHUNK = 3;
+    for (let i = 0; i < assistantMsg.content.length; i += CHUNK) {
+      writeChunk({ content: assistantMsg.content.slice(i, i + CHUNK) });
+    }
+  }
+
+  if (assistantMsg.tool_calls) {
+    const withIndex = assistantMsg.tool_calls.map((tc, idx) => ({ index: idx, ...tc }));
+    writeChunk({ tool_calls: withIndex });
+  }
+
+  writeChunk({}, 'stop');
+  reply.raw.write('data: [DONE]\n\n');
+  reply.raw.end();
+  return;
+}
+
 const chatRoute: FastifyPluginAsync = async (fastify) => {
   // POST /v1/chat/completions
   fastify.post('/v1/chat/completions', {
@@ -358,7 +430,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
     const body = request.body as ChatCompletionRequestWithTools;
 
     // --- Agent key resolution ---
-    let agentConfig: { systemPrompt: string; allowedTools: string[] | null; pageTools: PageToolsPolicy; model: string | null; temperature: number | null } | null = null;
+    let agentConfig: { systemPrompt: string; allowedTools: string[] | null; pageTools: PageToolsPolicy; model: string | null; temperature: number | null; type: 'mock' | undefined } | null = null;
 
     if (isAgentKey(request.headers.authorization)) {
       const agentKey = extractToken(request.headers.authorization);
@@ -408,7 +480,25 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
         pageTools: (parsed.pageTools as PageToolsPolicy) ?? 'all',
         model: (parsed.model as string | undefined) || null,
         temperature: (parsed.temperature as number | undefined) ?? null,
+        type: parsed.type === 'mock' ? 'mock' : undefined,
       };
+    }
+
+    // Early exit for mock-type agents — skip backend probing entirely (no LLM ever called).
+    if (agentConfig?.type === 'mock') {
+      const { messages: rawMessages, stream = false } = body as ChatCompletionRequestWithTools;
+      const mockMessages: NonNullableMessage[] = (rawMessages as Message[]).map((m) => ({
+        role: m.role,
+        content: m.content ?? '',
+        name: m.name,
+      }));
+      if (agentConfig.systemPrompt) {
+        mockMessages.unshift({ role: 'system', content: agentConfig.systemPrompt });
+      }
+      const mockModel = agentConfig.model || 'mock';
+      const result = await dispatchMock(mockMessages, mockModel, stream, reply, request.headers.origin);
+      if (stream) return;
+      return result;
     }
 
     // Backend selection priority:
@@ -485,59 +575,15 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
       });
     }
 
-    // If no real backend is available, redirect to mock endpoint
+    // No backend reachable — fall through to deterministic mock so client always gets a valid response.
     if (backend === 'fallback') {
-      // Forward to mock chat endpoint (use normalizedMessages which includes agent system prompt)
-      const mockUrl = `http://localhost:${process.env.PORT || 3000}/mock/chat`;
-      const mockBody = { ...body, messages: normalizedMessages, ...(filteredTools ? { tools: filteredTools } : {}) };
-      try {
-        const mockResponse = await fetch(mockUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': request.headers.authorization || 'Bearer mock'
-          },
-          body: JSON.stringify(mockBody)
-        });
-        
-        if (stream) {
-          // Forward SSE stream from mock
-          reply.raw.writeHead(mockResponse.status, {
-            'content-type': 'text/event-stream',
-            'cache-control': 'no-cache',
-            'connection': 'keep-alive',
-            'access-control-allow-origin': request.headers.origin || '*',
-            'access-control-allow-credentials': 'true',
-          });
-          
-          if (mockResponse.body) {
-            const reader = mockResponse.body.getReader();
-            try {
-              let done = false;
-              while (!done) {
-                const result = await reader.read();
-                done = result.done;
-                if (!done) {
-                  reply.raw.write(result.value);
-                }
-              }
-            } finally {
-              reply.raw.end();
-            }
-          }
-          return;
-        } else {
-          const mockData = await mockResponse.json();
-          return mockData;
-        }
-      } catch (mockError) {
-        request.log.error({ err: mockError }, 'Mock endpoint failed, using simple generator');
-        // Fall through to simple generator below
-      }
+      const result = await dispatchMock(normalizedMessages, model, stream, reply, request.headers.origin);
+      if (stream) return;
+      return result;
     }
 
     // Use a real LLM backend
-    if (backend !== 'fallback') {
+    {
       try {
         // Select pre-constructed client based on backend
         const client = llmConfigured ? llmClient! : ollamaClient;
@@ -782,111 +828,10 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
       }
     }
 
-    // Create prompt from messages
-    const prompt = (messages as Message[]).map((msg) => `${msg.role}: ${msg.content}`).join('\n');
-    const requestId = generateId('chatcmpl');
-    const created = Math.floor(Date.now() / 1000);
-
-    // Add OpenAI-compatible headers
-    reply.headers({
-      'x-request-id': `req_${Date.now()}`,
-      'openai-processing-ms': '150',
-      'openai-version': '2020-10-01',
-    });
-
-    if (stream) {
-      // Streaming response with CORS headers
-      reply.raw.writeHead(200, {
-        'content-type': 'text/event-stream',
-        'cache-control': 'no-cache',
-        'connection': 'keep-alive',
-        'access-control-allow-origin': request.headers.origin || '*',
-        'access-control-allow-credentials': 'true',
-        'x-request-id': `req_${Date.now()}`,
-        'openai-processing-ms': '150',
-        'openai-version': '2020-10-01',
-      });
-
-      const generator = SimpleTextGenerator.generateStream(prompt, max_tokens);
-
-      // Send initial chunk with role
-      const initialChunk = {
-        id: requestId,
-        object: 'chat.completion.chunk' as const,
-        created,
-        model,
-        choices: [{
-          index: 0,
-          delta: { role: 'assistant' },
-          finish_reason: null,
-        }],
-      };
-      reply.raw.write(`data: ${JSON.stringify(initialChunk)}\n\n`);
-
-      // Send content chunks
-      for (const token of generator) {
-        const chunk = {
-          id: requestId,
-          object: 'chat.completion.chunk' as const,
-          created,
-          model,
-          choices: [{
-            index: 0,
-            delta: { content: token },
-            finish_reason: null,
-          }],
-        };
-        reply.raw.write(`data: ${JSON.stringify(chunk)}\n\n`);
-        // Add small delay to simulate streaming
-        await new Promise(resolve => setTimeout(resolve, 50));
-      }
-
-      // Send final chunk
-      const finalChunk = {
-        id: requestId,
-        object: 'chat.completion.chunk' as const,
-        created,
-        model,
-        choices: [{
-          index: 0,
-          delta: {},
-          finish_reason: 'stop' as const,
-        }],
-      };
-      reply.raw.write(`data: ${JSON.stringify(finalChunk)}\n\n`);
-      reply.raw.write('data: [DONE]\n\n');
-      reply.raw.end();
-      return;
-    }
-
-    // Non-streaming response
-    const content = SimpleTextGenerator.generate(prompt, max_tokens, temperature);
-    const promptTokens = countTokens(prompt);
-    const completionTokens = countTokens(content);
-
-    return {
-      id: requestId,
-      object: 'chat.completion' as const,
-      created,
-      model,
-      choices: [{
-        index: 0,
-        message: {
-          role: 'assistant' as const,
-          content,
-          name: undefined,
-          function_call: undefined,
-          tool_calls: undefined,
-          tool_call_id: undefined,
-        },
-        finish_reason: 'stop' as const,
-      }],
-      usage: {
-        prompt_tokens: promptTokens,
-        completion_tokens: completionTokens,
-        total_tokens: promptTokens + completionTokens,
-      },
-    };
+    // LLM error final fallback: dispatch deterministic mock so the client always gets a valid response.
+    const result = await dispatchMock(normalizedMessages, model, stream, reply, request.headers.origin);
+    if (stream) return;
+    return result;
   });
 };
 

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -263,6 +263,17 @@ function buildFallbackWarning(originalModel: string, fallbackModel: string) {
   };
 }
 
+// Marks every mock response so callers (and the chat widget) can always tell a deterministic
+// mock from a real LLM answer. Three reasons cover all paths that emit a mock body.
+function buildMockWarning(reason: 'no_backend' | 'llm_error' | 'mock_agent', model: string) {
+  const messages = {
+    no_backend: `No LLM backend configured or reachable — deterministic mock returned for model ${model}.`,
+    llm_error: `LLM backend errored — deterministic mock returned as fallback for model ${model}.`,
+    mock_agent: `Agent is configured as type: mock — response is deterministic, no LLM called.`,
+  };
+  return { type: 'mock_response' as const, reason, model, message: messages[reason] };
+}
+
 // Hoist static env reads (these never change at runtime)
 const LLM_PROVIDER = process.env.LLM_PROVIDER || '';
 const LLM_MODEL = process.env.LLM_MODEL || 'gpt-4o-mini';
@@ -286,42 +297,56 @@ const ollamaClient = new OzwellAI({
   timeout: 120000,
 });
 
-// Mock dispatch — handles `type: mock` agents and the no-backend fallback.
-// Returns a non-streaming completion body, or writes SSE chunks to reply and returns void.
-async function dispatchMock(
-  messages: NonNullableMessage[],
-  model: string,
-  stream: boolean,
-  reply: FastifyReply,
-  origin: string | undefined,
-): Promise<unknown> {
+// Mock dispatch — split into stream / non-stream variants so the call-site
+// contract is enforced by the type system (no more silent `if (stream) return` footgun).
+// Both variants attach a structured warning so callers always know the response is mock.
+
+type MockWarning = ReturnType<typeof buildMockWarning>;
+
+function buildMockAssistant(messages: NonNullableMessage[]) {
   const userMsg = extractUserMessage(messages as MockChatMessage[]);
   const hasResult = hasToolResult(messages as MockChatMessage[]);
   const toolResult = hasResult ? extractToolResult(messages as MockChatMessage[]) : null;
   const assistantMsg = generateMockResponse(userMsg, hasResult, toolResult);
   const finishReason = assistantMsg.tool_calls?.length ? 'tool_calls' : 'stop';
+  return { assistantMsg, finishReason };
+}
 
+function dispatchMockNonStream(
+  messages: NonNullableMessage[],
+  model: string,
+  warning: MockWarning,
+) {
+  const { assistantMsg, finishReason } = buildMockAssistant(messages);
+  const promptText = messages.map((m) => m.content).join(' ');
+  const completionText = assistantMsg.content || JSON.stringify(assistantMsg.tool_calls || []);
+  const promptTokens = countTokens(promptText);
+  const completionTokens = countTokens(completionText);
+  return {
+    id: generateId('chatcmpl'),
+    object: 'chat.completion' as const,
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{ index: 0, message: assistantMsg, finish_reason: finishReason }],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+    },
+    warning,
+  };
+}
+
+function dispatchMockStream(
+  messages: NonNullableMessage[],
+  model: string,
+  reply: FastifyReply,
+  origin: string | undefined,
+  warning: MockWarning,
+): void {
+  const { assistantMsg, finishReason } = buildMockAssistant(messages);
   const id = generateId('chatcmpl');
   const created = Math.floor(Date.now() / 1000);
-
-  if (!stream) {
-    const promptText = messages.map((m) => m.content).join(' ');
-    const completionText = assistantMsg.content || JSON.stringify(assistantMsg.tool_calls || []);
-    const promptTokens = countTokens(promptText);
-    const completionTokens = countTokens(completionText);
-    return {
-      id,
-      object: 'chat.completion' as const,
-      created,
-      model,
-      choices: [{ index: 0, message: assistantMsg, finish_reason: finishReason }],
-      usage: {
-        prompt_tokens: promptTokens,
-        completion_tokens: completionTokens,
-        total_tokens: promptTokens + completionTokens,
-      },
-    };
-  }
 
   reply.raw.writeHead(200, {
     'content-type': 'text/event-stream',
@@ -331,10 +356,13 @@ async function dispatchMock(
     'access-control-allow-credentials': 'true',
   });
 
-  const writeChunk = (delta: Record<string, unknown>, finishReason: string | null = null) => {
+  // Emit warning event before chunks so widget can react before content streams in
+  reply.raw.write(`event: warning\ndata: ${JSON.stringify(warning)}\n\n`);
+
+  const writeChunk = (delta: Record<string, unknown>, finish: string | null = null) => {
     reply.raw.write(`data: ${JSON.stringify({
       id, object: 'chat.completion.chunk', created, model,
-      choices: [{ index: 0, delta, finish_reason: finishReason }],
+      choices: [{ index: 0, delta, finish_reason: finish }],
     })}\n\n`);
   };
 
@@ -355,7 +383,6 @@ async function dispatchMock(
   writeChunk({}, finishReason);
   reply.raw.write('data: [DONE]\n\n');
   reply.raw.end();
-  return;
 }
 
 const chatRoute: FastifyPluginAsync = async (fastify) => {
@@ -431,7 +458,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
     const body = request.body as ChatCompletionRequestWithTools;
 
     // --- Agent key resolution ---
-    let agentConfig: { systemPrompt: string; allowedTools: string[] | null; pageTools: PageToolsPolicy; model: string | null; temperature: number | null; type: 'mock' | undefined } | null = null;
+    let agentConfig: { systemPrompt: string; allowedTools: string[] | null; pageTools: PageToolsPolicy; model: string | null; temperature: number | null; type: 'mock' | null } | null = null;
 
     if (isAgentKey(request.headers.authorization)) {
       const agentKey = extractToken(request.headers.authorization);
@@ -481,7 +508,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
         pageTools: (parsed.pageTools as PageToolsPolicy) ?? 'all',
         model: (parsed.model as string | undefined) || null,
         temperature: (parsed.temperature as number | undefined) ?? null,
-        type: parsed.type === 'mock' ? 'mock' : undefined,
+        type: parsed.type === 'mock' ? 'mock' : null,
       };
     }
 
@@ -497,9 +524,12 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
         mockMessages.unshift({ role: 'system', content: agentConfig.systemPrompt });
       }
       const mockModel = agentConfig.model || 'mock';
-      const result = await dispatchMock(mockMessages, mockModel, stream, reply, request.headers.origin);
-      if (stream) return;
-      return result;
+      const warning = buildMockWarning('mock_agent', mockModel);
+      if (stream) {
+        dispatchMockStream(mockMessages, mockModel, reply, request.headers.origin, warning);
+        return;
+      }
+      return dispatchMockNonStream(mockMessages, mockModel, warning);
     }
 
     // Backend selection priority:
@@ -578,9 +608,12 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
 
     // No backend reachable — fall through to deterministic mock so client always gets a valid response.
     if (backend === 'fallback') {
-      const result = await dispatchMock(normalizedMessages, model, stream, reply, request.headers.origin);
-      if (stream) return;
-      return result;
+      const warning = buildMockWarning('no_backend', model);
+      if (stream) {
+        dispatchMockStream(normalizedMessages, model, reply, request.headers.origin, warning);
+        return;
+      }
+      return dispatchMockNonStream(normalizedMessages, model, warning);
     }
 
     // Use a real LLM backend
@@ -830,9 +863,13 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
     }
 
     // LLM error final fallback: dispatch deterministic mock so the client always gets a valid response.
-    const result = await dispatchMock(normalizedMessages, model, stream, reply, request.headers.origin);
-    if (stream) return;
-    return result;
+    // Warning marker tells caller the configured LLM failed — never silent.
+    const warning = buildMockWarning('llm_error', model);
+    if (stream) {
+      dispatchMockStream(normalizedMessages, model, reply, request.headers.origin, warning);
+      return;
+    }
+    return dispatchMockNonStream(normalizedMessages, model, warning);
   });
 };
 

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -299,6 +299,7 @@ async function dispatchMock(
   const hasResult = hasToolResult(messages as MockChatMessage[]);
   const toolResult = hasResult ? extractToolResult(messages as MockChatMessage[]) : null;
   const assistantMsg = generateMockResponse(userMsg, hasResult, toolResult);
+  const finishReason = assistantMsg.tool_calls?.length ? 'tool_calls' : 'stop';
 
   const id = generateId('chatcmpl');
   const created = Math.floor(Date.now() / 1000);
@@ -313,7 +314,7 @@ async function dispatchMock(
       object: 'chat.completion' as const,
       created,
       model,
-      choices: [{ index: 0, message: assistantMsg, finish_reason: 'stop' as const }],
+      choices: [{ index: 0, message: assistantMsg, finish_reason: finishReason }],
       usage: {
         prompt_tokens: promptTokens,
         completion_tokens: completionTokens,
@@ -351,7 +352,7 @@ async function dispatchMock(
     writeChunk({ tool_calls: withIndex });
   }
 
-  writeChunk({}, 'stop');
+  writeChunk({}, finishReason);
   reply.raw.write('data: [DONE]\n\n');
   reply.raw.end();
   return;

--- a/reference-server/src/routes/mock-chat.ts
+++ b/reference-server/src/routes/mock-chat.ts
@@ -1,71 +1,13 @@
-import { FastifyPluginAsync } from 'fastify';
-import { generateId, countTokens } from '../util';
+// Pure helpers for deterministic mock chat responses.
+// Used by the chat route to bypass the LLM for `type: mock` agents
+// and as a final fallback when no LLM backend is reachable.
 
-interface ChatMessage {
+export interface ChatMessage {
   role: string;
   content: string;
 }
 
-interface StreamingConfig {
-  initialDelayMs: number;    // Delay before first token (simulates TTFB)
-  perChunkDelayMs: number;   // Delay between each chunk
-  chunkSize: number;         // Characters per chunk
-  enableJitter: boolean;     // Add random variance to delays
-}
-
-/**
- * Sleep helper for simulating delays
- */
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-/**
- * Split text into chunks for streaming
- */
-function splitIntoChunks(text: string, chunkSize: number): string[] {
-  const chunks: string[] = [];
-  for (let i = 0; i < text.length; i += chunkSize) {
-    chunks.push(text.slice(i, i + chunkSize));
-  }
-  return chunks;
-}
-
-/**
- * Get streaming configuration from query parameters
- */
-function getStreamingConfig(queryParams: Record<string, unknown>): StreamingConfig {
-  // Preset modes
-  if (queryParams.slow === 'true') {
-    return { initialDelayMs: 2000, perChunkDelayMs: 150, chunkSize: 3, enableJitter: true };
-  }
-  if (queryParams.fast === 'true') {
-    return { initialDelayMs: 100, perChunkDelayMs: 30, chunkSize: 5, enableJitter: false };
-  }
-  if (queryParams.realistic === 'true' || !queryParams.initialDelay) {
-    // Default realistic mode
-    return { initialDelayMs: 500, perChunkDelayMs: 50, chunkSize: 3, enableJitter: true };
-  }
-
-  // Custom params
-  return {
-    initialDelayMs: parseInt(String(queryParams.initialDelay || '500'), 10),
-    perChunkDelayMs: parseInt(String(queryParams.chunkDelay || '50'), 10),
-    chunkSize: parseInt(String(queryParams.chunkSize || '3'), 10),
-    enableJitter: queryParams.jitter === 'true'
-  };
-}
-
-interface Tool {
-  type: string;
-  function: {
-    name: string;
-    description: string;
-    parameters: Record<string, unknown>;
-  };
-}
-
-interface ToolCall {
+export interface ToolCall {
   id: string;
   type: 'function';
   function: {
@@ -74,32 +16,13 @@ interface ToolCall {
   };
 }
 
-interface MockChatRequest {
-  model: string;
-  messages: ChatMessage[];
-  tools?: Tool[];
-  temperature?: number;
-  max_tokens?: number;
-  stream?: boolean;
-}
-
-/**
- * Mock AI Chat Endpoint
- *
- * This endpoint simulates AI responses using keyword matching and switch-case logic.
- * It's designed for reliable demos - always returns predictable, correct responses.
- *
- * Purpose: Prove MCP tool calling works via iframe-sync + postMessage without
- * relying on unpredictable LLM behavior.
- */
-
-function extractUserMessage(messages: ChatMessage[]): string {
+export function extractUserMessage(messages: ChatMessage[]): string {
   // Get the last user message
   const lastUserMsg = messages.filter(msg => msg.role === 'user').pop();
   return lastUserMsg?.content || '';
 }
 
-function hasToolResult(messages: ChatMessage[]): boolean {
+export function hasToolResult(messages: ChatMessage[]): boolean {
   // Check if the LAST non-system message is a tool result (second round of OpenAI protocol)
   // We need to check recency, not just existence, to avoid treating all messages after
   // the first tool call as tool results
@@ -108,7 +31,7 @@ function hasToolResult(messages: ChatMessage[]): boolean {
   return lastMessage?.role === 'tool';
 }
 
-function extractToolResult(messages: ChatMessage[]): Record<string, unknown> | null {
+export function extractToolResult(messages: ChatMessage[]): Record<string, unknown> | null {
   // Get the LAST tool result from messages (most recent)
   const toolMessages = messages.filter(msg => msg.role === 'tool');
   const toolMsg = toolMessages[toolMessages.length - 1];
@@ -121,7 +44,7 @@ function extractToolResult(messages: ChatMessage[]): Record<string, unknown> | n
   }
 }
 
-function generateMockResponse(userMessage: string, hasToolResult: boolean, toolResult: Record<string, unknown> | null): { role: string; content: string; tool_calls?: ToolCall[] } {
+export function generateMockResponse(userMessage: string, hasToolResult: boolean, toolResult: Record<string, unknown> | null): { role: string; content: string; tool_calls?: ToolCall[] } {
   const msg = userMessage.toLowerCase();
 
   // If this is the second round (after tool execution), generate final response
@@ -328,175 +251,3 @@ function generateMockResponse(userMessage: string, hasToolResult: boolean, toolR
   };
 }
 
-const mockChatRoute: FastifyPluginAsync = async (fastify) => {
-  fastify.post('/mock/chat', {
-    schema: {
-      body: {
-        type: 'object',
-        properties: {
-          model: { type: 'string' },
-          messages: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                role: { type: 'string' },
-                content: { type: 'string' },
-              },
-              required: ['role', 'content'],
-            },
-          },
-          tools: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                type: { type: 'string' },
-                function: {
-                  type: 'object',
-                  properties: {
-                    name: { type: 'string' },
-                    description: { type: 'string' },
-                    parameters: { type: 'object' },
-                  },
-                },
-              },
-            },
-          },
-          temperature: { type: 'number' },
-          max_tokens: { type: 'number' },
-          stream: { type: 'boolean' },
-        },
-        required: ['messages'],
-      },
-    },
-  }, async (request, _reply) => {
-    const body = request.body as MockChatRequest;
-    const model = body.model || 'mock-ai';  // Default to mock-ai if not specified
-
-    // Use messages as-is (OpenAI format)
-    const messages: ChatMessage[] = body.messages;
-
-    // Extract user message and tool result
-    const userMessage = extractUserMessage(messages);
-    const hasResult = hasToolResult(messages);
-    const toolResult = hasResult ? extractToolResult(messages) : null;
-
-    // Generate mock response
-    const assistantMessage = generateMockResponse(userMessage, hasResult, toolResult);
-
-    const requestId = generateId('mockcmpl');
-    const created = Math.floor(Date.now() / 1000);
-
-    // Calculate mock token usage
-    const prompt = messages.map(msg => msg.content).join(' ');
-    const completion = assistantMessage.content || JSON.stringify(assistantMessage.tool_calls || []);
-
-    // Handle streaming response
-    if (body.stream) {
-      _reply.raw.setHeader('Content-Type', 'text/event-stream');
-      _reply.raw.setHeader('Cache-Control', 'no-cache');
-      _reply.raw.setHeader('Connection', 'keep-alive');
-      _reply.raw.setHeader('Access-Control-Allow-Origin', '*');
-
-      // Get streaming config from query params
-      const streamingConfig = getStreamingConfig(request.query as Record<string, unknown>);
-
-      // Initial delay (simulate TTFB/model loading)
-      await sleep(streamingConfig.initialDelayMs);
-
-      // Stream text content in chunks
-      if (assistantMessage.content) {
-        const chunks = splitIntoChunks(
-          assistantMessage.content,
-          streamingConfig.chunkSize
-        );
-
-        for (const chunk of chunks) {
-          const delay = streamingConfig.perChunkDelayMs;
-          const actualDelay = streamingConfig.enableJitter
-            ? delay * (0.7 + Math.random() * 0.6)  // ±30% variance
-            : delay;
-
-          await sleep(actualDelay);
-
-          _reply.raw.write(`data: ${JSON.stringify({
-            id: requestId,
-            object: 'chat.completion.chunk',
-            created,
-            model,
-            choices: [{
-              index: 0,
-              delta: { content: chunk },
-              finish_reason: null
-            }]
-          })}\n\n`);
-        }
-      }
-
-      // Send tool calls if present (streaming format requires index on each tool call)
-      if (assistantMessage.tool_calls) {
-        // Brief pause before tool call appears
-        await sleep(200);
-
-        const toolCallsWithIndex = assistantMessage.tool_calls.map((tc: ToolCall, idx: number) => ({
-          index: idx,
-          id: tc.id,
-          type: tc.type,
-          function: tc.function
-        }));
-
-        _reply.raw.write(`data: ${JSON.stringify({
-          id: requestId,
-          object: 'chat.completion.chunk',
-          created,
-          model,
-          choices: [{
-            index: 0,
-            delta: { tool_calls: toolCallsWithIndex },
-            finish_reason: null
-          }]
-        })}\n\n`);
-      }
-
-      // Send final chunk
-      await sleep(100); // Small delay before finish
-      _reply.raw.write(`data: ${JSON.stringify({
-        id: requestId,
-        object: 'chat.completion.chunk',
-        created,
-        model,
-        choices: [{
-          index: 0,
-          delta: {},
-          finish_reason: 'stop'
-        }]
-      })}\n\n`);
-      _reply.raw.write('data: [DONE]\n\n');
-      _reply.raw.end();
-      return _reply;
-    }
-
-    // Non-streaming response (existing behavior)
-    return {
-      id: requestId,
-      object: 'chat.completion',
-      created,
-      model,
-      choices: [
-        {
-          index: 0,
-          message: assistantMessage,
-          finish_reason: 'stop'
-        }
-      ],
-      usage: {
-        prompt_tokens: countTokens(prompt),
-        completion_tokens: countTokens(completion),
-        total_tokens: countTokens(prompt) + countTokens(completion),
-      },
-    };
-  });
-};
-
-export default mockChatRoute;

--- a/reference-server/src/server.ts
+++ b/reference-server/src/server.ts
@@ -13,9 +13,8 @@ import chatRoute from './routes/chat';
 import responsesRoute from './routes/responses';
 import embeddingsRoute from './routes/embeddings';
 import filesRoute from './routes/files';
-import mockChatRoute from './routes/mock-chat';
 import agentsRoute from './routes/agents';
-import { getDatabase, initializeAuthTables, seedDemoData } from './storage/agents';
+import { getDatabase, initializeAuthTables, seedDemoData, seedMockAgent } from './storage/agents';
 // Import schemas for OpenAPI generation
 import * as schemas from '../../spec';
 
@@ -141,7 +140,6 @@ async function buildServer() {
   await fastify.register(responsesRoute);
   await fastify.register(embeddingsRoute);
   await fastify.register(filesRoute);
-  await fastify.register(mockChatRoute);  // Mock AI for demos
   await fastify.register(agentsRoute);  // Agent registration CRUD
 
   // Serve public assets (documentation, misc)
@@ -214,6 +212,7 @@ if (require.main === module) {
       if (process.env.NODE_ENV !== 'production') {
         try {
           seedDemoData(db);
+          seedMockAgent();
         } catch (_e) {
           // Seeding may fail on repeated starts — that's fine
         }

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -16,6 +16,14 @@ const DB_PATH = process.env.DB_PATH
 // Demo parent API key
 export const DEMO_API_KEY = 'ozw_demo_localhost_key_for_testing';
 
+// Fixed mock agent — deterministic responses for testing the API pipeline without an LLM.
+export const MOCK_AGENT_ID = 'mock-agent';
+export const MOCK_AGENT_KEY = 'agnt_key-mock-test';
+export const MOCK_AGENT_YAML = `name: Mock Test Agent
+type: mock
+instructions: Deterministic mock agent for API testing. No LLM is called.
+`;
+
 // ── Database singleton ──────────────────────────────────────────────
 
 let _db: Database.Database | null = null;
@@ -58,6 +66,21 @@ export function seedDemoData(db: Database.Database): void {
     `).run(demoKeyId, 'Demo Key', DEMO_API_KEY, keyHint, now);
 
     console.log('[auth] Demo API key seeded');
+}
+
+/**
+ * Seed the fixed mock agent. Idempotent — skips if already present.
+ * Anyone can use MOCK_AGENT_KEY to exercise the chat pipeline without an LLM.
+ */
+export function seedMockAgent(): void {
+    if (agentStore.getById(MOCK_AGENT_ID)) return;
+    agentStore.createAgent({
+        id: MOCK_AGENT_ID,
+        agent_key: MOCK_AGENT_KEY,
+        parent_key: DEMO_API_KEY,
+        yaml: MOCK_AGENT_YAML,
+    });
+    console.log('[mock] Mock agent seeded');
 }
 
 // ── Agent model ─────────────────────────────────────────────────────

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -74,6 +74,7 @@ export function seedDemoData(db: Database.Database): void {
  */
 export function seedMockAgent(): void {
     if (agentStore.getById(MOCK_AGENT_ID)) return;
+    if (agentStore.getByKey(MOCK_AGENT_KEY)) return;
     agentStore.createAgent({
         id: MOCK_AGENT_ID,
         agent_key: MOCK_AGENT_KEY,

--- a/reference-server/test/mock-agent.test.js
+++ b/reference-server/test/mock-agent.test.js
@@ -73,13 +73,14 @@ test('mock agent — emits tool_calls for action phrases (proves full pipeline)'
     const j = await r.json();
 
     const msg = j.choices[0].message;
+    assert.equal(j.choices[0].finish_reason, 'tool_calls');
     assert.ok(Array.isArray(msg.tool_calls), 'tool_calls present');
     assert.equal(msg.tool_calls[0].function.name, 'update_form_data');
     const args = JSON.parse(msg.tool_calls[0].function.arguments);
     assert.equal(args.name, 'Bob');
 });
 
-test('mock agent — streaming ends with [DONE] and yields content chunks', async () => {
+test('mock agent — streaming text response ends with stop', async () => {
     const r = await fetch(`${BASE}/v1/chat/completions`, {
         method: 'POST',
         headers: H,
@@ -92,6 +93,21 @@ test('mock agent — streaming ends with [DONE] and yields content chunks', asyn
     assert.ok(text.includes('data: [DONE]'), 'stream terminates with [DONE]');
     assert.ok(text.includes('"role":"assistant"'), 'role chunk emitted');
     assert.ok(text.includes('"finish_reason":"stop"'), 'final chunk has stop');
+});
+
+test('mock agent — streaming tool-call response ends with tool_calls', async () => {
+    const r = await fetch(`${BASE}/v1/chat/completions`, {
+        method: 'POST',
+        headers: H,
+        body: JSON.stringify({ messages: [{ role: 'user', content: 'update name to Bob' }], stream: true })
+    });
+    assert.equal(r.status, 200);
+    assert.match(r.headers.get('content-type') || '', /text\/event-stream/);
+
+    const text = await r.text();
+    assert.ok(text.includes('data: [DONE]'), 'stream terminates with [DONE]');
+    assert.ok(text.includes('"tool_calls"'), 'tool call chunk emitted');
+    assert.ok(text.includes('"finish_reason":"tool_calls"'), 'final chunk has tool_calls');
 });
 
 test('mock agent — unauthenticated request rejected', async () => {

--- a/reference-server/test/mock-agent.test.js
+++ b/reference-server/test/mock-agent.test.js
@@ -56,6 +56,8 @@ test('mock agent — non-stream returns deterministic content for greeting', asy
     assert.equal(j1.choices[0].finish_reason, 'stop');
     assert.equal(j1.choices[0].message.role, 'assistant');
     assert.match(j1.choices[0].message.content, /Hello/);
+    assert.equal(j1.warning?.type, 'mock_response');
+    assert.equal(j1.warning?.reason, 'mock_agent');
 
     const r2 = await fetch(`${BASE}/v1/chat/completions`, { method: 'POST', headers: H, body });
     const j2 = await r2.json();
@@ -93,6 +95,8 @@ test('mock agent — streaming text response ends with stop', async () => {
     assert.ok(text.includes('data: [DONE]'), 'stream terminates with [DONE]');
     assert.ok(text.includes('"role":"assistant"'), 'role chunk emitted');
     assert.ok(text.includes('"finish_reason":"stop"'), 'final chunk has stop');
+    assert.ok(text.includes('event: warning'), 'warning event emitted');
+    assert.ok(text.includes('"reason":"mock_agent"'), 'warning reason is mock_agent');
 });
 
 test('mock agent — streaming tool-call response ends with tool_calls', async () => {

--- a/reference-server/test/mock-agent.test.js
+++ b/reference-server/test/mock-agent.test.js
@@ -1,0 +1,104 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+// Keep MOCK_KEY in sync with MOCK_AGENT_KEY in src/storage/agents.ts.
+// Test file is plain JS (no TS imports) so the constant cannot be pulled directly.
+const MOCK_KEY = 'agnt_key-mock-test';
+const PORT = 3334;
+const BASE = `http://localhost:${PORT}`;
+
+let server;
+let tmp;
+
+async function waitForReady(maxMs = 10_000) {
+    const start = Date.now();
+    while (Date.now() - start < maxMs) {
+        try {
+            const r = await fetch(`${BASE}/health`);
+            if (r.status === 200) return;
+        } catch { /* not ready */ }
+        await delay(200);
+    }
+    throw new Error('server never became ready');
+}
+
+before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-mock-test-'));
+    const dbPath = path.join(tmp, 'ozwell.db');
+    server = spawn('npm', ['run', 'dev'], {
+        cwd: process.cwd(),
+        stdio: 'pipe',
+        detached: true,
+        env: { ...process.env, PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development' }
+    });
+    await waitForReady();
+});
+
+after(() => {
+    try { process.kill(-server.pid, 'SIGKILL'); } catch { /* ignore */ }
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+const H = { 'Content-Type': 'application/json', 'Authorization': `Bearer ${MOCK_KEY}` };
+
+test('mock agent — non-stream returns deterministic content for greeting', async () => {
+    const body = JSON.stringify({ messages: [{ role: 'user', content: 'hello' }] });
+
+    const r1 = await fetch(`${BASE}/v1/chat/completions`, { method: 'POST', headers: H, body });
+    assert.equal(r1.status, 200);
+    const j1 = await r1.json();
+    assert.equal(j1.object, 'chat.completion');
+    assert.equal(j1.choices[0].finish_reason, 'stop');
+    assert.equal(j1.choices[0].message.role, 'assistant');
+    assert.match(j1.choices[0].message.content, /Hello/);
+
+    const r2 = await fetch(`${BASE}/v1/chat/completions`, { method: 'POST', headers: H, body });
+    const j2 = await r2.json();
+    assert.equal(j1.choices[0].message.content, j2.choices[0].message.content,
+        'same input produces identical content');
+});
+
+test('mock agent — emits tool_calls for action phrases (proves full pipeline)', async () => {
+    const body = JSON.stringify({
+        messages: [{ role: 'user', content: 'update name to Bob' }]
+    });
+
+    const r = await fetch(`${BASE}/v1/chat/completions`, { method: 'POST', headers: H, body });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+
+    const msg = j.choices[0].message;
+    assert.ok(Array.isArray(msg.tool_calls), 'tool_calls present');
+    assert.equal(msg.tool_calls[0].function.name, 'update_form_data');
+    const args = JSON.parse(msg.tool_calls[0].function.arguments);
+    assert.equal(args.name, 'Bob');
+});
+
+test('mock agent — streaming ends with [DONE] and yields content chunks', async () => {
+    const r = await fetch(`${BASE}/v1/chat/completions`, {
+        method: 'POST',
+        headers: H,
+        body: JSON.stringify({ messages: [{ role: 'user', content: 'hello' }], stream: true })
+    });
+    assert.equal(r.status, 200);
+    assert.match(r.headers.get('content-type') || '', /text\/event-stream/);
+
+    const text = await r.text();
+    assert.ok(text.includes('data: [DONE]'), 'stream terminates with [DONE]');
+    assert.ok(text.includes('"role":"assistant"'), 'role chunk emitted');
+    assert.ok(text.includes('"finish_reason":"stop"'), 'final chunk has stop');
+});
+
+test('mock agent — unauthenticated request rejected', async () => {
+    const r = await fetch(`${BASE}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: [{ role: 'user', content: 'hello' }] })
+    });
+    assert.equal(r.status, 401);
+});


### PR DESCRIPTION
## Summary
- Adds a fixed mock agent (key: \`agnt_key-mock-test\`, parent: demo key) seeded at startup
- With \`type: mock\` in agent YAML, the chat route bypasses the LLM and returns OpenAI-shaped responses from the existing rule engine (repurposed from \`mock-chat.ts\`)
- Removes the \`/mock/chat\` route and the self-HTTP fallback in chat.ts

## Why
Need a way to exercise the full \`auth → agent lookup → routing → response\` pipeline without calling a real LLM (cost, latency, nondeterminism). One shared seeded agent — anyone hits the same key, gets byte-identical responses.

## Stacked on
PR #120 (\`feat/agents-yaml-blob\`). Will auto-retarget to \`main\` once #120 merges.

## Test plan
- [x] \`npm test\` — 17/17 passing (4 new mock-agent cases: deterministic content, tool_calls emission, SSE streaming, auth rejection)
- [x] \`act -W .github/workflows/reference-server-ci.yml\` — green on ubuntu-latest + Node 22
- [x] Manual test via landing-page widget after swapping \`LANDING_AGENT_KEY=agnt_key-mock-test\` in \`landing-page/.env\`