### PR TITLE
feat: add audio transcription endpoint POST /v1/audio/transcriptions

### DIFF
--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -143,6 +143,29 @@ const models = await client.listModels();
 console.log(models.data);
 ```
 
+### Audio Transcription
+
+```typescript
+// Transcribe an audio file
+const transcription = await client.createTranscription({
+  file: new File([audioBuffer], 'audio.mp3', { type: 'audio/mpeg' }),
+  model: 'whisper-1',
+});
+
+console.log(transcription.text);
+
+// With options
+const detailed = await client.createTranscription({
+  file: new File([audioBuffer], 'audio.mp3', { type: 'audio/mpeg' }),
+  model: 'whisper-1',
+  response_format: 'verbose_json',
+  language: 'en',
+  timestamp_granularities: ['word', 'segment'],
+});
+
+console.log('Duration:', detailed.duration);
+```
+
 ### Ozwell-Specific Features
 
 ```typescript
@@ -160,6 +183,8 @@ This package is written in TypeScript and includes full type definitions. All AP
 
 ```typescript
 import type {
+  AudioTranscriptionRequest,
+  AudioTranscriptionResponse,
   ChatCompletionRequest,
   ChatCompletionResponse,
   EmbeddingRequest,

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -295,10 +295,18 @@ export class OzwellAI {
   /**
    * Create an audio transcription.
    * Transcribes audio into text using the specified model (e.g., whisper-1).
+   *
+   * Returns `string` for text/srt/vtt formats, `AudioTranscriptionResponse` for json/verbose_json.
    */
   async createTranscription(
+    request: AudioTranscriptionRequest & { response_format: 'text' | 'srt' | 'vtt' }
+  ): Promise<string>;
+  async createTranscription(
+    request: AudioTranscriptionRequest & { response_format?: 'json' | 'verbose_json' }
+  ): Promise<AudioTranscriptionResponse>;
+  async createTranscription(
     request: AudioTranscriptionRequest
-  ): Promise<AudioTranscriptionResponse> {
+  ): Promise<AudioTranscriptionResponse | string> {
     const formData = new FormData();
     formData.append('file', request.file);
     formData.append('model', request.model);
@@ -315,7 +323,7 @@ export class OzwellAI {
       ? 'text'
       : 'json';
 
-    return this.makeRequest<AudioTranscriptionResponse>('/v1/audio/transcriptions', {
+    return this.makeRequest<AudioTranscriptionResponse | string>('/v1/audio/transcriptions', {
       method: 'POST',
       body: formData,
     }, responseType);

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -9,6 +9,8 @@ import type {
   FileListResponse,
   ResponseRequest,
   Response,
+  AudioTranscriptionRequest,
+  AudioTranscriptionResponse,
 } from './types.ts';
 
 /**
@@ -283,6 +285,34 @@ export class OzwellAI {
       body: JSON.stringify(request),
     });
   }
+
+  /**
+   * Create an audio transcription.
+   * Transcribes audio into text using the specified model (e.g., whisper-1).
+   */
+  async createTranscription(
+    request: AudioTranscriptionRequest
+  ): Promise<AudioTranscriptionResponse> {
+    const formData = new FormData();
+    formData.append('file', request.file);
+    formData.append('model', request.model);
+    if (request.response_format) formData.append('response_format', request.response_format);
+    if (request.language) formData.append('language', request.language);
+    if (request.temperature !== undefined) formData.append('temperature', String(request.temperature));
+    if (request.timestamp_granularities) {
+      for (const g of request.timestamp_granularities) {
+        formData.append('timestamp_granularities[]', g);
+      }
+    }
+
+    return this.makeRequest<AudioTranscriptionResponse>('/v1/audio/transcriptions', {
+      method: 'POST',
+      body: formData,
+      headers: {
+        ...(this.apiKey ? { 'Authorization': `Bearer ${this.apiKey}` } : {}),
+      },
+    });
+  }
 }
 
 export default OzwellAI;
@@ -299,4 +329,6 @@ export type {
   FileListResponse,
   ResponseRequest,
   Response,
+  AudioTranscriptionRequest,
+  AudioTranscriptionResponse,
 } from './types.ts';

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -85,19 +85,26 @@ export class OzwellAI {
 
   private async makeRequest<T>(
     endpoint: string,
-    options: RequestInit = {}
+    options: RequestInit = {},
+    responseType: 'json' | 'text' = 'json'
   ): Promise<T> {
     const url = `${this.baseURL}${endpoint}`;
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this.timeout);
 
     try {
+      const headers: Record<string, string> = {
+        ...this.defaultHeaders,
+        ...options.headers as Record<string, string>,
+      };
+      // Let fetch set Content-Type with the multipart boundary
+      if (options.body instanceof FormData) {
+        delete headers['Content-Type'];
+      }
+
       const response = await fetch(url, {
         ...options,
-        headers: {
-          ...this.defaultHeaders,
-          ...options.headers,
-        },
+        headers,
         signal: controller.signal,
       });
 
@@ -107,6 +114,9 @@ export class OzwellAI {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
+      if (responseType === 'text') {
+        return await response.text() as T;
+      }
       return await response.json();
     } catch (error) {
       clearTimeout(timeoutId);
@@ -246,10 +256,6 @@ export class OzwellAI {
     return this.makeRequest<FileObject>('/v1/files', {
       method: 'POST',
       body: formData,
-      headers: {
-        ...(this.apiKey ? { 'Authorization': `Bearer ${this.apiKey}` } : {}),
-        // Don't set Content-Type, let browser set it with boundary for FormData
-      },
     });
   }
 
@@ -301,17 +307,18 @@ export class OzwellAI {
     if (request.temperature !== undefined) formData.append('temperature', String(request.temperature));
     if (request.timestamp_granularities) {
       for (const g of request.timestamp_granularities) {
-        formData.append('timestamp_granularities[]', g);
+        formData.append('timestamp_granularities', g);
       }
     }
+
+    const responseType = request.response_format && ['text', 'srt', 'vtt'].includes(request.response_format)
+      ? 'text'
+      : 'json';
 
     return this.makeRequest<AudioTranscriptionResponse>('/v1/audio/transcriptions', {
       method: 'POST',
       body: formData,
-      headers: {
-        ...(this.apiKey ? { 'Authorization': `Bearer ${this.apiKey}` } : {}),
-      },
-    });
+    }, responseType);
   }
 }
 

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -284,3 +284,56 @@ export interface ChatCompletionChunk {
     finish_reason: 'stop' | 'length' | 'function_call' | 'tool_calls' | 'content_filter' | null;
   }>;
 }
+
+/**
+ * Request object for audio transcription API calls.
+ * Transcribes audio into text using a specified model.
+ */
+export interface AudioTranscriptionRequest {
+  /** Audio file to transcribe (mp3, mp4, mpeg, mpga, m4a, wav, webm) */
+  file: File | Blob;
+  /** Model ID to use (e.g., "whisper-1") */
+  model: string;
+  /** Output format: json, text, srt, verbose_json, or vtt (default: json) */
+  response_format?: 'json' | 'text' | 'srt' | 'verbose_json' | 'vtt';
+  /** ISO-639-1 language code */
+  language?: string;
+  /** Sampling temperature (0-1) */
+  temperature?: number;
+  /** Timestamp granularities: word, segment, or both */
+  timestamp_granularities?: Array<'word' | 'segment'>;
+}
+
+/**
+ * Response object from audio transcription API calls.
+ * Contains the transcribed text and optional timing information.
+ */
+export interface AudioTranscriptionResponse {
+  /** The task performed */
+  task: 'transcribe';
+  /** The language of the audio */
+  language: string;
+  /** Duration of the audio in seconds */
+  duration: number;
+  /** The transcribed text */
+  text: string;
+  /** Word-level timestamps (when requested) */
+  words?: Array<{
+    word: string;
+    start: number;
+    end: number;
+  }>;
+  /** Segment-level timestamps (when requested) */
+  segments?: Array<{
+    id: number;
+    seek?: number;
+    start: number;
+    end: number;
+    text: string;
+    tokens?: number[];
+    temperature?: number;
+    avg_logprob?: number;
+    compression_ratio?: number;
+    no_speech_prob?: number;
+  }>;
+}

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -16,7 +16,7 @@ export interface ChatCompletionRequest {
     content: string;
     /** The name of the author of this message */
     name?: string;
-  }>;
+  }>; 
   /** The maximum number of tokens to generate in the chat completion */
   max_tokens?: number;
   /** What sampling temperature to use, between 0 and 2 */

--- a/docs/backend/api-endpoints.md
+++ b/docs/backend/api-endpoints.md
@@ -246,6 +246,76 @@ GET /v1/files/{file_id}/content
 
 ---
 
+## Audio
+
+### Create Transcription
+
+Transcribes audio into the input language.
+
+```
+POST /v1/audio/transcriptions
+```
+
+This is a multipart/form-data endpoint.
+
+#### Request Body (multipart/form-data)
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `file` | file | Yes | The audio file to transcribe. Supported formats: mp3, mp4, mpeg, mpga, m4a, wav, webm |
+| `model` | string | Yes | Model ID (currently `whisper-1`) |
+| `language` | string | No | Language code in ISO-639-1 format |
+| `response_format` | string | No | Output format: `json`, `text`, `srt`, `verbose_json`, `vtt`. Default: `json` |
+| `temperature` | number | No | Sampling temperature (0-1). Default: 0 |
+| `timestamp_granularities` | array | No | Timestamp granularities: `word`, `segment`. Requires `verbose_json` format |
+
+#### Example Request
+
+```bash
+curl https://ozwellapi.opensource.mieweb.org/v1/audio/transcriptions \
+  -H "Authorization: Bearer $OZWELL_API_KEY" \
+  -F "file=@audio.mp3" \
+  -F model=whisper-1
+```
+
+#### Response (json format)
+
+```json
+{
+  "text": "Hello, this is a transcription of the audio file."
+}
+```
+
+#### Response (verbose_json format)
+
+```json
+{
+  "task": "transcribe",
+  "language": "english",
+  "duration": 3.0,
+  "text": "Hello, this is a transcription of the audio file.",
+  "words": [
+    { "word": "Hello", "start": 0.0, "end": 0.5 }
+  ],
+  "segments": [
+    {
+      "id": 0,
+      "seek": 0,
+      "start": 0.0,
+      "end": 3.0,
+      "text": "Hello, this is a transcription of the audio file.",
+      "tokens": [50364, 639, 307],
+      "temperature": 0.0,
+      "avg_logprob": -0.25,
+      "compression_ratio": 1.0,
+      "no_speech_prob": 0.01
+    }
+  ]
+}
+```
+
+---
+
 ## Models
 
 ### List Models

--- a/docs/backend/api-examples.md
+++ b/docs/backend/api-examples.md
@@ -313,6 +313,56 @@ console.log('File deleted');
 
 ---
 
+## Audio Transcription
+
+### Basic Transcription
+
+```typescript
+import fs from 'fs';
+
+const transcription = await client.audio.transcriptions.create({
+  file: fs.createReadStream('audio.mp3'),
+  model: 'whisper-1',
+});
+
+console.log(transcription.text);
+```
+
+### With Options
+
+```typescript
+const transcription = await client.audio.transcriptions.create({
+  file: fs.createReadStream('meeting.m4a'),
+  model: 'whisper-1',
+  language: 'en',
+  response_format: 'verbose_json',
+  timestamp_granularities: ['word', 'segment'],
+});
+
+console.log('Duration:', transcription.duration);
+console.log('Text:', transcription.text);
+
+// Word-level timestamps
+for (const word of transcription.words) {
+  console.log(`${word.word}: ${word.start}s - ${word.end}s`);
+}
+```
+
+### Subtitle Generation
+
+```typescript
+// Get SRT subtitles
+const srt = await client.audio.transcriptions.create({
+  file: fs.createReadStream('video-audio.mp3'),
+  model: 'whisper-1',
+  response_format: 'srt',
+});
+
+fs.writeFileSync('subtitles.srt', srt);
+```
+
+---
+
 ## Error Handling
 
 ### Basic Error Handling

--- a/docs/backend/sdk-typescript.md
+++ b/docs/backend/sdk-typescript.md
@@ -342,6 +342,54 @@ await client.files.delete('file-abc123');
 
 ---
 
+## Audio
+
+### Transcribe Audio
+
+```typescript
+import fs from 'fs';
+
+const transcription = await client.audio.transcriptions.create({
+  file: fs.createReadStream('recording.mp3'),
+  model: 'whisper-1',
+});
+
+console.log(transcription.text);
+```
+
+### Response Formats
+
+```typescript
+// Get verbose JSON with timestamps
+const verbose = await client.audio.transcriptions.create({
+  file: fs.createReadStream('audio.mp3'),
+  model: 'whisper-1',
+  response_format: 'verbose_json',
+  timestamp_granularities: ['word', 'segment'],
+});
+
+console.log('Duration:', verbose.duration);
+for (const word of verbose.words) {
+  console.log(`${word.word}: ${word.start}s - ${word.end}s`);
+}
+
+// Get plain text
+const text = await client.audio.transcriptions.create({
+  file: fs.createReadStream('audio.mp3'),
+  model: 'whisper-1',
+  response_format: 'text',
+});
+
+// Get SRT subtitles
+const srt = await client.audio.transcriptions.create({
+  file: fs.createReadStream('audio.mp3'),
+  model: 'whisper-1',
+  response_format: 'srt',
+});
+```
+
+---
+
 ## Error Handling
 
 ### Error Types

--- a/docs/backend/sdk-typescript.md
+++ b/docs/backend/sdk-typescript.md
@@ -347,10 +347,8 @@ await client.files.delete('file-abc123');
 ### Transcribe Audio
 
 ```typescript
-import fs from 'fs';
-
-const transcription = await client.audio.transcriptions.create({
-  file: fs.createReadStream('recording.mp3'),
+const transcription = await client.createTranscription({
+  file: new File([audioBuffer], 'recording.mp3', { type: 'audio/mpeg' }),
   model: 'whisper-1',
 });
 
@@ -361,8 +359,8 @@ console.log(transcription.text);
 
 ```typescript
 // Get verbose JSON with timestamps
-const verbose = await client.audio.transcriptions.create({
-  file: fs.createReadStream('audio.mp3'),
+const verbose = await client.createTranscription({
+  file: new File([audioBuffer], 'audio.mp3', { type: 'audio/mpeg' }),
   model: 'whisper-1',
   response_format: 'verbose_json',
   timestamp_granularities: ['word', 'segment'],
@@ -374,15 +372,15 @@ for (const word of verbose.words) {
 }
 
 // Get plain text
-const text = await client.audio.transcriptions.create({
-  file: fs.createReadStream('audio.mp3'),
+const text = await client.createTranscription({
+  file: new File([audioBuffer], 'audio.mp3', { type: 'audio/mpeg' }),
   model: 'whisper-1',
   response_format: 'text',
 });
 
 // Get SRT subtitles
-const srt = await client.audio.transcriptions.create({
-  file: fs.createReadStream('audio.mp3'),
+const srt = await client.createTranscription({
+  file: new File([audioBuffer], 'audio.mp3', { type: 'audio/mpeg' }),
   model: 'whisper-1',
   response_format: 'srt',
 });

--- a/reference-server/src/routes/audio.ts
+++ b/reference-server/src/routes/audio.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
-import { validateAuth, createError, isLLMBackendConfigured } from '../util';
+import { validateAuth, createError, extractToken, isLLMBackendConfigured } from '../util';
+import { agentStore } from '../storage/agents';
 
 const LLM_BASE_URL = process.env.LLM_BASE_URL || '';
 const LLM_API_KEY = process.env.LLM_API_KEY || '';
@@ -25,6 +26,13 @@ const audioRoute: FastifyPluginAsync = async (fastify) => {
     if (!validateAuth(request.headers.authorization)) {
       reply.code(401);
       return createError('Invalid API key provided', 'invalid_request_error');
+    }
+
+    // Validate token exists in database
+    const token = extractToken(request.headers.authorization);
+    if (!agentStore.validateKey(token)) {
+      reply.code(401);
+      return createError('API key not found. Verify the key exists in the database.', 'invalid_request_error');
     }
 
     // Parse all multipart parts in order-independent fashion

--- a/reference-server/src/routes/audio.ts
+++ b/reference-server/src/routes/audio.ts
@@ -1,5 +1,9 @@
 import { FastifyPluginAsync } from 'fastify';
-import { validateAuth, createError } from '../util';
+import { validateAuth, createError, isLLMBackendConfigured } from '../util';
+
+const LLM_BASE_URL = process.env.LLM_BASE_URL || '';
+const LLM_API_KEY = process.env.LLM_API_KEY || '';
+const LLM_PROVIDER = process.env.LLM_PROVIDER || '';
 
 const audioRoute: FastifyPluginAsync = async (fastify) => {
   // POST /v1/audio/transcriptions
@@ -72,7 +76,56 @@ const audioRoute: FastifyPluginAsync = async (fastify) => {
       'openai-version': '2020-10-01',
     });
 
-    // Mock transcription response
+    // Forward to real backend if configured, otherwise return mock
+    if (isLLMBackendConfigured()) {
+      const upstreamForm = new FormData();
+      upstreamForm.append('file', new Blob([Buffer.concat(chunks)], { type: data.mimetype }), data.filename);
+      upstreamForm.append('model', model);
+      if (responseFormat) upstreamForm.append('response_format', responseFormat);
+      if (language) upstreamForm.append('language', language);
+
+      const temperature = fields.temperature?.value as string | undefined;
+      if (temperature) upstreamForm.append('temperature', temperature);
+
+      const timestampGranularities = fields.timestamp_granularities?.value;
+      if (timestampGranularities) {
+        const granularities = Array.isArray(timestampGranularities) ? timestampGranularities : [timestampGranularities];
+        for (const g of granularities) {
+          upstreamForm.append('timestamp_granularities[]', g);
+        }
+      }
+
+      const headers: Record<string, string> = {
+        'Authorization': `Bearer ${LLM_API_KEY}`,
+      };
+      if (LLM_PROVIDER) headers['x-portkey-provider'] = LLM_PROVIDER;
+
+      const upstreamResp = await fetch(`${LLM_BASE_URL}/v1/audio/transcriptions`, {
+        method: 'POST',
+        headers,
+        body: upstreamForm,
+      });
+
+      if (!upstreamResp.ok) {
+        const errBody = await upstreamResp.text();
+        reply.code(upstreamResp.status);
+        try {
+          return JSON.parse(errBody);
+        } catch {
+          return createError(errBody, 'upstream_error');
+        }
+      }
+
+      // For text-based formats, return as plain text
+      if (['text', 'srt', 'vtt'].includes(responseFormat)) {
+        reply.type('text/plain');
+        return upstreamResp.text();
+      }
+
+      return upstreamResp.json();
+    }
+
+    // ── Mock fallback (no LLM backend configured) ──
     const mockText = 'This is a mock transcription from the reference server.';
 
     if (responseFormat === 'text') {

--- a/reference-server/src/routes/audio.ts
+++ b/reference-server/src/routes/audio.ts
@@ -9,6 +9,9 @@ const audioRoute: FastifyPluginAsync = async (fastify) => {
   // POST /v1/audio/transcriptions
   fastify.post('/v1/audio/transcriptions', {
     schema: {
+      summary: 'Transcribe audio to text',
+      description: 'Transcribes audio into text using the specified model. Accepts multipart/form-data with fields: file (required, audio binary), model (required, e.g. "whisper-1"), response_format (json|text|srt|verbose_json|vtt), language (ISO-639-1), temperature (0-1), timestamp_granularities (word|segment).',
+      tags: ['Audio'],
       headers: {
         type: 'object',
         properties: {
@@ -24,23 +27,43 @@ const audioRoute: FastifyPluginAsync = async (fastify) => {
       return createError('Invalid API key provided', 'invalid_request_error');
     }
 
-    const data = await request.file();
-    if (!data) {
+    // Parse all multipart parts in order-independent fashion
+    const fields: Record<string, any> = {};
+    const chunks: Buffer[] = [];
+    let fileMimetype = '';
+    let filename = '';
+    let hasFile = false;
+
+    for await (const part of request.parts()) {
+      if (part.type === 'file') {
+        if (!hasFile) {
+          hasFile = true;
+          fileMimetype = part.mimetype;
+          filename = part.filename;
+          for await (const chunk of part.file) {
+            chunks.push(chunk);
+          }
+        } else {
+          // Drain extra file streams
+          for await (const _ of part.file) { /* drain */ }
+        }
+      } else {
+        fields[part.fieldname] = { value: part.value };
+      }
+    }
+
+    if (!hasFile) {
       reply.code(400);
       return createError('Missing required parameter: file', 'invalid_request_error', 'file');
     }
-
-    // Consume the file stream
-    const chunks: Buffer[] = [];
-    for await (const chunk of data.file) {
-      chunks.push(chunk);
-    }
-
-    // Extract fields from multipart
-    const fields = data.fields as Record<string, any>;
     const model = fields.model?.value as string | undefined;
     const responseFormat = (fields.response_format?.value as string) || 'json';
     const language = fields.language?.value as string | undefined;
+    const temperature = fields.temperature?.value as string | undefined;
+    const rawGranularities = fields.timestamp_granularities?.value;
+    const granularities: string[] = rawGranularities
+      ? (Array.isArray(rawGranularities) ? rawGranularities : [rawGranularities])
+      : ['segment'];
 
     if (!model) {
       reply.code(400);
@@ -60,7 +83,7 @@ const audioRoute: FastifyPluginAsync = async (fastify) => {
       'audio/m4a', 'audio/wav', 'audio/webm', 'audio/x-m4a',
       'audio/x-wav', 'video/mp4', 'video/webm',
     ];
-    if (data.mimetype && !allowedMimeTypes.includes(data.mimetype)) {
+    if (fileMimetype && !allowedMimeTypes.includes(fileMimetype)) {
       reply.code(400);
       return createError(
         `Invalid file format. Supported formats: mp3, mp4, mpeg, mpga, m4a, wav, webm`,
@@ -79,17 +102,13 @@ const audioRoute: FastifyPluginAsync = async (fastify) => {
     // Forward to real backend if configured, otherwise return mock
     if (isLLMBackendConfigured()) {
       const upstreamForm = new FormData();
-      upstreamForm.append('file', new Blob([Buffer.concat(chunks)], { type: data.mimetype }), data.filename);
+      upstreamForm.append('file', new Blob([Buffer.concat(chunks)], { type: fileMimetype }), filename);
       upstreamForm.append('model', model);
       if (responseFormat) upstreamForm.append('response_format', responseFormat);
       if (language) upstreamForm.append('language', language);
-
-      const temperature = fields.temperature?.value as string | undefined;
       if (temperature) upstreamForm.append('temperature', temperature);
 
-      const timestampGranularities = fields.timestamp_granularities?.value;
-      if (timestampGranularities) {
-        const granularities = Array.isArray(timestampGranularities) ? timestampGranularities : [timestampGranularities];
+      if (rawGranularities) {
         for (const g of granularities) {
           upstreamForm.append('timestamp_granularities[]', g);
         }
@@ -151,11 +170,6 @@ const audioRoute: FastifyPluginAsync = async (fastify) => {
     };
 
     if (responseFormat === 'verbose_json') {
-      const timestampGranularities = fields.timestamp_granularities?.value;
-      const granularities = timestampGranularities
-        ? (Array.isArray(timestampGranularities) ? timestampGranularities : [timestampGranularities])
-        : ['segment'];
-
       if (granularities.includes('word')) {
         response.words = [
           { word: 'This', start: 0.0, end: 0.2 },

--- a/reference-server/src/routes/audio.ts
+++ b/reference-server/src/routes/audio.ts
@@ -1,0 +1,143 @@
+import { FastifyPluginAsync } from 'fastify';
+import { validateAuth, createError } from '../util';
+
+const audioRoute: FastifyPluginAsync = async (fastify) => {
+  // POST /v1/audio/transcriptions
+  fastify.post('/v1/audio/transcriptions', {
+    schema: {
+      headers: {
+        type: 'object',
+        properties: {
+          authorization: { type: 'string' },
+        },
+      },
+      consumes: ['multipart/form-data'],
+    },
+  }, async (request, reply) => {
+    // Validate authorization
+    if (!validateAuth(request.headers.authorization)) {
+      reply.code(401);
+      return createError('Invalid API key provided', 'invalid_request_error');
+    }
+
+    const data = await request.file();
+    if (!data) {
+      reply.code(400);
+      return createError('Missing required parameter: file', 'invalid_request_error', 'file');
+    }
+
+    // Consume the file stream
+    const chunks: Buffer[] = [];
+    for await (const chunk of data.file) {
+      chunks.push(chunk);
+    }
+
+    // Extract fields from multipart
+    const fields = data.fields as Record<string, any>;
+    const model = fields.model?.value as string | undefined;
+    const responseFormat = (fields.response_format?.value as string) || 'json';
+    const language = fields.language?.value as string | undefined;
+
+    if (!model) {
+      reply.code(400);
+      return createError('Missing required parameter: model', 'invalid_request_error', 'model');
+    }
+
+    // Validate model
+    const supportedModels = ['whisper-1'];
+    if (!supportedModels.includes(model)) {
+      reply.code(400);
+      return createError(`Model '${model}' not found`, 'invalid_request_error', 'model');
+    }
+
+    // Validate file type
+    const allowedMimeTypes = [
+      'audio/mpeg', 'audio/mp3', 'audio/mp4', 'audio/mpga',
+      'audio/m4a', 'audio/wav', 'audio/webm', 'audio/x-m4a',
+      'audio/x-wav', 'video/mp4', 'video/webm',
+    ];
+    if (data.mimetype && !allowedMimeTypes.includes(data.mimetype)) {
+      reply.code(400);
+      return createError(
+        `Invalid file format. Supported formats: mp3, mp4, mpeg, mpga, m4a, wav, webm`,
+        'invalid_request_error',
+        'file',
+      );
+    }
+
+    // Add OpenAI-compatible headers
+    reply.headers({
+      'x-request-id': `req_${Date.now()}`,
+      'openai-processing-ms': '500',
+      'openai-version': '2020-10-01',
+    });
+
+    // Mock transcription response
+    const mockText = 'This is a mock transcription from the reference server.';
+
+    if (responseFormat === 'text') {
+      reply.type('text/plain');
+      return mockText;
+    }
+
+    if (responseFormat === 'srt') {
+      reply.type('text/plain');
+      return '1\n00:00:00,000 --> 00:00:03,000\nThis is a mock transcription from the reference server.\n';
+    }
+
+    if (responseFormat === 'vtt') {
+      reply.type('text/plain');
+      return 'WEBVTT\n\n00:00:00.000 --> 00:00:03.000\nThis is a mock transcription from the reference server.\n';
+    }
+
+    const response: any = {
+      task: 'transcribe',
+      language: language || 'english',
+      duration: 3.0,
+      text: mockText,
+    };
+
+    if (responseFormat === 'verbose_json') {
+      const timestampGranularities = fields.timestamp_granularities?.value;
+      const granularities = timestampGranularities
+        ? (Array.isArray(timestampGranularities) ? timestampGranularities : [timestampGranularities])
+        : ['segment'];
+
+      if (granularities.includes('word')) {
+        response.words = [
+          { word: 'This', start: 0.0, end: 0.2 },
+          { word: 'is', start: 0.2, end: 0.3 },
+          { word: 'a', start: 0.3, end: 0.4 },
+          { word: 'mock', start: 0.4, end: 0.6 },
+          { word: 'transcription', start: 0.6, end: 1.2 },
+        ];
+      }
+
+      if (granularities.includes('segment')) {
+        response.segments = [
+          {
+            id: 0,
+            seek: 0,
+            start: 0.0,
+            end: 3.0,
+            text: mockText,
+            tokens: [50364, 639, 307, 257, 13473, 38752, 13],
+            temperature: 0.0,
+            avg_logprob: -0.25,
+            compression_ratio: 1.0,
+            no_speech_prob: 0.01,
+          },
+        ];
+      }
+    }
+
+    // For plain 'json' format, return just the text
+    if (responseFormat === 'json') {
+      return { text: mockText };
+    }
+
+    return response;
+  });
+};
+
+export default audioRoute;

--- a/reference-server/src/routes/audio.ts
+++ b/reference-server/src/routes/audio.ts
@@ -56,7 +56,17 @@ const audioRoute: FastifyPluginAsync = async (fastify) => {
           part.file.resume();
         }
       } else {
-        fields[part.fieldname] = { value: part.value };
+        // Accumulate repeated fields (e.g. timestamp_granularities) into arrays
+        if (fields[part.fieldname]) {
+          const existing = fields[part.fieldname].value;
+          fields[part.fieldname] = {
+            value: Array.isArray(existing)
+              ? [...existing, part.value]
+              : [existing, part.value],
+          };
+        } else {
+          fields[part.fieldname] = { value: part.value };
+        }
       }
     }
 
@@ -66,6 +76,17 @@ const audioRoute: FastifyPluginAsync = async (fastify) => {
     }
     const model = fields.model?.value as string | undefined;
     const responseFormat = (fields.response_format?.value as string) || 'json';
+
+    // Validate response_format
+    const validFormats = ['json', 'text', 'srt', 'verbose_json', 'vtt'];
+    if (!validFormats.includes(responseFormat)) {
+      reply.code(400);
+      return createError(
+        `Invalid response_format '${responseFormat}'. Supported formats: ${validFormats.join(', ')}`,
+        'invalid_request_error',
+        'response_format',
+      );
+    }
     const language = fields.language?.value as string | undefined;
     const temperature = fields.temperature?.value as string | undefined;
     const rawGranularities = fields.timestamp_granularities?.value;

--- a/reference-server/src/routes/audio.ts
+++ b/reference-server/src/routes/audio.ts
@@ -45,7 +45,7 @@ const audioRoute: FastifyPluginAsync = async (fastify) => {
           }
         } else {
           // Drain extra file streams
-          for await (const _ of part.file) { /* drain */ }
+          part.file.resume();
         }
       } else {
         fields[part.fieldname] = { value: part.value };

--- a/reference-server/src/server.ts
+++ b/reference-server/src/server.ts
@@ -14,6 +14,7 @@ import responsesRoute from './routes/responses';
 import embeddingsRoute from './routes/embeddings';
 import filesRoute from './routes/files';
 import agentsRoute from './routes/agents';
+import audioRoute from './routes/audio';
 import { getDatabase, initializeAuthTables, seedDemoData, seedMockAgent } from './storage/agents';
 // Import schemas for OpenAPI generation
 import * as schemas from '../../spec';
@@ -88,6 +89,8 @@ async function buildServer() {
           EmbeddingResponse: schemas.EmbeddingResponseSchema,
           FileObject: schemas.FileObjectSchema,
           FileListResponse: schemas.FileListResponseSchema,
+          AudioTranscriptionRequest: schemas.AudioTranscriptionRequestSchema,
+          AudioTranscriptionResponse: schemas.AudioTranscriptionResponseSchema,
         },
       },
       security: [
@@ -141,6 +144,7 @@ async function buildServer() {
   await fastify.register(embeddingsRoute);
   await fastify.register(filesRoute);
   await fastify.register(agentsRoute);  // Agent registration CRUD
+  await fastify.register(audioRoute);   // Audio transcription
 
   // Serve public assets (documentation, misc)
   await fastify.register(fastifyStatic, {

--- a/reference-server/test/audio.test.js
+++ b/reference-server/test/audio.test.js
@@ -240,6 +240,37 @@ test('audio transcription — 400 with unsupported model', async () => {
   assert.match(json.error.message, /not found/);
 });
 
+test('audio transcription — 400 with invalid response_format', async () => {
+  const form = createAudioFormData({ model: 'whisper-1', responseFormat: 'foo' });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 400);
+  const json = await r.json();
+  assert.match(json.error.message, /Invalid response_format/);
+});
+
+test('audio transcription — verbose_json with both word and segment granularities', async () => {
+  const form = createAudioFormData({
+    model: 'whisper-1',
+    responseFormat: 'verbose_json',
+    granularities: ['word', 'segment'],
+  });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 200);
+  const json = await r.json();
+  assert.ok(Array.isArray(json.words), 'expected words array when both granularities requested');
+  assert.ok(json.words.length > 0);
+  assert.ok(Array.isArray(json.segments), 'expected segments array when both granularities requested');
+  assert.ok(json.segments.length > 0);
+});
+
 test('audio transcription — 400 with invalid file type', async () => {
   const form = new FormData();
   form.append('file', new Blob(['not audio'], { type: 'text/plain' }), 'test.txt');

--- a/reference-server/test/audio.test.js
+++ b/reference-server/test/audio.test.js
@@ -1,0 +1,239 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const API_KEY = 'ozw_test-audio-key';
+const PORT = 3335;
+const BASE = `http://localhost:${PORT}`;
+
+let server;
+let tmp;
+
+async function waitForReady(maxMs = 10_000) {
+  const start = Date.now();
+  while (Date.now() - start < maxMs) {
+    try {
+      const r = await fetch(`${BASE}/health`);
+      if (r.status === 200) return;
+    } catch { /* not ready */ }
+    await delay(200);
+  }
+  throw new Error('server never became ready');
+}
+
+before(async () => {
+  tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-audio-test-'));
+  const dbPath = path.join(tmp, 'ozwell.db');
+  server = spawn('npm', ['run', 'dev'], {
+    cwd: process.cwd(),
+    stdio: 'pipe',
+    detached: true,
+    env: { ...process.env, PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development' },
+  });
+  await waitForReady();
+});
+
+after(() => {
+  try { process.kill(-server.pid, 'SIGKILL'); } catch { /* ignore */ }
+  try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function createAudioFormData({ file, model, responseFormat, language, temperature, granularities } = {}) {
+  const formData = new FormData();
+  // Append non-file fields BEFORE the file so fastify multipart captures them in data.fields
+  if (model !== undefined) formData.append('model', model);
+  if (responseFormat) formData.append('response_format', responseFormat);
+  if (language) formData.append('language', language);
+  if (temperature !== undefined) formData.append('temperature', String(temperature));
+  if (granularities) {
+    for (const g of granularities) {
+      formData.append('timestamp_granularities', g);
+    }
+  }
+  // File last
+  if (file !== undefined) {
+    formData.append('file', file);
+  } else {
+    formData.append('file', new Blob([new Uint8Array(100)], { type: 'audio/mpeg' }), 'test.mp3');
+  }
+  return formData;
+}
+
+// --- Success cases ---
+
+test('audio transcription — json format (default)', async () => {
+  const form = createAudioFormData({ model: 'whisper-1' });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 200);
+  const json = await r.json();
+  assert.equal(typeof json.text, 'string');
+  assert.ok(json.text.length > 0);
+});
+
+test('audio transcription — text format', async () => {
+  const form = createAudioFormData({ model: 'whisper-1', responseFormat: 'text' });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 200);
+  const text = await r.text();
+  assert.ok(text.length > 0);
+});
+
+test('audio transcription — srt format', async () => {
+  const form = createAudioFormData({ model: 'whisper-1', responseFormat: 'srt' });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 200);
+  const srt = await r.text();
+  assert.match(srt, /-->/);
+  assert.match(srt, /^\d+\n/);
+});
+
+test('audio transcription — vtt format', async () => {
+  const form = createAudioFormData({ model: 'whisper-1', responseFormat: 'vtt' });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 200);
+  const vtt = await r.text();
+  assert.match(vtt, /^WEBVTT/);
+  assert.match(vtt, /-->/);
+});
+
+test('audio transcription — verbose_json with word timestamps', async () => {
+  const form = createAudioFormData({
+    model: 'whisper-1',
+    responseFormat: 'verbose_json',
+    granularities: ['word'],
+  });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 200);
+  const json = await r.json();
+  assert.equal(json.task, 'transcribe');
+  assert.equal(typeof json.language, 'string');
+  assert.equal(typeof json.duration, 'number');
+  assert.equal(typeof json.text, 'string');
+  assert.ok(Array.isArray(json.words));
+  assert.ok(json.words.length > 0);
+  assert.equal(typeof json.words[0].word, 'string');
+  assert.equal(typeof json.words[0].start, 'number');
+  assert.equal(typeof json.words[0].end, 'number');
+});
+
+test('audio transcription — verbose_json with segment timestamps', async () => {
+  const form = createAudioFormData({
+    model: 'whisper-1',
+    responseFormat: 'verbose_json',
+    granularities: ['segment'],
+  });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 200);
+  const json = await r.json();
+  assert.equal(json.task, 'transcribe');
+  assert.ok(Array.isArray(json.segments));
+  assert.ok(json.segments.length > 0);
+  const seg = json.segments[0];
+  assert.equal(typeof seg.id, 'number');
+  assert.equal(typeof seg.start, 'number');
+  assert.equal(typeof seg.end, 'number');
+  assert.equal(typeof seg.text, 'string');
+});
+
+test('audio transcription — verbose_json with language parameter', async () => {
+  const form = createAudioFormData({
+    model: 'whisper-1',
+    responseFormat: 'verbose_json',
+    language: 'es',
+  });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 200);
+  const json = await r.json();
+  assert.equal(json.language, 'es');
+});
+
+// --- Error cases ---
+
+test('audio transcription — 401 without auth', async () => {
+  const form = createAudioFormData({ model: 'whisper-1' });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    body: form,
+  });
+  assert.equal(r.status, 401);
+});
+
+test('audio transcription — 401 with invalid key', async () => {
+  const form = createAudioFormData({ model: 'whisper-1' });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: 'Bearer invalid-key' },
+    body: form,
+  });
+  assert.equal(r.status, 401);
+});
+
+test('audio transcription — 400 without model', async () => {
+  const form = createAudioFormData({});
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 400);
+  const json = await r.json();
+  assert.equal(json.error.type, 'invalid_request_error');
+});
+
+test('audio transcription — 400 with unsupported model', async () => {
+  const form = createAudioFormData({ model: 'gpt-4' });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 400);
+  const json = await r.json();
+  assert.match(json.error.message, /not found/);
+});
+
+test('audio transcription — 400 with invalid file type', async () => {
+  const form = new FormData();
+  form.append('file', new Blob(['not audio'], { type: 'text/plain' }), 'test.txt');
+  form.append('model', 'whisper-1');
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+  });
+  assert.equal(r.status, 400);
+  const json = await r.json();
+  assert.match(json.error.message, /Invalid file format/);
+});

--- a/reference-server/test/audio.test.js
+++ b/reference-server/test/audio.test.js
@@ -28,11 +28,16 @@ async function waitForReady(maxMs = 10_000) {
 before(async () => {
   tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-audio-test-'));
   const dbPath = path.join(tmp, 'ozwell.db');
+  const env = { ...process.env, PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development' };
+  // Force mock mode — override LLM env vars so dotenv/.env can't set them
+  env.LLM_BASE_URL = '';
+  env.LLM_API_KEY = '';
+  env.LLM_PROVIDER = '';
   server = spawn('npm', ['run', 'dev'], {
     cwd: process.cwd(),
     stdio: 'pipe',
     detached: true,
-    env: { ...process.env, PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development' },
+    env,
   });
   await waitForReady();
 });
@@ -44,7 +49,12 @@ after(() => {
 
 function createAudioFormData({ file, model, responseFormat, language, temperature, granularities } = {}) {
   const formData = new FormData();
-  // Append non-file fields BEFORE the file so fastify multipart captures them in data.fields
+  // Append file first (matches SDK behavior — @fastify/multipart handles field order)
+  if (file !== undefined) {
+    formData.append('file', file);
+  } else {
+    formData.append('file', new Blob([new Uint8Array(100)], { type: 'audio/mpeg' }), 'test.mp3');
+  }
   if (model !== undefined) formData.append('model', model);
   if (responseFormat) formData.append('response_format', responseFormat);
   if (language) formData.append('language', language);
@@ -53,12 +63,6 @@ function createAudioFormData({ file, model, responseFormat, language, temperatur
     for (const g of granularities) {
       formData.append('timestamp_granularities', g);
     }
-  }
-  // File last
-  if (file !== undefined) {
-    formData.append('file', file);
-  } else {
-    formData.append('file', new Blob([new Uint8Array(100)], { type: 'audio/mpeg' }), 'test.mp3');
   }
   return formData;
 }

--- a/reference-server/test/audio.test.js
+++ b/reference-server/test/audio.test.js
@@ -6,7 +6,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-const API_KEY = 'ozw_test-audio-key';
+const API_KEY = 'ozw_demo_localhost_key_for_testing';
 const PORT = 3335;
 const BASE = `http://localhost:${PORT}`;
 
@@ -202,6 +202,18 @@ test('audio transcription — 401 with invalid key', async () => {
     body: form,
   });
   assert.equal(r.status, 401);
+});
+
+test('audio transcription — 401 with well-formed but unregistered key', async () => {
+  const form = createAudioFormData({ model: 'whisper-1' });
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: 'Bearer ozw_does_not_exist' },
+    body: form,
+  });
+  assert.equal(r.status, 401);
+  const json = await r.json();
+  assert.match(json.error.message, /not found/i);
 });
 
 test('audio transcription — 400 without model', async () => {

--- a/spec/index.ts
+++ b/spec/index.ts
@@ -181,3 +181,44 @@ export type FileObject = z.infer<typeof FileObjectSchema>;
 export type FileListResponse = z.infer<typeof FileListResponseSchema>;
 export type ModelsListResponse = z.infer<typeof ModelsListResponseSchema>;
 export type ChatCompletionChunk = z.infer<typeof ChatCompletionChunkSchema>;
+
+// Audio transcription schemas
+export const AudioTranscriptionRequestSchema = z.object({
+  file: z.any().describe('Audio file (mp3, mp4, mpeg, mpga, m4a, wav, webm)'),
+  model: z.string(),
+  response_format: z.enum(['json', 'text', 'srt', 'verbose_json', 'vtt']).optional(),
+  language: z.string().optional(),
+  temperature: z.number().min(0).max(1).optional(),
+  timestamp_granularities: z.array(z.enum(['word', 'segment'])).optional(),
+});
+
+export const TranscriptionWordSchema = z.object({
+  word: z.string(),
+  start: z.number(),
+  end: z.number(),
+});
+
+export const TranscriptionSegmentSchema = z.object({
+  id: z.number(),
+  seek: z.number().optional(),
+  start: z.number(),
+  end: z.number(),
+  text: z.string(),
+  tokens: z.array(z.number()).optional(),
+  temperature: z.number().optional(),
+  avg_logprob: z.number().optional(),
+  compression_ratio: z.number().optional(),
+  no_speech_prob: z.number().optional(),
+});
+
+export const AudioTranscriptionResponseSchema = z.object({
+  task: z.literal('transcribe'),
+  language: z.string(),
+  duration: z.number(),
+  text: z.string(),
+  words: z.array(TranscriptionWordSchema).optional(),
+  segments: z.array(TranscriptionSegmentSchema).optional(),
+});
+
+export type AudioTranscriptionRequest = z.infer<typeof AudioTranscriptionRequestSchema>;
+export type AudioTranscriptionResponse = z.infer<typeof AudioTranscriptionResponseSchema>;


### PR DESCRIPTION
## Summary

Adds the `POST /v1/audio/transcriptions` endpoint across the spec, reference server, and TypeScript client, as requested in #113.

## Changes

### Spec (`spec/index.ts`)
- Added Zod schemas: `AudioTranscriptionRequestSchema`, `TranscriptionWordSchema`, `TranscriptionSegmentSchema`, `AudioTranscriptionResponseSchema`
- Exported inferred TypeScript types

### Reference Server (`reference-server/src/routes/audio.ts`)
- New multipart route with auth validation, model validation, and file type checking
- Mock responses for all 5 response formats: `json`, `text`, `srt`, `verbose_json`, `vtt`
- Registered in `server.ts` with OpenAPI schema entries

### TypeScript Client (`clients/typescript/`)
- Added `AudioTranscriptionRequest` and `AudioTranscriptionResponse` interfaces to `types.ts`
- Added `createTranscription()` method to `OzwellAI` class (handles FormData construction)
- Re-exported new types from `index.ts`

Closes #113