### PR TITLE
ci: retarget deploy workflows to ozwell prod

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -33,7 +33,7 @@ jobs:
           retention-days: 1
 
   deploy:
-    name: Deploy to ozwellai-embedtest
+    name: Deploy to ozwell-prod landing
     needs: build
     runs-on: ubuntu-latest
 
@@ -48,7 +48,7 @@ jobs:
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634
         with:
           host: ${{ secrets.EMBEDTEST_HOST }}
-          port: 2240
+          port: 2061
           username: ${{ secrets.EMBEDTEST_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: landing-page-build.tar.gz
@@ -59,7 +59,7 @@ jobs:
         uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
         with:
           host: ${{ secrets.EMBEDTEST_HOST }}
-          port: 2240
+          port: 2061
           username: ${{ secrets.EMBEDTEST_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
@@ -77,9 +77,9 @@ jobs:
             npm ci --omit=dev
 
             # Restart service with reference server URL
-            pm2 stop embedtest || true
-            pm2 delete embedtest || true
-            REFERENCE_SERVER_URL=https://ozwellai-reference-server.opensource.mieweb.org pm2 start server.js --name embedtest
+            pm2 stop landing || true
+            pm2 delete landing || true
+            REFERENCE_SERVER_URL=https://ozwellapi.opensource.mieweb.org pm2 start server.js --name landing
             pm2 save
 
             # Cleanup

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -47,9 +47,9 @@ jobs:
       - name: Upload to server
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634
         with:
-          host: ${{ secrets.OZWELL_PROD_HOST }}
+          host: ${{ vars.OZWELL_PROD_HOST }}
           port: 2061
-          username: ${{ secrets.OZWELL_PROD_USER }}
+          username: ${{ vars.OZWELL_PROD_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: landing-page-build.tar.gz
           target: /tmp/
@@ -58,9 +58,9 @@ jobs:
       - name: Extract and restart service
         uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
         with:
-          host: ${{ secrets.OZWELL_PROD_HOST }}
+          host: ${{ vars.OZWELL_PROD_HOST }}
           port: 2061
-          username: ${{ secrets.OZWELL_PROD_USER }}
+          username: ${{ vars.OZWELL_PROD_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             set -e

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -47,9 +47,9 @@ jobs:
       - name: Upload to server
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634
         with:
-          host: ${{ secrets.EMBEDTEST_HOST }}
+          host: ${{ secrets.OZWELL_PROD_HOST }}
           port: 2061
-          username: ${{ secrets.EMBEDTEST_USER }}
+          username: ${{ secrets.OZWELL_PROD_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: landing-page-build.tar.gz
           target: /tmp/
@@ -58,9 +58,9 @@ jobs:
       - name: Extract and restart service
         uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
         with:
-          host: ${{ secrets.EMBEDTEST_HOST }}
+          host: ${{ secrets.OZWELL_PROD_HOST }}
           port: 2061
-          username: ${{ secrets.EMBEDTEST_USER }}
+          username: ${{ secrets.OZWELL_PROD_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             set -e
@@ -76,7 +76,7 @@ jobs:
             cd landing-page
             npm ci --omit=dev
 
-            # Restart service with reference server URL
+            # Restart landing service with public reference-server/API base URL
             pm2 stop landing || true
             pm2 delete landing || true
             REFERENCE_SERVER_URL=https://ozwellapi.opensource.mieweb.org pm2 start server.js --name landing

--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -70,9 +70,9 @@ jobs:
       - name: Upload to server
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634
         with:
-          host: ${{ secrets.OZWELL_PROD_HOST }}
+          host: ${{ vars.OZWELL_PROD_HOST }}
           port: 2061
-          username: ${{ secrets.OZWELL_PROD_USER }}
+          username: ${{ vars.OZWELL_PROD_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: reference-server-build.tar.gz
           target: /tmp/
@@ -81,9 +81,9 @@ jobs:
       - name: Extract and restart service
         uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
         with:
-          host: ${{ secrets.OZWELL_PROD_HOST }}
+          host: ${{ vars.OZWELL_PROD_HOST }}
           port: 2061
-          username: ${{ secrets.OZWELL_PROD_USER }}
+          username: ${{ vars.OZWELL_PROD_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             set -e

--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -70,9 +70,9 @@ jobs:
       - name: Upload to server
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634
         with:
-          host: ${{ secrets.REFSERVER_HOST }}
+          host: ${{ secrets.OZWELL_PROD_HOST }}
           port: 2061
-          username: ${{ secrets.REFSERVER_USER }}
+          username: ${{ secrets.OZWELL_PROD_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: reference-server-build.tar.gz
           target: /tmp/
@@ -81,9 +81,9 @@ jobs:
       - name: Extract and restart service
         uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
         with:
-          host: ${{ secrets.REFSERVER_HOST }}
+          host: ${{ secrets.OZWELL_PROD_HOST }}
           port: 2061
-          username: ${{ secrets.REFSERVER_USER }}
+          username: ${{ secrets.OZWELL_PROD_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             set -e

--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -56,7 +56,7 @@ jobs:
           retention-days: 1
 
   deploy:
-    name: Deploy to ozwellai-reference-server
+    name: Deploy to ozwell-prod refserver
     needs: build
     runs-on: ubuntu-latest
 
@@ -71,7 +71,7 @@ jobs:
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634
         with:
           host: ${{ secrets.REFSERVER_HOST }}
-          port: 2241
+          port: 2061
           username: ${{ secrets.REFSERVER_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: reference-server-build.tar.gz
@@ -82,7 +82,7 @@ jobs:
         uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
         with:
           host: ${{ secrets.REFSERVER_HOST }}
-          port: 2241
+          port: 2061
           username: ${{ secrets.REFSERVER_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |


### PR DESCRIPTION
## Summary
- retarget reference-server deploy workflow to the new ozwell-prod SSH target
- retarget demo deploy workflow to the landing PM2 process on ozwell-prod
- update landing deploy runtime API URL to the current public API host

## What changed
- changed deploy SSH port from the old per-container ports to `2061`
- changed deploy job labels to `ozwell-prod refserver` and `ozwell-prod landing`
- changed landing PM2 process management from `embedtest` to `landing`
- changed landing `REFERENCE_SERVER_URL` to `https://ozwellapi.opensource.mieweb.org`

## Verification
- verified `ozwell-prod` has PM2 processes `refserver` and `landing` online
- verified `ozwell-prod` serves refserver on port `3000` and landing on port `8080`
- verified package extraction paths match the current `~/ozwellai-api` layout
- ran deploy workflows locally with `act --pull=false`; build/package steps passed before the known local `ACTIONS_RUNTIME_TOKEN` artifact limitation
- ran `npm test` locally: reference-server `13/13`, TypeScript client `5/5`
