### PR TITLE
fix: remove iframe-sync leftovers

### DIFF
--- a/docs/frontend/cdn-embed.md
+++ b/docs/frontend/cdn-embed.md
@@ -110,14 +110,33 @@ OzwellChat.close();
 // OzwellChat.toggle();
 ```
 
-### Update Context
+### Read Page Data With Tools
 
 ```javascript
-// Set context data (passed to the agent)
-OzwellChat.updateContext({
-  userId: 'user_123',
-  page: window.location.pathname,
-  customData: { ... }
+window.OzwellChatConfig = {
+  tools: [
+    {
+      type: 'function',
+      function: {
+        name: 'get_page_data',
+        description: 'Read current page data',
+        parameters: {
+          type: 'object',
+          properties: {}
+        }
+      }
+    }
+  ]
+};
+
+document.addEventListener('ozwell-tool-call', (event) => {
+  const { name, respond } = event.detail;
+  if (name !== 'get_page_data') return;
+
+  respond({
+    userId: 'user_123',
+    page: window.location.pathname
+  });
 });
 
 // Send a message as the user (coming soon)

--- a/docs/frontend/cdn-embed.md
+++ b/docs/frontend/cdn-embed.md
@@ -114,6 +114,7 @@ OzwellChat.close();
 
 ```javascript
 window.OzwellChatConfig = {
+  ...window.OzwellChatConfig,
   tools: [
     {
       type: 'function',

--- a/landing-page/package-lock.json
+++ b/landing-page/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "dotenv": "^17.2.3",
-        "express": "^4.22.1",
-        "iframe-sync": "^1.0.4"
+        "express": "^4.22.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
@@ -970,12 +969,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/iframe-sync": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/iframe-sync/-/iframe-sync-1.0.4.tgz",
-      "integrity": "sha512-JOBbfXPUAVEdKj2sawmJf+xV9wy4B67f98V7CTt4qAN3gLzNXOFse83H74eYhnAvjYm1sRIniUdzZcLFqi1IBg==",
-      "license": "ISC"
     },
     "node_modules/inherits": {
       "version": "2.0.4",

--- a/landing-page/package.json
+++ b/landing-page/package.json
@@ -14,8 +14,7 @@
   },
   "dependencies": {
     "dotenv": "^17.2.3",
-    "express": "^4.22.1",
-    "iframe-sync": "^1.0.4"
+    "express": "^4.22.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",

--- a/landing-page/playwright.config.ts
+++ b/landing-page/playwright.config.ts
@@ -7,7 +7,7 @@ import { defineConfig, devices } from '@playwright/test';
  * - Widget loading and initialization
  * - Chat interactions with the AI
  * - Tool calls (update_form_data)
- * - iframe-sync state synchronization
+ * - postMessage tool-call flow
  */
 export default defineConfig({
   testDir: './tests',

--- a/landing-page/public/demo.css
+++ b/landing-page/public/demo.css
@@ -687,10 +687,6 @@ body {
   color: #1a1a1a;
 }
 
-.event-type.iframe-sync {
-  color: #1a1a1a;
-}
-
 .event-type.postmessage {
   color: #1a1a1a;
 }

--- a/landing-page/tests/landing.spec.ts
+++ b/landing-page/tests/landing.spec.ts
@@ -7,7 +7,7 @@ import { test, expect, type Page, type FrameLocator } from '@playwright/test';
  * - Widget loading and auto-detection
  * - Chat interactions with AI
  * - Tool calls (update_form_data)
- * - State synchronization via iframe-sync
+ * - State synchronization via postMessage tool calls
  */
 
 test.describe('Ozwell Embed Widget', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,8 +84,7 @@
       "extraneous": true,
       "dependencies": {
         "dotenv": "^17.2.3",
-        "express": "^4.22.1",
-        "iframe-sync": "^1.0.4"
+        "express": "^4.22.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
@@ -12551,12 +12550,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/iframe-sync": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/iframe-sync/-/iframe-sync-1.0.4.tgz",
-      "integrity": "sha512-JOBbfXPUAVEdKj2sawmJf+xV9wy4B67f98V7CTt4qAN3gLzNXOFse83H74eYhnAvjYm1sRIniUdzZcLFqi1IBg==",
-      "license": "ISC"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -22674,7 +22667,6 @@
         "dotenv": "^17.2.3",
         "fastify": "^4.24.3",
         "fastify-zod": "^1.4.0",
-        "iframe-sync": "^1.0.4",
         "node-fetch": "^3.3.2",
         "openai": "^5.12.2",
         "ozwellai": "file:../clients/typescript",

--- a/reference-server/embed/README.md
+++ b/reference-server/embed/README.md
@@ -71,33 +71,38 @@ Use the AI to improve text, then get it back with the "Save & Close" button:
 
 **Use cases:** Draft emails, improve notes, generate summaries, rewrite content - anytime you want AI help but don't need MCP tools.
 
-## Providing Page Context
+## Reading Page Context With Tools
 
-Send page data to the widget so the AI can answer questions about current state:
+Expose current page data as a tool so the AI can request it when needed:
 
 ```html
 <input id="user-name" value="Alice">
 <input id="user-email" value="alice@example.com">
 
 <script>
-  window.OzwellChatConfig = {};
-
-  // Send context when inputs change
-  function updateContext() {
-    OzwellChat.updateContext({
-      formData: {
-        name: document.getElementById('user-name').value,
-        email: document.getElementById('user-email').value
+  window.OzwellChatConfig = {
+    tools: [
+      {
+        type: 'function',
+        function: {
+          name: 'get_form_data',
+          description: 'Read the current form values',
+          parameters: {
+            type: 'object',
+            properties: {}
+          }
+        }
       }
-    });
-  }
+    ]
+  };
 
-  // Wait for widget to load, then send initial context and listen for changes
-  document.addEventListener('DOMContentLoaded', () => {
-    OzwellChat.ready().then(() => {
-      updateContext();
-      document.getElementById('user-name').addEventListener('input', updateContext);
-      document.getElementById('user-email').addEventListener('input', updateContext);
+  document.addEventListener('ozwell-tool-call', (event) => {
+    const { name, respond } = event.detail;
+    if (name !== 'get_form_data') return;
+
+    respond({
+      name: document.getElementById('user-name').value,
+      email: document.getElementById('user-email').value
     });
   });
 </script>
@@ -106,7 +111,7 @@ Send page data to the widget so the AI can answer questions about current state:
 
 Now users can ask: "What's my name?" and the AI responds: "Your name is Alice."
 
-**How it works:** Context is included in the system prompt for every message, so the AI always sees current page state.
+**How it works:** The tool schema tells the AI what page data it can request. When the AI calls the tool, the page responds with the current values through the `ozwell-tool-call` event.
 
 ## With MCP Tools
 

--- a/reference-server/embed/README.md
+++ b/reference-server/embed/README.md
@@ -81,6 +81,7 @@ Expose current page data as a tool so the AI can request it when needed:
 
 <script>
   window.OzwellChatConfig = {
+    ...window.OzwellChatConfig,
     tools: [
       {
         type: 'function',
@@ -122,6 +123,7 @@ Enable page interactions using MCP tools (OpenAI function calling format). The l
 
 <script>
   window.OzwellChatConfig = {
+    ...window.OzwellChatConfig,
     tools: [
       {
         type: 'function',

--- a/reference-server/package-lock.json
+++ b/reference-server/package-lock.json
@@ -20,7 +20,6 @@
         "dotenv": "^17.2.3",
         "fastify": "^4.24.3",
         "fastify-zod": "^1.4.0",
-        "iframe-sync": "^1.0.4",
         "node-fetch": "^3.3.2",
         "openai": "^5.12.2",
         "ozwellai": "file:../clients/typescript",
@@ -2500,12 +2499,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/iframe-sync": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/iframe-sync/-/iframe-sync-1.0.4.tgz",
-      "integrity": "sha512-JOBbfXPUAVEdKj2sawmJf+xV9wy4B67f98V7CTt4qAN3gLzNXOFse83H74eYhnAvjYm1sRIniUdzZcLFqi1IBg==",
-      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/reference-server/package.json
+++ b/reference-server/package.json
@@ -26,7 +26,6 @@
     "dotenv": "^17.2.3",
     "fastify": "^4.24.3",
     "fastify-zod": "^1.4.0",
-    "iframe-sync": "^1.0.4",
     "node-fetch": "^3.3.2",
     "openai": "^5.12.2",
     "ozwellai": "file:../clients/typescript",


### PR DESCRIPTION
## Summary
- remove the unused iframe-sync dependency from landing-page and reference-server package metadata
- replace stale iframe-sync comments with the current postMessage/tool-call wording
- update embed docs to teach ozwell-tool-call instead of OzwellChat.updateContext

Closes #80

## Testing
- rg -n "iframe-sync|IframeSync|updateContext|state\.broker|state\.formData|OzwellChat\.updateContext" . --glob '!node_modules/**' --glob '!**/dist/**' --glob '!**/.git/**'
- git diff --check
- npm test
- npm run build --workspaces --if-present
- npm test from landing-page
- act -W .github/workflows/reference-server-ci.yml -j test --matrix os:ubuntu-latest --matrix node-version:22
- act -W .github/workflows/landing-page-e2e.yml -j e2e-tests