### PR TITLE
docs: update public environment URLs and agent onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Live Demo
 
-**Try it now:** [https://ozwellai-embedtest.opensource.mieweb.org](https://ozwellai-embedtest.opensource.mieweb.org)
+**Try it now:** [https://ozwelldemo.opensource.mieweb.org](https://ozwelldemo.opensource.mieweb.org)
 
 **Watch demo:** [YouTube Short](https://youtube.com/shorts/mqcoEoQzQMM?si=FLa_dq_4y2TeO_48)
 

--- a/docs/backend/agents.md
+++ b/docs/backend/agents.md
@@ -1,5 +1,14 @@
 # Agent Registration API
 
+:::tip Fastest Way to Create an Agent
+The easiest path is to open `https://ozwelldemo.opensource.mieweb.org/register.html` and create/manage your agents through the register page UI.
+
+To get an Ozwell API key (`ozw_` prefix) for agent creation, contact:
+
+- **`horner@mieweb.com`** (Doug Horner)
+- **`adamerla128@gmail.com`** (Aditya Damerla)
+:::
+
 :::info Getting an API Key
 The Ozwell Dashboard for key provisioning is **coming soon**. In the meantime, to get an API key (`ozw_` prefix), contact:
 
@@ -15,8 +24,11 @@ Agent chat requests are processed by whichever backend the server has configured
 
 | Environment | URL |
 |-------------|-----|
-| **Development** | `https://ozwell-dev-refserver.opensource.mieweb.org` |
+| **Current official public** | `https://ozwellapi.opensource.mieweb.org` |
+| **Beta / development** | `https://ozwellapi.os.mieweb.org` *(unstable, active development)* |
 | **Production** | `https://api.ozwell.ai` *(coming soon)* |
+
+Use the current official public environment above for normal testing and integrations. The beta / development URL may change or break and should only be used if you specifically need the latest in-progress changes.
 
 ## Authentication
 
@@ -28,10 +40,21 @@ Authorization: Bearer ozw_your_api_key_here
 
 ## Quick Start
 
+### Option A — Create an agent in the UI
+
+1. Get an Ozwell API key by contacting **`horner@mieweb.com`** or **`adamerla128@gmail.com`**
+2. Open `https://ozwelldemo.opensource.mieweb.org/register.html`
+3. Create or edit your agent in the register page
+4. Copy the returned `agent_key` and use it in your widget embed
+
+### Option B — Create an agent via API
+
+If you want the lower-level/manual flow, use the API directly:
+
 ### Step 1 — Set your server and key
 
 ```bash
-BASE="https://ozwell-dev-refserver.opensource.mieweb.org"
+BASE="https://ozwellapi.opensource.mieweb.org"
 AUTH="Authorization: Bearer ozw_your_api_key_here"
 ```
 
@@ -89,7 +112,7 @@ curl -s -X POST "$BASE/v1/agents" \
 <script>
   window.OzwellChatConfig = { apiKey: 'agnt_key-abc123...' };
 </script>
-<script src="https://ozwell-dev-refserver.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 That's it — 4 steps: set credentials, create agent, copy the key, embed it.

--- a/docs/backend/api-endpoints.md
+++ b/docs/backend/api-endpoints.md
@@ -6,11 +6,12 @@ Complete reference for all Ozwell API endpoints.
 
 | Environment | URL |
 |-------------|-----|
-| **Development** | `https://ozwell-dev-refserver.opensource.mieweb.org` |
+| **Current official public** | `https://ozwellapi.opensource.mieweb.org` |
+| **Beta / development** | `https://ozwellapi.os.mieweb.org` *(unstable, active development)* |
 | **Production** | `https://api.ozwell.ai` *(coming soon)* |
 
 :::tip
-All examples below use `https://api.ozwell.ai` as the base URL. For development and testing, replace with the development URL above.
+All examples below use `https://ozwellapi.opensource.mieweb.org` as the current official public base URL. Use the beta / development URL only if you specifically need the latest in-progress changes.
 :::
 
 ## Chat
@@ -55,7 +56,7 @@ POST /v1/chat/completions
 #### Example Request
 
 ```bash
-curl https://api.ozwell.ai/v1/chat/completions \
+curl https://ozwellapi.opensource.mieweb.org/v1/chat/completions \
   -H "Authorization: Bearer $OZWELL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -117,7 +118,7 @@ POST /v1/embeddings
 #### Example Request
 
 ```bash
-curl https://api.ozwell.ai/v1/embeddings \
+curl https://ozwellapi.opensource.mieweb.org/v1/embeddings \
   -H "Authorization: Bearer $OZWELL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -168,7 +169,7 @@ POST /v1/files
 #### Example Request
 
 ```bash
-curl https://api.ozwell.ai/v1/files \
+curl https://ozwellapi.opensource.mieweb.org/v1/files \
   -H "Authorization: Bearer $OZWELL_API_KEY" \
   -F "file=@document.pdf" \
   -F "purpose=assistants"
@@ -312,7 +313,7 @@ Includes all `chat/completions` parameters plus:
 #### Example Request
 
 ```bash
-curl https://api.ozwell.ai/v1/responses \
+curl https://ozwellapi.opensource.mieweb.org/v1/responses \
   -H "Authorization: Bearer $OZWELL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -368,11 +369,11 @@ List endpoints support pagination:
 
 ```bash
 # First page
-curl "https://api.ozwell.ai/v1/files?limit=10" \
+curl "https://ozwellapi.opensource.mieweb.org/v1/files?limit=10" \
   -H "Authorization: Bearer $OZWELL_API_KEY"
 
 # Next page
-curl "https://api.ozwell.ai/v1/files?limit=10&after=file-abc123" \
+curl "https://ozwellapi.opensource.mieweb.org/v1/files?limit=10&after=file-abc123" \
   -H "Authorization: Bearer $OZWELL_API_KEY"
 ```
 

--- a/docs/frontend/cdn-embed.md
+++ b/docs/frontend/cdn-embed.md
@@ -13,13 +13,13 @@ To get an API key and create an agent, see the [Agent Registration API](../backe
 Add this snippet to your HTML, just before the closing `</body>` tag:
 
 ```html
-<!-- Development server (current) -->
+<!-- Current official public environment -->
 <script>
   window.OzwellChatConfig = { apiKey: 'agnt_key-your-agent-key' };
 </script>
-<script src="https://ozwell-dev-refserver.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 
-<!-- Production (coming soon) -->
+<!-- Future production CDN (coming soon) -->
 <!--
 <script 
   src="https://cdn.ozwell.ai/embed.js" 
@@ -185,7 +185,7 @@ Your agent definition (created via the [Agent Registration API](../backend/agent
 <script>
   window.OzwellChatConfig = { apiKey: 'agnt_key-your-agent-key' };
 </script>
-<script src="https://ozwell-dev-refserver.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 That's the same script tag from [Quick Start](#quick-start). If your agent has tools defined, they just work — the widget discovers them during its MCP handshake with the server.
@@ -263,7 +263,7 @@ If you're using a parent API key (`ozw_...`) instead of an agent key, you can de
     }]
   };
 </script>
-<script src="https://ozwell-dev-refserver.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 You still handle `ozwell-tool-call` the same way — the event listener code doesn't change.
@@ -298,8 +298,8 @@ For the full postMessage protocol details (useful if you're building a custom in
 :::note Current Script URLs
 The examples below use `cdn.ozwell.ai/embed.js` which is the future production CDN. For now, use:
 
-- **Dev:** `https://ozwell-dev-refserver.opensource.mieweb.org/embed/ozwell-loader.js`
-- **Production:** `https://ozwellai-refserver.opensource.mieweb.org/embed/ozwell-loader.js`
+- **Current official public:** `https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js`
+- **Beta / development:** `https://ozwellapi.os.mieweb.org/embed/ozwell-loader.js` *(unstable, active development — prefer the `opensource` host unless you specifically need the latest changes)*
 :::
 
 ### Basic Embed
@@ -383,7 +383,7 @@ A full working example — an AI assistant that can read and update form fields 
       debug: true  // shows tool pills in chat — turn off in production
     };
   </script>
-  <script src="https://ozwell-dev-refserver.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+  <script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 
   <!-- 2. Handle tool calls -->
   <script>
@@ -453,7 +453,7 @@ If your site uses CSP headers, add Ozwell's domains:
 Content-Security-Policy: 
   script-src 'self' https://cdn.ozwell.ai;
   frame-src 'self' https://embed.ozwell.ai;
-  connect-src 'self' https://api.ozwell.ai;
+  connect-src 'self' https://ozwellapi.opensource.mieweb.org;
 ```
 
 ---

--- a/docs/frontend/cdn-embed.md
+++ b/docs/frontend/cdn-embed.md
@@ -451,7 +451,7 @@ If your site uses CSP headers, add Ozwell's domains:
 
 ```
 Content-Security-Policy: 
-  script-src 'self' https://cdn.ozwell.ai;
+  script-src 'self' https://ozwellapi.opensource.mieweb.org https://cdn.ozwell.ai;
   frame-src 'self' https://embed.ozwell.ai;
   connect-src 'self' https://ozwellapi.opensource.mieweb.org;
 ```

--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -8,7 +8,10 @@ description: Integrate Ozwell's privacy-first AI chat into your website or web a
 
 Ozwell is an embeddable AI assistant that runs inside an iframe on your website. Users chat with it. The AI can call **tools you define** — JavaScript functions that read from or write to your page. Conversations are private by default; your page only sees tool calls and lifecycle events, never message content.
 
-> **Try it live:** See Ozwell in action at the [demo site](https://ozwellai-embedtest.opensource.mieweb.org/).
+> **Try it live:** See Ozwell in action at the [demo site](https://ozwelldemo.opensource.mieweb.org/).
+>
+> **Current official public API:** `https://ozwellapi.opensource.mieweb.org`  
+> **Beta / development API:** `https://ozwellapi.os.mieweb.org` *(unstable, active development — prefer the `opensource` host for normal use)*
 
 ## What You're Building
 
@@ -50,7 +53,7 @@ Here's a page that exposes two tools: one that reads the current email (get) and
     ]
   };
 </script>
-<script src="https://ozwell-dev-refserver.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 ### 2. Handle Tool Calls
@@ -154,7 +157,7 @@ Add Ozwell to any website with a single script tag. No build step required. Supp
 <script>
   window.OzwellChatConfig = { apiKey: 'agnt_key-your-agent-key' };
 </script>
-<script src="https://ozwell-dev-refserver.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 ➡️ [Full CDN documentation with tool calling tutorial](./cdn-embed.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -333,7 +333,7 @@ If you're unsure whether your use case complies with our trademark policy, pleas
 
 ## Next Steps
 
-1. **See it in action?** Try the [live demo](https://ozwellai-embedtest.opensource.mieweb.org/) to experience Ozwell's chat widget.
+1. **See it in action?** Try the [live demo](https://ozwelldemo.opensource.mieweb.org/) to experience Ozwell's chat widget.
 
 2. **New to Ozwell?** Start with the [CDN integration](./frontend/cdn-embed.md) for the fastest path to a working demo.
 

--- a/reference-server/README.md
+++ b/reference-server/README.md
@@ -235,7 +235,7 @@ The server will start at `http://localhost:3000`
 **Simple (one line):**
 
 ```html
-<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="http://localhost:3000/embed/ozwell-loader.js"></script>
 ```
 
 **Advanced (with config):**
@@ -243,11 +243,17 @@ The server will start at `http://localhost:3000`
 ```html
 <script>
   window.OzwellChatConfig = {
-    endpoint: 'https://ozwellapi.opensource.mieweb.org/v1/chat/completions',
+    endpoint: 'http://localhost:3000/v1/chat/completions',
     welcomeMessage: 'Hi! How can I help?',
     debug: false  // Set to true to see tool execution details (developer mode)
   };
 </script>
+<script src="http://localhost:3000/embed/ozwell-loader.js"></script>
+```
+
+**Hosted/public environment:**
+
+```html
 <script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 

--- a/reference-server/README.md
+++ b/reference-server/README.md
@@ -235,7 +235,7 @@ The server will start at `http://localhost:3000`
 **Simple (one line):**
 
 ```html
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 **Advanced (with config):**
@@ -243,15 +243,15 @@ The server will start at `http://localhost:3000`
 ```html
 <script>
   window.OzwellChatConfig = {
-    endpoint: 'https://ozwellai-reference-server.opensource.mieweb.org/v1/chat/completions',
+    endpoint: 'https://ozwellapi.opensource.mieweb.org/v1/chat/completions',
     welcomeMessage: 'Hi! How can I help?',
     debug: false  // Set to true to see tool execution details (developer mode)
   };
 </script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
-**Live Demo:** <https://ozwellai-embedtest.opensource.mieweb.org>
+**Live Demo:** <https://ozwelldemo.opensource.mieweb.org>
 
 **Watch Demo:** [YouTube Short](https://youtube.com/shorts/mqcoEoQzQMM?si=FLa_dq_4y2TeO_48)
 

--- a/reference-server/embed/README.md
+++ b/reference-server/embed/README.md
@@ -7,7 +7,7 @@ Add an AI chatbot to any website with one script tag.
 Add this to your HTML:
 
 ```html
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 The chat button appears automatically in the bottom-right corner.
@@ -25,7 +25,7 @@ Customize the widget with `window.OzwellChatConfig`:
     system: 'You are a helpful assistant.'
   };
 </script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 ## With Custom UI
@@ -42,7 +42,7 @@ Use your own button and layout by disabling the default floating button:
     containerId: 'my-chat-container'
   };
 </script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 **How it works:** Setting `defaultUI: false` disables the automatic floating button and wrapper. The widget iframe mounts directly in your custom container instead.
@@ -64,7 +64,7 @@ Use the AI to improve text, then get it back with the "Save & Close" button:
     document.getElementById('my-note').value = event.detail.text;
   });
 </script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 **How it works:** User asks AI to improve their text, clicks "Save & Close" in widget, and the AI's response gets inserted into the textarea.
@@ -101,7 +101,7 @@ Send page data to the widget so the AI can answer questions about current state:
     });
   });
 </script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 Now users can ask: "What's my name?" and the AI responds: "Your name is Alice."
@@ -145,7 +145,7 @@ Enable page interactions using MCP tools (OpenAI function calling format). The l
     }
   });
 </script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 Now users can type: "update my email to john@example.com" and the field updates automatically.
@@ -266,7 +266,7 @@ Disable auto-mount and control when/where the widget appears. Useful for:
     autoMount: false
   };
 </script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 
 <script>
   // Mount when user clicks button
@@ -290,7 +290,7 @@ The reference server automatically detects and routes to the best available back
     apiKey: 'agnt_key-your-agent-key'  // or 'ozw_your-parent-key'
   };
 </script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 To use Ollama as the backend, configure the server's `.env` file — set `OLLAMA_BASE_URL` (and optionally `OLLAMA_MODEL`). No client-side changes needed; the widget talks to the reference server and the server handles backend routing. See `../.env.example` for details.
@@ -307,7 +307,7 @@ Use `openaiApiKey` or custom headers for API authentication:
     model: 'gpt-4o'
   };
 </script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 Or use custom headers for any authentication scheme:
@@ -322,7 +322,7 @@ Or use custom headers for any authentication scheme:
     }
   };
 </script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 ## MCP Tool Flow
@@ -509,7 +509,7 @@ Enable debug mode during development to visualize tool executions:
     debug: true  // Shows tool execution details
   };
 </script>
-<script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
+<script src="https://ozwellapi.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
 **How it works:** Clickable tool pills appear before AI responses. Click a pill to expand and see:
@@ -535,8 +535,8 @@ The widget handles all mobile optimizations automatically.
 
 ## Live Demo
 
-- **Demo:** <https://ozwellai-embedtest.opensource.mieweb.org>
-- **Reference Server:** <https://ozwellai-reference-server.opensource.mieweb.org>
+- **Demo:** <https://ozwelldemo.opensource.mieweb.org>
+- **Reference Server:** <https://ozwellapi.opensource.mieweb.org>
 
 ## Local Development
 


### PR DESCRIPTION
## Summary
- update documentation to use the current official public Ozwell environment URLs
- keep beta/development references clearly secondary
- add agent onboarding guidance for the register page flow

## What changed
- updated public API references to `https://ozwellapi.opensource.mieweb.org`
- updated live demo references to `https://ozwelldemo.opensource.mieweb.org`
- updated embed loader examples to use the current public API host
- added agent onboarding guidance pointing users to:
  - `https://ozwelldemo.opensource.mieweb.org/register.html`
  - `horner@mieweb.com`
  - `adamerla128@gmail.com`

## Files changed
- `README.md`
- `reference-server/README.md`
- `docs/overview.md`
- `docs/backend/agents.md`
- `docs/frontend/cdn-embed.md`
- `docs/frontend/overview.md`
