### PR TITLE
fix: align widget tool result flow with OpenAI

### DIFF
--- a/docs/frontend/cdn-embed.md
+++ b/docs/frontend/cdn-embed.md
@@ -172,6 +172,7 @@ sequenceDiagram
     Ozwell->>Page: ozwell-tool-call event
     Page->>Page: Your handler runs (updates the input)
     Page->>Ozwell: respond({ success: true })
+    Ozwell->>Ozwell: Sends tool result back to AI
     Ozwell->>User: "Done! I've updated your name to Bob."
 ```
 
@@ -204,7 +205,7 @@ document.addEventListener('ozwell-tool-call', (e) => {
     if (args.email) document.getElementById('input-email').value = args.email;
 
     // Tell Ozwell what happened
-    respond({ success: true, message: 'Fields updated' });
+    respond({ success: true, updated: { name: args.name, email: args.email } });
 
   } else if (name === 'get_form_data') {
     // Tools can also READ from your page
@@ -286,7 +287,7 @@ The AI can only call tools you've defined. It cannot access your page's DOM, mak
 
 - **Write good tool descriptions.** The AI reads them to decide when to use a tool. "Updates user profile fields on the page" is better than "updates stuff."
 - **Validate arguments.** The AI usually gets the schema right, but treat the incoming `args` like any untrusted input — check types and ranges before acting on them.
-- **Return useful results.** The AI uses `respond()` data to craft its reply. If you return `{ success: true }`, the AI can only say "done." If you return `{ success: true, message: "Name changed from Alice to Bob" }`, the AI can confirm the details.
+- **Return useful results.** The AI uses `respond()` data to craft its reply. If you return `{ success: true }`, the AI can only say "done." If you return `{ success: true, updated: { name: { from: "Alice", to: "Bob" } } }`, the AI can confirm the details.
 - **Use `debug: true` during development.** It shows tool execution pills in the chat UI so you can see what's happening.
 
 For the full postMessage protocol details (useful if you're building a custom integration without the loader), see the [Embed Widget README](https://github.com/mieweb/ozwellai-api/tree/main/reference-server/embed). For the design inspiration behind this architecture, see [MCP postMessage Standard](./mcp-postmessage-standard.md).
@@ -404,7 +405,7 @@ A full working example — an AI assistant that can read and update form fields 
         if (args.name)  document.getElementById('input-name').value = args.name;
         if (args.email) document.getElementById('input-email').value = args.email;
         if (args.zip)   document.getElementById('input-zip').value = args.zip;
-        respond({ success: true, message: 'Profile updated' });
+        respond({ success: true, updated: { name: args.name, email: args.email, zip: args.zip } });
 
       } else {
         respond({ success: false, error: `Unknown tool: ${name}` });

--- a/docs/frontend/cdn-embed.md
+++ b/docs/frontend/cdn-embed.md
@@ -220,7 +220,7 @@ document.addEventListener('ozwell-tool-call', (e) => {
 });
 ```
 
-**You must call `respond()`.** The AI is waiting for the result. If you don't respond, the conversation will hang.
+**You must call `respond()` or `error()`.** The AI is waiting for the result. If you don't respond, the loader returns a tool error after a timeout.
 
 ### Step 3: That's It
 
@@ -267,7 +267,7 @@ If you're using a parent API key (`ozw_...`) instead of an agent key, you can de
 <script src="https://ozwell-dev-refserver.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
-You still handle `ozwell-tool-call` the same way — the event listener code doesn't change.
+`tools[].function` is the OpenAI-style tool schema: name, description, and JSON-schema parameters. Do not put executable JavaScript functions there. You still handle actual execution with `ozwell-tool-call` — the event listener code doesn't change.
 
 ### Security: What Crosses the Iframe Boundary
 

--- a/landing-page/public/tictactoe-app.js
+++ b/landing-page/public/tictactoe-app.js
@@ -523,9 +523,21 @@ function handleMakeMove(position, respond) {
     return;
   }
 
-  const index = typeof position === 'number' ? position : parseInt(position);
-  if (isNaN(index) || index < 0 || index > 8) {
-    respond({ success: false, error: `Invalid position: ${position}. Must be 0-8.` });
+  let index;
+  let positionName;
+  if (typeof position === 'number' || (typeof position === 'string' && /^\d+$/.test(position.trim()))) {
+    index = typeof position === 'number' ? position : parseInt(position, 10);
+    positionName = indexToPosition[index];
+  } else {
+    positionName = normalizePosition(position);
+    index = positionName ? positionMap[positionName] : NaN;
+  }
+
+  if (isNaN(index) || index < 0 || index > 8 || !positionName) {
+    respond({
+      success: false,
+      error: `Invalid position: ${position}. Use a board index 0-8 or a position like center, top-left, or bottom-right.`
+    });
     return;
   }
 
@@ -548,16 +560,19 @@ function handleMakeMove(position, respond) {
   }
 
   // Place piece and check for winner
-  const positionName = indexToPosition[index];
   const gameEnded = placePieceAndCheckWin(index, positionName);
 
-  // Return success message (NOT raw data) so widget doesn't auto-continue
-  respond({ success: true, message: `Placed X at ${positionName}.` });
-
-  // If game continues and it's now O's turn, trigger AI the same way as clicks
-  if (!gameEnded && currentPlayer === 'O') {
-    sendUserMessageToWidget(`I placed X at ${positionName}. Your turn.`);
-  }
+  respond({
+    success: true,
+    move: index,
+    position: positionName,
+    message: `Placed X at ${positionName}.`,
+    board: boardState.map((v, i) => v || i),
+    gameOver: gameOver,
+    winner: winner,
+    nextPlayer: currentPlayer,
+    shouldCallAiMove: !gameEnded && currentPlayer === 'O'
+  });
 }
 
 function handleResetGame() {
@@ -608,7 +623,14 @@ document.addEventListener('ozwell-tool-call', (e) => {
     handleAiMove(respond);
   } else if (name === 'reset_game') {
     handleResetGame();
-    respond({ success: true, message: 'Game reset successfully' });
+    respond({
+      success: true,
+      message: 'Game reset successfully',
+      board: boardState.map((v, i) => v || i),
+      currentPlayer: currentPlayer,
+      gameOver: gameOver,
+      winner: winner
+    });
   }
 });
 

--- a/landing-page/tests/landing.spec.ts
+++ b/landing-page/tests/landing.spec.ts
@@ -281,6 +281,28 @@ test.describe('Tic-Tac-Toe Demo', () => {
     const iframe = page.frameLocator('#ozwell-chat-container iframe');
     await expect(iframe.locator('#chat-input')).toBeVisible({ timeout: 10000 });
 
+    await page.evaluate(() => {
+      (window as any).OzwellChat.configure({
+        apiKey: 'ozw_playwright_test',
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'make_move',
+              description: 'Place the player move on the board',
+              parameters: {
+                type: 'object',
+                properties: {
+                  position: { type: 'string' },
+                },
+                required: ['position'],
+              },
+            },
+          },
+        ],
+      });
+    });
+
     await iframe.locator('#chat-input').fill('play center');
     await iframe.locator('#chat-input').press('Enter');
 

--- a/landing-page/tests/landing.spec.ts
+++ b/landing-page/tests/landing.spec.ts
@@ -214,6 +214,33 @@ test.describe('Tic-Tac-Toe Demo', () => {
     // Verify the difficulty selector is present
     await expect(page.locator('#difficulty')).toBeVisible();
   });
+
+  test('make_move tool accepts natural language positions and returns continuation data', async ({ page }) => {
+    await page.goto('/tictactoe.html');
+    await expect(page.locator('#board')).toBeVisible({ timeout: 5000 });
+
+    const result = await page.evaluate(() => {
+      return new Promise((resolve) => {
+        document.dispatchEvent(new CustomEvent('ozwell-tool-call', {
+          detail: {
+            name: 'make_move',
+            arguments: { position: 'center' },
+            respond: resolve,
+            error: (message: string) => resolve({ success: false, error: message }),
+          },
+        }));
+      });
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      move: 4,
+      position: 'middle-center',
+      nextPlayer: 'O',
+      shouldCallAiMove: true,
+    });
+    await expect(page.locator('.cell').nth(4)).toHaveText('X');
+  });
 });
 
 test.describe('Console Errors', () => {

--- a/landing-page/tests/landing.spec.ts
+++ b/landing-page/tests/landing.spec.ts
@@ -241,6 +241,70 @@ test.describe('Tic-Tac-Toe Demo', () => {
     });
     await expect(page.locator('.cell').nth(4)).toHaveText('X');
   });
+
+  test('typed make_move continues with matching OpenAI tool result message', async ({ page }) => {
+    const chatRequests: any[] = [];
+
+    await page.route('**/v1/chat/completions', async (route) => {
+      const requestBody = route.request().postDataJSON();
+      chatRequests.push(requestBody);
+
+      if (chatRequests.length === 1) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/event-stream',
+          body: [
+            'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_center_1","type":"function","function":{"name":"make_move","arguments":"{\\"position\\":\\"center\\"}"}}]}}]}',
+            '',
+            'data: [DONE]',
+            '',
+          ].join('\n'),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: [
+          'data: {"choices":[{"delta":{"content":"Placed X in the center."}}]}',
+          '',
+          'data: [DONE]',
+          '',
+        ].join('\n'),
+      });
+    });
+
+    await page.goto('/tictactoe.html');
+    await expect(page.locator('#board')).toBeVisible({ timeout: 5000 });
+
+    const iframe = page.frameLocator('#ozwell-chat-container iframe');
+    await expect(iframe.locator('#chat-input')).toBeVisible({ timeout: 10000 });
+
+    await iframe.locator('#chat-input').fill('play center');
+    await iframe.locator('#chat-input').press('Enter');
+
+    await expect(page.locator('.cell').nth(4)).toHaveText('X');
+    await expect.poll(() => chatRequests.length, { timeout: 10000 }).toBeGreaterThanOrEqual(2);
+
+    const followUpMessages = chatRequests[1].messages;
+    const assistantToolMessageIndex = followUpMessages.findIndex((message: any) => {
+      return message.role === 'assistant' && message.tool_calls?.[0]?.id === 'call_center_1';
+    });
+    expect(assistantToolMessageIndex).toBeGreaterThanOrEqual(0);
+
+    const toolResultMessage = followUpMessages[assistantToolMessageIndex + 1];
+    expect(toolResultMessage).toMatchObject({
+      role: 'tool',
+      tool_call_id: 'call_center_1',
+    });
+    expect(typeof toolResultMessage.content).toBe('string');
+    expect(JSON.parse(toolResultMessage.content)).toMatchObject({
+      success: true,
+      move: 4,
+      position: 'middle-center',
+    });
+  });
 });
 
 test.describe('Console Errors', () => {

--- a/reference-server/embed/README.md
+++ b/reference-server/embed/README.md
@@ -148,6 +148,8 @@ Enable page interactions using MCP tools (OpenAI function calling format). The l
 <script src="https://ozwellai-reference-server.opensource.mieweb.org/embed/ozwell-loader.js"></script>
 ```
 
+The `tools[].function` object above is a schema only. Actual JavaScript execution stays in your `ozwell-tool-call` event listener.
+
 Now users can type: "update my email to john@example.com" and the field updates automatically.
 
 ## Configuration Options
@@ -401,6 +403,8 @@ document.addEventListener('ozwell-tool-call', (e) => {
 ```
 
 The loader automatically sends the correct JSON-RPC 2.0 response back to the widget. The widget then appends that result as a `tool` message and sends it back to the model, matching OpenAI-style tool continuation.
+
+If the page never calls `respond()` or `error()`, the loader returns a normal tool error after a timeout so one missing handler does not leave the widget waiting forever.
 
 ### Widget → Parent Messages
 

--- a/reference-server/embed/README.md
+++ b/reference-server/embed/README.md
@@ -141,7 +141,7 @@ Enable page interactions using MCP tools (OpenAI function calling format). The l
 
     if (name === 'update_email') {
       document.getElementById('user-email').value = args.email;
-      respond({ success: true, message: 'Email updated successfully' });
+      respond({ success: true, updated: { email: args.email } });
     }
   });
 </script>
@@ -396,11 +396,11 @@ After receiving an `ozwell-tool-call` DOM event, call `respond()` from the event
 document.addEventListener('ozwell-tool-call', (e) => {
   const { name, arguments: args, respond } = e.detail;
   // execute the tool, then:
-  respond({ success: true, message: 'Action completed' });
+  respond({ success: true, result: { action: name, completed: true } });
 });
 ```
 
-The loader automatically sends the correct JSON-RPC 2.0 response back to the widget.
+The loader automatically sends the correct JSON-RPC 2.0 response back to the widget. The widget then appends that result as a `tool` message and sends it back to the model, matching OpenAI-style tool continuation.
 
 ### Widget → Parent Messages
 

--- a/reference-server/embed/ozwell-loader.js
+++ b/reference-server/embed/ozwell-loader.js
@@ -64,6 +64,10 @@
     agentTools: null, // Tools fetched from server via agent key (MCP discovery)
   };
 
+  const EMPTY_SCHEMA = { type: 'object', properties: {} };
+  const PAGE_TOOL_PREFIX = 'postMessage:';
+  const TOOL_RESPONSE_TIMEOUT_MS = 29000;
+
   function readGlobalConfig() {
     const { OzwellChatConfig } = window;
     if (OzwellChatConfig && typeof OzwellChatConfig === 'object') {
@@ -78,6 +82,68 @@
       ...readGlobalConfig(),
       ...state.runtimeConfig,
     };
+  }
+
+  const warnedToolConfigNames = new Set();
+
+  function warnCallableToolFunction(toolName) {
+    const key = toolName || '<unnamed>';
+    if (warnedToolConfigNames.has(key)) return;
+    warnedToolConfigNames.add(key);
+    console.warn(
+      `[OzwellChat] Ignoring callable JavaScript function in tools[].function for "${key}". ` +
+      'OpenAI-style tools[].function must be a schema object. Execute browser tools with the ozwell-tool-call event instead.'
+    );
+  }
+
+  function normalizeTool(tool) {
+    if (typeof tool === 'string') {
+      return { name: tool, description: '', inputSchema: EMPTY_SCHEMA };
+    }
+    if (!tool || typeof tool !== 'object') return null;
+    if (typeof tool.function === 'function') {
+      warnCallableToolFunction(tool.name || tool.function.name);
+      return tool.name ? {
+        name: tool.name,
+        description: tool.description || '',
+        inputSchema: tool.inputSchema || tool.parameters || EMPTY_SCHEMA,
+      } : null;
+    }
+    if (tool.function && typeof tool.function === 'object') {
+      return {
+        name: tool.function.name,
+        description: tool.function.description || '',
+        inputSchema: tool.function.parameters || EMPTY_SCHEMA,
+      };
+    }
+    return tool.name ? {
+      name: tool.name,
+      description: tool.description || '',
+      inputSchema: tool.inputSchema || tool.parameters || EMPTY_SCHEMA,
+    } : null;
+  }
+
+  function toolSchemaForWidget(tool) {
+    const normalized = normalizeTool(tool);
+    if (!normalized) return null;
+    return {
+      type: 'function',
+      function: {
+        name: normalized.name,
+        description: normalized.description,
+        parameters: normalized.inputSchema,
+      },
+    };
+  }
+
+  function sanitizeConfigForWidget(config) {
+    const sanitized = { ...config };
+    if (Array.isArray(config.tools)) {
+      sanitized.tools = config.tools
+        .map(toolSchemaForWidget)
+        .filter(Boolean);
+    }
+    return sanitized;
   }
 
   function ensureIframe(options = {}) {
@@ -151,7 +217,7 @@
     postToWidget({
       type: 'config',
       payload: {
-        config: currentConfig(),
+        config: sanitizeConfigForWidget(currentConfig()),
       },
     });
   }
@@ -166,27 +232,6 @@
     iframeWindow.postMessage(message, '*');
   }
 
-  const EMPTY_SCHEMA = { type: 'object', properties: {} };
-  const PAGE_TOOL_PREFIX = 'postMessage:';
-
-  function normalizeTool(tool) {
-    if (typeof tool === 'string') {
-      return { name: tool, description: '', inputSchema: EMPTY_SCHEMA };
-    }
-    if (tool.function) {
-      return {
-        name: tool.function.name,
-        description: tool.function.description || '',
-        inputSchema: tool.function.parameters || EMPTY_SCHEMA,
-      };
-    }
-    return {
-      name: tool.name,
-      description: tool.description || '',
-      inputSchema: tool.inputSchema || tool.parameters || EMPTY_SCHEMA,
-    };
-  }
-
   /** Add postMessage: prefix to a page tool so it can't collide with server-side tools. */
   function prefixPageTool(tool) {
     return { ...tool, name: PAGE_TOOL_PREFIX + tool.name };
@@ -194,12 +239,15 @@
 
   function getMcpTools() {
     const agentTools = (state.agentTools && state.agentTools.length > 0)
-      ? state.agentTools.map(normalizeTool)
+      ? state.agentTools.map(normalizeTool).filter(Boolean)
       : [];
     // Page tools are prefixed so they occupy a separate namespace from
     // server-implemented tools. The prefix is transparent to page authors —
     // it is stripped before dispatching ozwell-tool-call events.
-    const pageTools = (currentConfig().tools || []).map(normalizeTool).map(prefixPageTool);
+    const pageTools = (currentConfig().tools || [])
+      .map(normalizeTool)
+      .filter(Boolean)
+      .map(prefixPageTool);
 
     // Merge: agent-defined tools first, then page tools that don't collide.
     // If the agent defines no tools, all page tools are available.
@@ -244,6 +292,13 @@
         const rawToolName = data.params?.name;
         const toolArgs = data.params?.arguments || {};
         const requestId = data.id;
+        let settled = false;
+
+        function finishToolCall(message) {
+          if (settled) return;
+          settled = true;
+          postJsonRpc(message);
+        }
 
         // Strip postMessage: prefix so page handlers see the original name
         const toolName = rawToolName && rawToolName.startsWith(PAGE_TOOL_PREFIX)
@@ -256,14 +311,14 @@
             name: toolName,
             arguments: toolArgs,
             respond: (result) => {
-              postJsonRpc({
+              finishToolCall({
                 jsonrpc: '2.0',
                 id: requestId,
                 result: result,
               });
             },
             error: (message) => {
-              postJsonRpc({
+              finishToolCall({
                 jsonrpc: '2.0',
                 id: requestId,
                 error: { code: -32000, message: message },
@@ -272,6 +327,18 @@
           },
         });
         document.dispatchEvent(toolEvent);
+        setTimeout(() => {
+          if (!settled) {
+            finishToolCall({
+              jsonrpc: '2.0',
+              id: requestId,
+              error: {
+                code: -32000,
+                message: `Tool "${toolName}" did not respond. Add an ozwell-tool-call handler and call respond() or error().`,
+              },
+            });
+          }
+        }, TOOL_RESPONSE_TIMEOUT_MS);
         break;
       }
 

--- a/reference-server/embed/ozwell.js
+++ b/reference-server/embed/ozwell.js
@@ -677,6 +677,19 @@ function trackPendingToolCall(id) {
   setTimeout(() => { delete mcpPendingToolCalls[id]; }, MCP_TOOL_TIMEOUT_MS);
 }
 
+function ensureToolCallId(toolCall) {
+  if (toolCall.id == null) {
+    toolCall.id = `ozwell_call_${++mcpRequestId}`;
+  }
+  return toolCall.id;
+}
+
+function serializeToolResult(result) {
+  if (typeof result === 'string') return result;
+  const serialized = JSON.stringify(result);
+  return serialized === undefined ? 'null' : serialized;
+}
+
 // Read OZWELL_CONFIG from window (set by embedding page before widget loads)
 if (typeof window !== 'undefined' && window.OZWELL_CONFIG) {
   const extConf = window.OZWELL_CONFIG;
@@ -1449,9 +1462,11 @@ async function sendMessageNonStreaming(text, tools) {
 
             console.log(`[widget.js] Executing tool '${toolName}' with args:`, args);
 
+            const toolCallId = ensureToolCallId(toolCall);
+
             // Send tool call to parent via MCP tools/call
-            trackPendingToolCall(toolCall.id);
-            mcpSend('tools/call', { name: toolName, arguments: args }, toolCall.id);
+            trackPendingToolCall(toolCallId);
+            mcpSend('tools/call', { name: toolName, arguments: args }, toolCallId);
         }
       }
 
@@ -1779,13 +1794,14 @@ async function sendMessageStreaming(text, tools, _thinkingRetryCount = 0) {
 
         if (toolName) {
             const args = parseToolArgs(toolCall.function.arguments);
+            const toolCallId = ensureToolCallId(toolCall);
 
             console.log(`[widget.js] Executing tool '${toolName}' with args:`, args);
 
             // Track tool execution in debug mode
             if (state.config.debug) {
               state.toolExecutions.push({
-                toolCallId: toolCall.id,
+                toolCallId: toolCallId,
                 toolName: toolName,
                 arguments: args,
                 result: null,
@@ -1798,11 +1814,11 @@ async function sendMessageStreaming(text, tools, _thinkingRetryCount = 0) {
             // In debug mode, pills show the execution instead
 
             // Store tool_call_id for later use in tool message
-            state.activeToolCalls[toolName] = toolCall.id;
+            state.activeToolCalls[toolName] = toolCallId;
 
             // Send tool call to parent via MCP tools/call
-            trackPendingToolCall(toolCall.id);
-            mcpSend('tools/call', { name: toolName, arguments: args }, toolCall.id);
+            trackPendingToolCall(toolCallId);
+            mcpSend('tools/call', { name: toolName, arguments: args }, toolCallId);
         }
       }
 
@@ -1911,25 +1927,23 @@ function handleParentMessage(event) {
     const result = data.error ? { error: data.error.message } : data.result;
     const toolCallId = data.id;
 
-    // Update tool execution result in debug mode
-    if (toolCallId) {
-      updateToolExecutionResult(toolCallId, result);
-    }
-
-    console.log('[widget.js] Sending tool result to LLM');
-
     // Get tool_call_id from parent response (required for OpenAI protocol)
-    if (!toolCallId) {
+    if (toolCallId == null) {
       console.error('[widget.js] tool_call_id missing from parent response - cannot continue conversation');
       addMessage('system', 'Error: Tool result missing ID');
       return;
     }
 
+    // Update tool execution result in debug mode
+    updateToolExecutionResult(toolCallId, result);
+
+    console.log('[widget.js] Sending tool result to LLM');
+
     // Add tool result to conversation history with tool_call_id
     state.messages.push({
       role: 'tool',
       tool_call_id: toolCallId,
-      content: JSON.stringify(result)
+      content: serializeToolResult(result)
     });
 
     // Continue conversation by calling LLM with tool result
@@ -2001,7 +2015,7 @@ notifyReady();
 // runtime via the MCP protocol instead of being passed in config.
 
 function mcpSend(method, params, explicitId) {
-  const id = explicitId !== undefined ? explicitId : ++mcpRequestId;
+  const id = explicitId != null ? explicitId : ++mcpRequestId;
   window.parent.postMessage({
     jsonrpc: '2.0',
     id: id,

--- a/reference-server/embed/ozwell.js
+++ b/reference-server/embed/ozwell.js
@@ -1888,114 +1888,6 @@ async function sendMessageStreaming(text, tools, _thinkingRetryCount = 0) {
   }
 }
 
-async function continueConversationWithToolResult(result) {
-  if (state.sending) return;
-
-  console.log('[widget.js] Continuing conversation with tool result:', result);
-
-  // Add tool result to conversation history
-  const toolResultMessage = {
-    role: 'tool',
-    content: typeof result === 'string' ? result : JSON.stringify(result)
-  };
-  state.messages.push(toolResultMessage);
-
-  setStatus('Processing...', true);
-  state.sending = true;
-  formEl?.classList.add('is-sending');
-
-  // Build MCP tools from parent config (same as sendMessage)
-  let tools = [];
-  if (state.config.tools && Array.isArray(state.config.tools)) {
-    tools = state.config.tools.map(tool => ({
-      type: 'function',
-      function: {
-        name: tool.function.name,
-        description: tool.function.description,
-        parameters: tool.function.parameters
-      }
-    }));
-  }
-
-  // Build system prompt (same as sendMessage - respects custom prompts)
-  const systemPrompt = buildSystemPrompt();
-
-  try {
-    const headers = getRequestHeaders();
-
-    // Build messages for request (OpenAI format: system message in messages array)
-    const requestMessages = buildMessages();
-    if (systemPrompt) {
-      // Add system message at the beginning
-      requestMessages.unshift({ role: 'system', content: systemPrompt });
-    }
-
-    // Build request body (always use OpenAI format)
-    // Only include model if explicitly configured - server chooses default otherwise
-    const requestBody = {
-      messages: requestMessages,
-      tools: tools,
-    };
-    if (state.config.model) {
-      requestBody.model = state.config.model;
-    }
-
-    console.log('[widget.js] Sending tool result to API:', requestBody);
-
-    const response = await fetch(state.config.endpoint || '/v1/chat/completions', {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(requestBody),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error('[widget.js] API error:', errorText);
-      throw new Error(`Request failed with status ${response.status}: ${errorText}`);
-    }
-
-    const payload = await response.json();
-    console.log('[widget.js] API response with tool result:', payload);
-
-    // Handle errors
-    if (payload.error) {
-      throw new Error(payload.error.message || 'Model request failed');
-    }
-
-    // Parse OpenAI response format
-    const choice = payload.choices?.[0];
-    if (!choice) {
-      throw new Error('Invalid response format: missing choices array');
-    }
-
-    const assistantContent = choice.message?.content || '';
-
-    // Add assistant's final response to conversation
-    const assistantMessage = {
-      role: 'assistant',
-      content: assistantContent || '(no response)',
-    };
-    state.messages.push(assistantMessage);
-    addMessage('assistant', assistantContent || '(no response)');
-
-    // Notify parent of assistant response (signal only — no message content)
-    postToParent({
-      source: 'ozwell-chat-widget',
-      type: 'assistant_response',
-      hadToolCalls: false
-    });
-
-    setStatus('', false);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unexpected error';
-    addMessage('system', `Error: ${message}`);
-    setStatus('Error', false);
-  } finally {
-    state.sending = false;
-    formEl?.classList.remove('is-sending');
-  }
-}
-
 function handleSubmit(event) {
   event.preventDefault();
   if (!inputEl) return;
@@ -2024,53 +1916,34 @@ function handleParentMessage(event) {
       updateToolExecutionResult(toolCallId, result);
     }
 
-    // Check if this is an update tool (has success/message) or a get tool (raw data)
-    if (result.success && result.message) {
-      // Update tool - just display the message (no LLM continuation needed)
-      addMessage('assistant', result.message);
+    console.log('[widget.js] Sending tool result to LLM');
 
-      // Notify parent of assistant response (signal only — no message content)
-      postToParent({
-        source: 'ozwell-chat-widget',
-        type: 'assistant_response',
-        hadToolCalls: false
-      });
-
-      // After displaying the tool result message, send any queued user message (if present)
-      if (state.queuedMessage) {
-        sendQueuedMessage();
-      }
-    } else {
-      // No display message — send tool result back to LLM for continuation
-      console.log('[widget.js] Sending tool result to LLM');
-
-      // Get tool_call_id from parent response (required for OpenAI protocol)
-      if (!toolCallId) {
-        console.error('[widget.js] tool_call_id missing from parent response - cannot continue conversation');
-        addMessage('system', 'Error: Tool result missing ID');
-        return;
-      }
-
-      // Add tool result to conversation history with tool_call_id
-      state.messages.push({
-        role: 'tool',
-        tool_call_id: toolCallId,
-        content: JSON.stringify(result)
-      });
-
-      // Continue conversation by calling LLM with tool result
-      const tools = state.config.tools?.map(tool => ({
-        type: 'function',
-        function: {
-          name: tool.function.name,
-          description: tool.function.description,
-          parameters: tool.function.parameters
-        }
-      })) || [];
-
-      // Send empty user message - we're just continuing the conversation with tool result
-      sendMessageStreaming('', tools);
+    // Get tool_call_id from parent response (required for OpenAI protocol)
+    if (!toolCallId) {
+      console.error('[widget.js] tool_call_id missing from parent response - cannot continue conversation');
+      addMessage('system', 'Error: Tool result missing ID');
+      return;
     }
+
+    // Add tool result to conversation history with tool_call_id
+    state.messages.push({
+      role: 'tool',
+      tool_call_id: toolCallId,
+      content: JSON.stringify(result)
+    });
+
+    // Continue conversation by calling LLM with tool result
+    const tools = state.config.tools?.map(tool => ({
+      type: 'function',
+      function: {
+        name: tool.function.name,
+        description: tool.function.description,
+        parameters: tool.function.parameters
+      }
+    })) || [];
+
+    // Send empty user message - we're just continuing the conversation with tool result
+    sendMessageStreaming('', tools);
 
     return;
   }

--- a/reference-server/test/widget-tool-flow.test.js
+++ b/reference-server/test/widget-tool-flow.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+const WIDGET_PATH = new URL('../embed/ozwell.js', import.meta.url);
+
+async function readWidgetSource() {
+  return readFile(WIDGET_PATH, 'utf8');
+}
+
+test('widget tool results do not use success+message as a direct response shortcut', async () => {
+  const source = await readWidgetSource();
+
+  assert.equal(
+    source.includes('result.success && result.message'),
+    false,
+    'success+message must remain ordinary tool output and continue through the model'
+  );
+  assert.equal(
+    source.includes("addMessage('assistant', result.message)"),
+    false,
+    'tool result messages must not be displayed directly by the widget'
+  );
+});
+
+test('widget tool results are sent back with the matching OpenAI tool_call_id', async () => {
+  const source = await readWidgetSource();
+
+  assert.match(source, /const toolCallId = data\.id;/);
+  assert.match(source, /role:\s*'tool'/);
+  assert.match(source, /tool_call_id:\s*toolCallId/);
+  assert.match(source, /content:\s*JSON\.stringify\(result\)/);
+  assert.match(source, /sendMessageStreaming\('', tools\)/);
+});

--- a/reference-server/test/widget-tool-flow.test.js
+++ b/reference-server/test/widget-tool-flow.test.js
@@ -3,9 +3,14 @@ import { readFile } from 'node:fs/promises';
 import { test } from 'node:test';
 
 const WIDGET_PATH = new URL('../embed/ozwell.js', import.meta.url);
+const LOADER_PATH = new URL('../embed/ozwell-loader.js', import.meta.url);
 
 async function readWidgetSource() {
   return readFile(WIDGET_PATH, 'utf8');
+}
+
+async function readLoaderSource() {
+  return readFile(LOADER_PATH, 'utf8');
 }
 
 test('widget tool results do not use success+message as a direct response shortcut', async () => {
@@ -29,6 +34,43 @@ test('widget tool results are sent back with the matching OpenAI tool_call_id', 
   assert.match(source, /const toolCallId = data\.id;/);
   assert.match(source, /role:\s*'tool'/);
   assert.match(source, /tool_call_id:\s*toolCallId/);
-  assert.match(source, /content:\s*JSON\.stringify\(result\)/);
+  assert.match(source, /content:\s*serializeToolResult\(result\)/);
   assert.match(source, /sendMessageStreaming\('', tools\)/);
+});
+
+test('widget accepts falsy JSON-RPC ids and always serializes tool result content as a string', async () => {
+  const source = await readWidgetSource();
+
+  assert.match(source, /if \(toolCallId == null\)/);
+  assert.doesNotMatch(source, /if \(!toolCallId\)/);
+  assert.match(source, /function serializeToolResult\(result\)/);
+  assert.match(source, /return serialized === undefined \? 'null' : serialized;/);
+});
+
+test('loader strips callable tool functions before sending config through postMessage', async () => {
+  const source = await readLoaderSource();
+
+  assert.match(source, /function sanitizeConfigForWidget\(config\)/);
+  assert.match(source, /typeof tool\.function === 'function'/);
+  assert.match(source, /Ignoring callable JavaScript function in tools\[\]\.function/);
+  assert.match(source, /config: sanitizeConfigForWidget\(currentConfig\(\)\)/);
+  assert.match(source, /\.map\(toolSchemaForWidget\)/);
+});
+
+test('loader preserves OpenAI-style function schema while keeping execution in ozwell-tool-call', async () => {
+  const source = await readLoaderSource();
+
+  assert.match(source, /tool\.function && typeof tool\.function === 'object'/);
+  assert.match(source, /name: tool\.function\.name/);
+  assert.match(source, /parameters: normalized\.inputSchema/);
+  assert.match(source, /document\.dispatchEvent\(toolEvent\)/);
+});
+
+test('loader returns a tool error if the page handler never responds', async () => {
+  const source = await readLoaderSource();
+
+  assert.match(source, /const TOOL_RESPONSE_TIMEOUT_MS = 29000/);
+  assert.match(source, /function finishToolCall\(message\)/);
+  assert.match(source, /Tool "\$\{toolName\}" did not respond/);
+  assert.match(source, /call respond\(\) or error\(\)/);
 });


### PR DESCRIPTION
**TL;DR:** Removes a non-standard widget shortcut so MCP tool results always flow back to the model as `role: "tool"` messages, matching the OpenAI tool-calling spec. Fixes typed-move tic-tac-toe (400 / thinking-only loop).

Fixes #126.

## Summary

The widget had a shortcut: if a tool returned `{ success: true, message }`, it rendered the message and skipped appending a `role: "tool"` result. That violates the OpenAI standard — assistant messages with `tool_calls` require a matching `role: "tool"` before the next turn.

Tic-tac-toe `make_move` returned exactly that shape, so typed moves produced malformed history and the next request 400'd on OpenAI / went thinking-only on Ollama. Click flow worked because clicks never invoked `make_move`.

After this PR, every tool result appends as `{ role: "tool", tool_call_id, content: JSON.stringify(result) }` and the model turn continues normally.