### PR TITLE
fix: remove widget tool prompt for agent keys

### DIFF
--- a/reference-server/embed/ozwell.js
+++ b/reference-server/embed/ozwell.js
@@ -1003,32 +1003,26 @@ function buildMessages() {
   return state.messages.map(({ thinking, ...rest }) => rest);
 }
 
+const DEFAULT_PARENT_SYSTEM_PROMPT = 'You are a helpful assistant. Answer clearly and concisely.';
+const DEFAULT_PARENT_TOOL_HINT = 'Use the available tools when they are helpful for answering the user or performing a requested action.';
+
+function isAgentKeyConfigured() {
+  return getAuthKey().startsWith('agnt_key-');
+}
+
 function buildSystemPrompt() {
-  // Start with custom system prompt from parent config
-  let systemPrompt = state.config.system || 'You are a helpful assistant.';
-
-  // Add generic tool usage guidance if tools are available
-  if (state.config.tools && state.config.tools.length > 0) {
-    systemPrompt += `\n\n=== TOOL USAGE GUIDELINES ===
-
-You have access to tools. Use them wisely:
-
-**Default behavior:** Respond naturally with conversation. Only use tools when truly necessary.
-
-**Do NOT use tools for:**
-- Simple greetings, pleasantries, or casual conversation
-- Questions you can answer from information already provided in the context above
-- General knowledge questions within your training
-- Clarifications or follow-up conversation
-
-**DO use tools when:**
-- User explicitly requests current/live data that isn't in the context above
-- User asks you to perform an action (update, change, modify, set, etc.)
-- You genuinely need information not available in the current context
-
-**After calling a tool:** Use the result to answer the user's question. Do not call the same tool repeatedly.`;
+  if (isAgentKeyConfigured()) {
+    return '';
   }
 
+  if (state.config.system) {
+    return state.config.system;
+  }
+
+  let systemPrompt = DEFAULT_PARENT_SYSTEM_PROMPT;
+  if (state.config.tools && state.config.tools.length > 0) {
+    systemPrompt += ` ${DEFAULT_PARENT_TOOL_HINT}`;
+  }
   return systemPrompt;
 }
 

--- a/reference-server/test/widget-system-prompt.test.js
+++ b/reference-server/test/widget-system-prompt.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+const WIDGET_PATH = new URL('../embed/ozwell.js', import.meta.url);
+
+async function readWidgetSource() {
+  return readFile(WIDGET_PATH, 'utf8');
+}
+
+test('agent-key widgets do not add a client-side system prompt', async () => {
+  const source = await readWidgetSource();
+
+  assert.match(source, /function isAgentKeyConfigured\(\)/);
+  assert.match(source, /getAuthKey\(\)\.startsWith\('agnt_key-'\)/);
+  assert.match(source, /if \(isAgentKeyConfigured\(\)\) {\s*return '';\s*}/);
+});
+
+test('widget default prompt does not discourage tool use', async () => {
+  const source = await readWidgetSource();
+
+  assert.doesNotMatch(source, /=== TOOL USAGE GUIDELINES ===/);
+  assert.doesNotMatch(source, /Do NOT use tools/);
+  assert.doesNotMatch(source, /Only use tools when truly necessary/);
+});
+
+test('parent-key widgets keep a small neutral default prompt and tool hint', async () => {
+  const source = await readWidgetSource();
+
+  assert.match(source, /const DEFAULT_PARENT_SYSTEM_PROMPT = 'You are a helpful assistant\. Answer clearly and concisely\.';/);
+  assert.match(source, /const DEFAULT_PARENT_TOOL_HINT = 'Use the available tools when they are helpful for answering the user or performing a requested action\.';/);
+  assert.match(source, /let systemPrompt = DEFAULT_PARENT_SYSTEM_PROMPT;/);
+  assert.match(source, /systemPrompt \+= ` \$\{DEFAULT_PARENT_TOOL_HINT\}`;/);
+});
+
+test('parent-key custom system prompt is preserved without widget tool rules', async () => {
+  const source = await readWidgetSource();
+  const promptFunction = source.match(/function buildSystemPrompt\(\) {[\s\S]*?\n}\n\n\/\*\* Get configured auth key/)[0];
+
+  assert.match(promptFunction, /if \(state\.config\.system\) {\s*return state\.config\.system;\s*}/);
+  assert.ok(
+    promptFunction.indexOf('return state.config.system;') < promptFunction.indexOf('let systemPrompt = DEFAULT_PARENT_SYSTEM_PROMPT;'),
+    'custom system prompt should return before default prompt or tool hint is appended'
+  );
+});

--- a/reference-server/test/widget-system-prompt.test.js
+++ b/reference-server/test/widget-system-prompt.test.js
@@ -35,7 +35,9 @@ test('parent-key widgets keep a small neutral default prompt and tool hint', asy
 
 test('parent-key custom system prompt is preserved without widget tool rules', async () => {
   const source = await readWidgetSource();
-  const promptFunction = source.match(/function buildSystemPrompt\(\) {[\s\S]*?\n}\n\n\/\*\* Get configured auth key/)[0];
+  const promptFunctionMatch = source.match(/function buildSystemPrompt\(\) {[\s\S]*?\n}\n\n\/\*\* Get configured auth key/);
+  assert.ok(promptFunctionMatch, 'could not extract buildSystemPrompt function body');
+  const promptFunction = promptFunctionMatch[0];
 
   assert.match(promptFunction, /if \(state\.config\.system\) {\s*return state\.config\.system;\s*}/);
   assert.ok(


### PR DESCRIPTION
## Summary
- stop agent-key widgets from adding a client-side default system prompt
- replace the parent-key widget default with a small neutral prompt
- keep parent-key custom system prompts unchanged
- add regression coverage for the widget prompt behavior

Closes #85

## Testing
- git diff --check
- node --test test/widget-system-prompt.test.js from reference-server
- npm test
- npm run build --workspaces --if-present
- ./scripts/start.sh smoke checks
- act -W .github/workflows/reference-server-ci.yml -j test --matrix os:ubuntu-latest --matrix node-version:22
- act -W .github/workflows/landing-page-e2e.yml -j e2e-tests
- act -W .github/workflows/typescript-client-ci.yml -j test --matrix os:ubuntu-latest --matrix node-version:22