### PR TITLE
Add admin key console

### DIFF
--- a/landing-page/public/demo.css
+++ b/landing-page/public/demo.css
@@ -414,8 +414,28 @@ body {
   background: #ffffff;
   color: #1a1a1a;
   padding: 1.5rem 2rem;
+  position: relative;
   text-align: center;
   border-bottom: 1px solid #e5e7eb;
+}
+
+.admin-console-link {
+  position: absolute;
+  right: 2rem;
+  top: 1.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  color: #374151;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 8px 12px;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.admin-console-link:hover {
+  border-color: #0066ff;
+  color: #0066ff;
 }
 
 .header-title {
@@ -783,6 +803,12 @@ body {
 
   .header-subtitle {
     font-size: 0.85rem;
+  }
+
+  .admin-console-link {
+    display: inline-block;
+    margin-bottom: 1rem;
+    position: static;
   }
 
   .demo-content {

--- a/landing-page/public/keys-demo.html
+++ b/landing-page/public/keys-demo.html
@@ -1,0 +1,437 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>API Keys Demo — Ozwell</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      background: #fafafa;
+      min-height: 100vh;
+      padding: 20px;
+      color: #1a1a1a;
+    }
+    .main-container { max-width: 1040px; margin: 0 auto; }
+    .header { text-align: center; margin-bottom: 32px; position: relative; }
+    .back-link-container { position: absolute; left: 0; top: 10px; }
+    .back-link {
+      color: #0066ff;
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+    }
+    .back-link:hover { text-decoration: underline; }
+    .header-title {
+      font-size: 32px;
+      font-weight: 700;
+      margin-bottom: 8px;
+      letter-spacing: -0.025em;
+    }
+    .header-subtitle { font-size: 16px; color: #6b7280; }
+    .demo-note {
+      background: #fffbeb;
+      color: #92400e;
+      border: 1px solid #fde68a;
+      border-radius: 10px;
+      padding: 12px 14px;
+      margin-bottom: 20px;
+      font-size: 14px;
+    }
+    .section {
+      background: #fff;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 20px;
+    }
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 14px;
+    }
+    h3 { font-size: 16px; font-weight: 700; }
+    p { color: #6b7280; font-size: 14px; margin-bottom: 12px; }
+    .row { display: flex; gap: 8px; align-items: center; }
+    .row.wrap { flex-wrap: wrap; }
+    input, select {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 10px 14px;
+      color: #1a1a1a;
+      font-size: 14px;
+      outline: none;
+    }
+    input:focus, select:focus { border-color: #0066ff; }
+    .key-input { flex: 1; min-width: 280px; font-family: monospace; }
+    .name-input { flex: 1; min-width: 220px; }
+    .owner-input { width: 180px; }
+    button {
+      border: 0;
+      border-radius: 8px;
+      padding: 10px 14px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      background: #e5e7eb;
+      color: #111827;
+    }
+    button.primary { background: #0066ff; color: #fff; }
+    button.danger { background: #dc2626; color: #fff; }
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+    .status {
+      margin-top: 8px;
+      min-height: 18px;
+      font-size: 13px;
+      color: #6b7280;
+    }
+    .status.ok { color: #16a34a; }
+    .status.error { color: #dc2626; }
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+      margin-bottom: 20px;
+    }
+    .stat-card {
+      background: #fff;
+      border-radius: 12px;
+      padding: 18px;
+    }
+    .stat-label { color: #6b7280; font-size: 13px; margin-bottom: 4px; }
+    .stat-value { font-size: 28px; font-weight: 700; }
+    .table-wrap { overflow-x: auto; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+    th, td {
+      text-align: left;
+      border-bottom: 1px solid #e5e7eb;
+      padding: 12px 8px;
+      vertical-align: middle;
+      white-space: nowrap;
+    }
+    th { color: #6b7280; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+    td.name-cell { min-width: 220px; }
+    .key-hint {
+      font-family: monospace;
+      color: #374151;
+    }
+    .badge {
+      display: inline-block;
+      border-radius: 999px;
+      padding: 3px 8px;
+      font-size: 12px;
+      font-weight: 600;
+    }
+    .badge.active { color: #166534; background: #dcfce7; }
+    .badge.revoked { color: #991b1b; background: #fee2e2; }
+    .badge.demo { color: #1d4ed8; background: #dbeafe; }
+    .actions { display: flex; gap: 8px; justify-content: flex-end; }
+    .new-key-box {
+      display: none;
+      margin-top: 12px;
+      border: 1px solid #bfdbfe;
+      background: #eff6ff;
+      color: #1e3a8a;
+      border-radius: 8px;
+      padding: 12px;
+    }
+    .new-key-box.visible { display: block; }
+    .new-key-value {
+      display: block;
+      margin-top: 6px;
+      font-family: monospace;
+      overflow-wrap: anywhere;
+    }
+    @media (max-width: 760px) {
+      .header { text-align: left; padding-top: 36px; }
+      .back-link-container { top: 0; }
+      .row { align-items: stretch; flex-direction: column; }
+      .key-input, .name-input, .owner-input { min-width: 0; width: 100%; }
+      .section-header { align-items: flex-start; flex-direction: column; }
+      .stats { grid-template-columns: 1fr; }
+      .actions { justify-content: flex-start; }
+    }
+  </style>
+</head>
+<body>
+  <div class="main-container">
+    <header class="header">
+      <div class="back-link-container">
+        <a href="/" class="back-link">&larr; Back to demos</a>
+      </div>
+      <h1 class="header-title">API Keys Demo</h1>
+      <p class="header-subtitle">Mocked admin workflow for team feedback.</p>
+    </header>
+
+    <div class="demo-note">
+      Demo only. This page uses local mock data and does not call the server.
+    </div>
+
+    <section class="section">
+      <h3>Admin key</h3>
+      <p>Mock login for reviewing the intended page flow.</p>
+      <div class="row">
+        <input id="admin-key-input" class="key-input" type="password" value="ozw_demo_admin_key_for_review" />
+        <button id="validate-btn" class="primary">Validate</button>
+      </div>
+      <div id="auth-status" class="status ok">Valid demo key.</div>
+    </section>
+
+    <div class="stats">
+      <div class="stat-card">
+        <div class="stat-label">Active keys</div>
+        <div id="active-count" class="stat-value">0</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Revoked keys</div>
+        <div id="revoked-count" class="stat-value">0</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Total keys</div>
+        <div id="total-count" class="stat-value">0</div>
+      </div>
+    </div>
+
+    <section class="section">
+      <div class="section-header">
+        <div>
+          <h3>Create key</h3>
+          <p>Create a new parent key and copy it immediately.</p>
+        </div>
+      </div>
+      <div class="row wrap">
+        <input id="new-key-name" class="name-input" type="text" placeholder="Key name, e.g. Aaron Demo Key" />
+        <input id="new-key-owner" class="owner-input" type="text" placeholder="Owner" />
+        <button id="create-key-btn" class="primary">Create key</button>
+      </div>
+      <div id="new-key-box" class="new-key-box">
+        New key created. Copy it now.
+        <span id="new-key-value" class="new-key-value"></span>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-header">
+        <div>
+          <h3>Parent keys</h3>
+          <p>Rename keys, revoke access, and scan current ownership.</p>
+        </div>
+        <button id="reset-demo-btn">Reset mock data</button>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Owner</th>
+              <th>Key hint</th>
+              <th>Status</th>
+              <th>Created</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="keys-tbody"></tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    const seedKeys = [
+      {
+        id: 'key_demo',
+        name: 'Demo Localhost Key',
+        owner: 'Aditya',
+        key_hint: 'ozw_...ting',
+        created_at: '2026-05-08T16:34:00Z',
+        revoked_at: null
+      },
+      {
+        id: 'key_aaron',
+        name: 'Aaron Review Key',
+        owner: 'Aaron',
+        key_hint: 'ozw_...9f2a',
+        created_at: '2026-05-13T13:22:00Z',
+        revoked_at: null
+      },
+      {
+        id: 'key_old',
+        name: 'Old Embed Test Key',
+        owner: 'Legacy',
+        key_hint: 'ozw_...1c8d',
+        created_at: '2026-04-21T18:11:00Z',
+        revoked_at: '2026-05-14T18:00:00Z'
+      }
+    ];
+
+    let keys = seedKeys.map(k => ({ ...k }));
+
+    const adminKeyInput = document.getElementById('admin-key-input');
+    const authStatus = document.getElementById('auth-status');
+    const activeCount = document.getElementById('active-count');
+    const revokedCount = document.getElementById('revoked-count');
+    const totalCount = document.getElementById('total-count');
+    const newKeyName = document.getElementById('new-key-name');
+    const newKeyOwner = document.getElementById('new-key-owner');
+    const newKeyBox = document.getElementById('new-key-box');
+    const newKeyValue = document.getElementById('new-key-value');
+    const keysTbody = document.getElementById('keys-tbody');
+
+    function formatDate(value) {
+      if (!value) return '-';
+      return new Date(value).toLocaleString();
+    }
+
+    function randomKey() {
+      const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+      let suffix = '';
+      for (let i = 0; i < 32; i += 1) {
+        suffix += chars[Math.floor(Math.random() * chars.length)];
+      }
+      return 'ozw_' + suffix;
+    }
+
+    function renderStats() {
+      const active = keys.filter(k => !k.revoked_at).length;
+      activeCount.textContent = String(active);
+      revokedCount.textContent = String(keys.length - active);
+      totalCount.textContent = String(keys.length);
+    }
+
+    function renderKeys() {
+      keysTbody.innerHTML = '';
+      for (const key of keys) {
+        const revoked = !!key.revoked_at;
+        const tr = document.createElement('tr');
+
+        const name = document.createElement('td');
+        name.className = 'name-cell';
+        name.textContent = key.name;
+
+        const owner = document.createElement('td');
+        owner.textContent = key.owner || '-';
+
+        const hint = document.createElement('td');
+        hint.className = 'key-hint';
+        hint.textContent = key.key_hint;
+
+        const status = document.createElement('td');
+        const badge = document.createElement('span');
+        badge.className = 'badge ' + (revoked ? 'revoked' : 'active');
+        badge.textContent = revoked ? 'Revoked' : 'Active';
+        status.appendChild(badge);
+
+        const created = document.createElement('td');
+        created.textContent = formatDate(key.created_at);
+
+        const actions = document.createElement('td');
+        const actionWrap = document.createElement('div');
+        actionWrap.className = 'actions';
+
+        const rename = document.createElement('button');
+        rename.textContent = 'Rename';
+        rename.disabled = revoked;
+        rename.addEventListener('click', () => renameKey(key.id));
+
+        const revoke = document.createElement('button');
+        revoke.className = 'danger';
+        revoke.textContent = 'Revoke';
+        revoke.disabled = revoked;
+        revoke.addEventListener('click', () => revokeKey(key.id));
+
+        actionWrap.appendChild(rename);
+        actionWrap.appendChild(revoke);
+        actions.appendChild(actionWrap);
+
+        tr.appendChild(name);
+        tr.appendChild(owner);
+        tr.appendChild(hint);
+        tr.appendChild(status);
+        tr.appendChild(created);
+        tr.appendChild(actions);
+        keysTbody.appendChild(tr);
+      }
+      renderStats();
+    }
+
+    function validateDemoKey() {
+      if (!adminKeyInput.value.trim().startsWith('ozw_')) {
+        authStatus.textContent = 'Invalid demo key.';
+        authStatus.className = 'status error';
+        return;
+      }
+      authStatus.textContent = 'Valid demo key.';
+      authStatus.className = 'status ok';
+    }
+
+    function createKey() {
+      const name = newKeyName.value.trim();
+      const owner = newKeyOwner.value.trim();
+      if (!name) {
+        authStatus.textContent = 'Enter a key name first.';
+        authStatus.className = 'status error';
+        return;
+      }
+
+      const key = randomKey();
+      keys.unshift({
+        id: 'key_' + Date.now().toString(36),
+        name,
+        owner: owner || 'Unassigned',
+        key_hint: 'ozw_...' + key.slice(-4),
+        created_at: new Date().toISOString(),
+        revoked_at: null
+      });
+      newKeyValue.textContent = key;
+      newKeyBox.classList.add('visible');
+      newKeyName.value = '';
+      newKeyOwner.value = '';
+      authStatus.textContent = 'Mock key created.';
+      authStatus.className = 'status ok';
+      renderKeys();
+    }
+
+    function renameKey(id) {
+      const key = keys.find(k => k.id === id);
+      if (!key) return;
+      const nextName = prompt('Key name', key.name);
+      if (nextName == null) return;
+      const nextOwner = prompt('Owner', key.owner || '');
+      if (nextOwner == null) return;
+      key.name = nextName.trim() || key.name;
+      key.owner = nextOwner.trim() || 'Unassigned';
+      renderKeys();
+    }
+
+    function revokeKey(id) {
+      const key = keys.find(k => k.id === id);
+      if (!key) return;
+      if (!confirm(`Revoke "${key.name}"?`)) return;
+      key.revoked_at = new Date().toISOString();
+      renderKeys();
+    }
+
+    function resetDemo() {
+      keys = seedKeys.map(k => ({ ...k }));
+      newKeyBox.classList.remove('visible');
+      renderKeys();
+    }
+
+    document.getElementById('validate-btn').addEventListener('click', validateDemoKey);
+    document.getElementById('create-key-btn').addEventListener('click', createKey);
+    document.getElementById('reset-demo-btn').addEventListener('click', resetDemo);
+
+    renderKeys();
+  </script>
+</body>
+</html>

--- a/landing-page/public/keys.html
+++ b/landing-page/public/keys.html
@@ -115,6 +115,22 @@
       white-space: nowrap;
     }
     th { color: #6b7280; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+    .expand-cell { width: 34px; }
+    .expand-btn {
+      align-items: center;
+      border-radius: 6px;
+      display: inline-flex;
+      justify-content: center;
+      min-height: 28px;
+      padding: 0;
+      width: 28px;
+    }
+    .expand-btn[disabled] { visibility: hidden; }
+    .chevron {
+      display: inline-block;
+      transition: transform 0.15s ease;
+    }
+    tr.expanded .chevron { transform: rotate(90deg); }
     td.name-cell { min-width: 220px; }
     .key-hint {
       font-family: monospace;
@@ -132,6 +148,57 @@
     .badge.admin { color: #1d4ed8; background: #dbeafe; }
     .badge.user { color: #374151; background: #f3f4f6; }
     .actions { display: flex; gap: 8px; justify-content: flex-end; }
+    .agent-row td {
+      background: #fbfcfe;
+      padding: 0;
+    }
+    .agent-panel {
+      border-top: 1px solid #e5e7eb;
+      display: none;
+      padding: 0 12px 8px 44px;
+    }
+    tr.expanded + .agent-row .agent-panel { display: block; }
+    .agent-panel-title {
+      align-items: center;
+      display: flex;
+      gap: 8px;
+      min-height: 34px;
+      font-weight: 700;
+    }
+    .agent-count-badge {
+      background: #eef2ff;
+      border-radius: 999px;
+      color: #3730a3;
+      font-size: 12px;
+      font-weight: 700;
+      padding: 2px 7px;
+    }
+    .agent-list {
+      font-size: 13px;
+    }
+    .agent-list-row {
+      align-items: center;
+      border-bottom: 1px solid #edf0f5;
+      display: grid;
+      gap: 10px;
+      grid-template-columns: minmax(210px, 1.5fr) minmax(150px, 1fr) 120px 120px;
+      min-height: 32px;
+      padding: 5px 8px;
+    }
+    .agent-list-row:last-child { border-bottom: 0; }
+    .agent-list-head {
+      color: #6b7280;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .agent-name { font-weight: 600; }
+    .empty-agents {
+      color: #6b7280;
+      font-size: 13px;
+      padding: 8px 0;
+    }
     .empty {
       display: none;
       padding: 20px;
@@ -157,6 +224,60 @@
       font-family: monospace;
       overflow-wrap: anywhere;
     }
+    .modal-backdrop {
+      align-items: center;
+      background: rgba(17, 24, 39, 0.45);
+      display: none;
+      inset: 0;
+      justify-content: center;
+      padding: 20px;
+      position: fixed;
+      z-index: 10;
+    }
+    .modal-backdrop.visible { display: flex; }
+    .modal {
+      background: #fff;
+      border-radius: 12px;
+      box-shadow: 0 20px 50px rgba(15, 23, 42, 0.18);
+      max-width: 460px;
+      padding: 22px;
+      width: 100%;
+    }
+    .modal h3 { margin-bottom: 6px; }
+    .modal-form {
+      display: grid;
+      gap: 12px;
+      margin-top: 16px;
+    }
+    .field {
+      display: grid;
+      gap: 6px;
+    }
+    .field label {
+      color: #374151;
+      font-size: 13px;
+      font-weight: 600;
+    }
+    .field input, .field select {
+      width: 100%;
+    }
+    .role-note {
+      display: none;
+      background: #fffbeb;
+      border: 1px solid #fde68a;
+      border-radius: 8px;
+      color: #92400e;
+      font-size: 13px;
+      line-height: 1.4;
+      padding: 10px;
+    }
+    .role-note.visible { display: block; }
+    .modal-actions {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+      margin-top: 18px;
+    }
     @media (max-width: 760px) {
       .header { text-align: left; padding-top: 36px; }
       .back-link-container { top: 0; }
@@ -165,6 +286,16 @@
       .section-header { align-items: flex-start; flex-direction: column; }
       .stats.visible { display: grid; grid-template-columns: 1fr; }
       .actions { justify-content: flex-start; }
+      .agent-panel { padding-left: 12px; }
+      .agent-list-row {
+        grid-template-columns: 1fr;
+        gap: 2px;
+        padding: 8px 0;
+      }
+      .agent-list-head { display: none; }
+      .modal-actions {
+        flex-direction: column-reverse;
+      }
     }
   </style>
 </head>
@@ -212,7 +343,7 @@
       </div>
       <div class="row wrap">
         <input id="new-key-name" class="name-input" type="text" placeholder="Key name, e.g. Aaron Demo Key" />
-        <input id="new-key-owner" class="owner-input" type="text" placeholder="Owner" />
+        <input id="new-key-owner" class="owner-input" type="text" placeholder="User name" />
         <select id="new-key-role" class="role-select">
           <option value="user">User</option>
           <option value="admin">Admin</option>
@@ -229,7 +360,7 @@
       <div class="section-header">
         <div>
           <h3>Parent keys</h3>
-          <p>Rename keys, change owner/role, revoke access, and scan current ownership.</p>
+          <p>Rename keys, change user/role, revoke access, and scan current ownership.</p>
         </div>
         <button id="refresh-btn">Refresh</button>
       </div>
@@ -238,10 +369,12 @@
         <table id="keys-table">
           <thead>
             <tr>
+              <th></th>
               <th>Name</th>
-              <th>Owner</th>
+              <th>User name</th>
               <th>Role</th>
               <th>Key hint</th>
+              <th>Agents</th>
               <th>Status</th>
               <th>Created</th>
               <th style="text-align: right;">Actions</th>
@@ -251,6 +384,37 @@
         </table>
       </div>
     </section>
+  </div>
+
+  <div id="edit-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="edit-modal-title">
+    <div class="modal">
+      <h3 id="edit-modal-title">Edit parent key</h3>
+      <p>Update the display details and access role for this parent key.</p>
+      <div class="modal-form">
+        <div class="field">
+          <label for="edit-key-name">Key name</label>
+          <input id="edit-key-name" type="text" />
+        </div>
+        <div class="field">
+          <label for="edit-user-name">User name</label>
+          <input id="edit-user-name" type="text" />
+        </div>
+        <div class="field">
+          <label for="edit-key-role">Role</label>
+          <select id="edit-key-role">
+            <option value="user">User</option>
+            <option value="admin">Admin</option>
+          </select>
+        </div>
+        <div id="edit-role-note" class="role-note">
+          Admins can access this console and manage parent keys.
+        </div>
+      </div>
+      <div class="modal-actions">
+        <button id="edit-cancel-btn">Cancel</button>
+        <button id="edit-save-btn" class="primary">Save changes</button>
+      </div>
+    </div>
   </div>
 
   <script>
@@ -276,9 +440,18 @@
     const keysEmpty = document.getElementById('keys-empty');
     const keysTable = document.getElementById('keys-table');
     const keysTbody = document.getElementById('keys-tbody');
+    const editModal = document.getElementById('edit-modal');
+    const editKeyName = document.getElementById('edit-key-name');
+    const editUserName = document.getElementById('edit-user-name');
+    const editKeyRole = document.getElementById('edit-key-role');
+    const editRoleNote = document.getElementById('edit-role-note');
+    const editCancelBtn = document.getElementById('edit-cancel-btn');
+    const editSaveBtn = document.getElementById('edit-save-btn');
 
     let validated = false;
     let keys = [];
+    let editingKeyId = null;
+    const expandedKeys = new Set();
 
     function authHeaders(extra) {
       return { Authorization: `Bearer ${adminKeyInput.value.trim()}`, ...(extra || {}) };
@@ -375,31 +548,54 @@
       }
     }
 
-    async function editKey(id) {
+    function syncRoleNote() {
+      editRoleNote.classList.toggle('visible', editKeyRole.value === 'admin');
+    }
+
+    function closeEditDialog() {
+      editingKeyId = null;
+      editModal.classList.remove('visible');
+    }
+
+    function openEditDialog(id) {
       const key = keys.find(k => k.id === id);
       if (!key) return;
-      const name = prompt('Key name', key.name || '');
-      if (name == null) return;
-      const owner = prompt('Owner', key.owner || '');
-      if (owner == null) return;
-      const role = prompt('Role: user or admin', key.role || 'user');
-      if (role == null) return;
-      const normalizedRole = role.trim().toLowerCase();
+
+      editingKeyId = id;
+      editKeyName.value = key.name || '';
+      editUserName.value = key.owner || '';
+      editKeyRole.value = key.role === 'admin' ? 'admin' : 'user';
+      syncRoleNote();
+      editModal.classList.add('visible');
+      editKeyName.focus();
+    }
+
+    async function saveEditDialog() {
+      if (!editingKeyId) return;
+
+      const name = editKeyName.value.trim();
+      if (!name) {
+        setStatus('Key name is required.', 'error');
+        return;
+      }
+
+      const normalizedRole = editKeyRole.value;
       if (!['user', 'admin'].includes(normalizedRole)) {
         setStatus('Role must be user or admin.', 'error');
         return;
       }
 
       try {
-        await requestJson(`/v1/admin/api-keys/${encodeURIComponent(id)}`, {
+        await requestJson(`/v1/admin/api-keys/${encodeURIComponent(editingKeyId)}`, {
           method: 'PATCH',
           headers: authHeaders({ 'Content-Type': 'application/json' }),
           body: JSON.stringify({
-            name: name.trim(),
-            owner: owner.trim(),
+            name,
+            owner: editUserName.value.trim(),
             role: normalizedRole
           })
         });
+        closeEditDialog();
         await loadKeys();
       } catch (err) {
         setStatus(err.message, 'error');
@@ -427,6 +623,75 @@
       totalCount.textContent = String(keys.length);
     }
 
+    function createTextCell(value, className) {
+      const cell = document.createElement('td');
+      if (className) cell.className = className;
+      cell.textContent = value || '-';
+      return cell;
+    }
+
+    function renderAgentList(agents) {
+      const panel = document.createElement('div');
+      panel.className = 'agent-panel';
+
+      const title = document.createElement('div');
+      title.className = 'agent-panel-title';
+      title.textContent = 'Agents';
+      const count = document.createElement('span');
+      count.className = 'agent-count-badge';
+      count.textContent = String(agents.length);
+      title.appendChild(count);
+      panel.appendChild(title);
+
+      if (!agents.length) {
+        const empty = document.createElement('div');
+        empty.className = 'empty-agents';
+        empty.textContent = 'No agents have been created with this parent key yet.';
+        panel.appendChild(empty);
+        return panel;
+      }
+
+      const list = document.createElement('div');
+      list.className = 'agent-list';
+
+      const header = document.createElement('div');
+      header.className = 'agent-list-row agent-list-head';
+      for (const label of ['Agent name', 'Agent key', 'Model', 'Created']) {
+        const item = document.createElement('span');
+        item.textContent = label;
+        header.appendChild(item);
+      }
+      list.appendChild(header);
+
+      for (const agent of agents) {
+        const row = document.createElement('div');
+        row.className = 'agent-list-row';
+
+        const name = document.createElement('span');
+        name.className = 'agent-name';
+        name.textContent = agent.name || 'Unnamed agent';
+
+        const hint = document.createElement('span');
+        hint.className = 'key-hint';
+        hint.textContent = agent.key_hint || '-';
+
+        const model = document.createElement('span');
+        model.textContent = agent.model || '-';
+
+        const created = document.createElement('span');
+        created.textContent = formatDate(agent.created_at);
+
+        row.appendChild(name);
+        row.appendChild(hint);
+        row.appendChild(model);
+        row.appendChild(created);
+        list.appendChild(row);
+      }
+
+      panel.appendChild(list);
+      return panel;
+    }
+
     function renderKeys() {
       keysTbody.innerHTML = '';
       keysEmpty.classList.toggle('visible', keys.length === 0);
@@ -434,7 +699,29 @@
 
       for (const key of keys) {
         const revoked = !!key.revoked_at;
+        const agents = Array.isArray(key.agents) ? key.agents : [];
         const tr = document.createElement('tr');
+        tr.classList.toggle('expanded', expandedKeys.has(key.id));
+
+        const expand = document.createElement('td');
+        expand.className = 'expand-cell';
+        const expandButton = document.createElement('button');
+        expandButton.className = 'expand-btn';
+        expandButton.disabled = agents.length === 0;
+        expandButton.setAttribute('aria-label', `Show agents for ${key.name || key.id}`);
+        const chevron = document.createElement('span');
+        chevron.className = 'chevron';
+        chevron.textContent = '›';
+        expandButton.appendChild(chevron);
+        expandButton.addEventListener('click', () => {
+          if (expandedKeys.has(key.id)) {
+            expandedKeys.delete(key.id);
+          } else {
+            expandedKeys.add(key.id);
+          }
+          renderKeys();
+        });
+        expand.appendChild(expandButton);
 
         const name = document.createElement('td');
         name.className = 'name-cell';
@@ -453,14 +740,16 @@
         hint.className = 'key-hint';
         hint.textContent = key.key_hint || '-';
 
+        const agentsCell = document.createElement('td');
+        agentsCell.textContent = agents.length === 1 ? '1 agent' : `${agents.length} agents`;
+
         const status = document.createElement('td');
         const statusBadge = document.createElement('span');
         statusBadge.className = 'badge ' + (revoked ? 'revoked' : 'active');
         statusBadge.textContent = revoked ? 'Revoked' : 'Active';
         status.appendChild(statusBadge);
 
-        const created = document.createElement('td');
-        created.textContent = formatDate(key.created_at);
+        const created = createTextCell(formatDate(key.created_at));
 
         const actions = document.createElement('td');
         const actionWrap = document.createElement('div');
@@ -469,7 +758,7 @@
         const edit = document.createElement('button');
         edit.textContent = 'Edit';
         edit.disabled = revoked;
-        edit.addEventListener('click', () => editKey(key.id));
+        edit.addEventListener('click', () => openEditDialog(key.id));
 
         const revoke = document.createElement('button');
         revoke.className = 'danger';
@@ -481,14 +770,24 @@
         actionWrap.appendChild(revoke);
         actions.appendChild(actionWrap);
 
+        tr.appendChild(expand);
         tr.appendChild(name);
         tr.appendChild(owner);
         tr.appendChild(role);
         tr.appendChild(hint);
+        tr.appendChild(agentsCell);
         tr.appendChild(status);
         tr.appendChild(created);
         tr.appendChild(actions);
         keysTbody.appendChild(tr);
+
+        const agentRow = document.createElement('tr');
+        agentRow.className = 'agent-row';
+        const agentCell = document.createElement('td');
+        agentCell.colSpan = 9;
+        agentCell.appendChild(renderAgentList(agents));
+        agentRow.appendChild(agentCell);
+        keysTbody.appendChild(agentRow);
       }
 
       renderStats();
@@ -503,6 +802,12 @@
     validateBtn.addEventListener('click', validateKey);
     refreshBtn.addEventListener('click', loadKeys);
     createKeyBtn.addEventListener('click', createKey);
+    editCancelBtn.addEventListener('click', closeEditDialog);
+    editSaveBtn.addEventListener('click', saveEditDialog);
+    editKeyRole.addEventListener('change', syncRoleNote);
+    editModal.addEventListener('click', event => {
+      if (event.target === editModal) closeEditDialog();
+    });
   </script>
 </body>
 </html>

--- a/landing-page/public/keys.html
+++ b/landing-page/public/keys.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>API Keys — Ozwell</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      background: #fafafa;
+      min-height: 100vh;
+      padding: 20px;
+      color: #1a1a1a;
+    }
+    .main-container { max-width: 1040px; margin: 0 auto; }
+    .header { text-align: center; margin-bottom: 32px; position: relative; }
+    .back-link-container { position: absolute; left: 0; top: 10px; }
+    .back-link {
+      color: #0066ff;
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+    }
+    .back-link:hover { text-decoration: underline; }
+    .header-title {
+      font-size: 32px;
+      font-weight: 700;
+      margin-bottom: 8px;
+      letter-spacing: -0.025em;
+    }
+    .header-subtitle { font-size: 16px; color: #6b7280; }
+    .section {
+      background: #fff;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 20px;
+    }
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 14px;
+    }
+    h3 { font-size: 16px; font-weight: 700; }
+    p { color: #6b7280; font-size: 14px; margin-bottom: 12px; }
+    .row { display: flex; gap: 8px; align-items: center; }
+    .row.wrap { flex-wrap: wrap; }
+    input, select {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 10px 14px;
+      color: #1a1a1a;
+      font-size: 14px;
+      outline: none;
+    }
+    input:focus, select:focus { border-color: #0066ff; }
+    .key-input { flex: 1; min-width: 280px; font-family: monospace; }
+    .name-input { flex: 1; min-width: 220px; }
+    .owner-input { width: 180px; }
+    .role-select { width: 130px; }
+    button {
+      border: 0;
+      border-radius: 8px;
+      padding: 10px 14px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      background: #e5e7eb;
+      color: #111827;
+    }
+    button.primary { background: #0066ff; color: #fff; }
+    button.danger { background: #dc2626; color: #fff; }
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+    .status {
+      margin-top: 8px;
+      min-height: 18px;
+      font-size: 13px;
+      color: #6b7280;
+    }
+    .status.ok { color: #16a34a; }
+    .status.error { color: #dc2626; }
+    .admin-only { display: none; }
+    .admin-only.visible { display: block; }
+    .stats {
+      display: none;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+      margin-bottom: 20px;
+    }
+    .stats.visible { display: grid; }
+    .stat-card {
+      background: #fff;
+      border-radius: 12px;
+      padding: 18px;
+    }
+    .stat-label { color: #6b7280; font-size: 13px; margin-bottom: 4px; }
+    .stat-value { font-size: 28px; font-weight: 700; }
+    .table-wrap { overflow-x: auto; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+    th, td {
+      text-align: left;
+      border-bottom: 1px solid #e5e7eb;
+      padding: 12px 8px;
+      vertical-align: middle;
+      white-space: nowrap;
+    }
+    th { color: #6b7280; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+    td.name-cell { min-width: 220px; }
+    .key-hint {
+      font-family: monospace;
+      color: #374151;
+    }
+    .badge {
+      display: inline-block;
+      border-radius: 999px;
+      padding: 3px 8px;
+      font-size: 12px;
+      font-weight: 600;
+    }
+    .badge.active { color: #166534; background: #dcfce7; }
+    .badge.revoked { color: #991b1b; background: #fee2e2; }
+    .badge.admin { color: #1d4ed8; background: #dbeafe; }
+    .badge.user { color: #374151; background: #f3f4f6; }
+    .actions { display: flex; gap: 8px; justify-content: flex-end; }
+    .empty {
+      display: none;
+      padding: 20px;
+      text-align: center;
+      color: #6b7280;
+      background: #f9fafb;
+      border-radius: 8px;
+    }
+    .empty.visible { display: block; }
+    .new-key-box {
+      display: none;
+      margin-top: 12px;
+      border: 1px solid #bfdbfe;
+      background: #eff6ff;
+      color: #1e3a8a;
+      border-radius: 8px;
+      padding: 12px;
+    }
+    .new-key-box.visible { display: block; }
+    .new-key-value {
+      display: block;
+      margin-top: 6px;
+      font-family: monospace;
+      overflow-wrap: anywhere;
+    }
+    @media (max-width: 760px) {
+      .header { text-align: left; padding-top: 36px; }
+      .back-link-container { top: 0; }
+      .row { align-items: stretch; flex-direction: column; }
+      .key-input, .name-input, .owner-input, .role-select { min-width: 0; width: 100%; }
+      .section-header { align-items: flex-start; flex-direction: column; }
+      .stats.visible { display: grid; grid-template-columns: 1fr; }
+      .actions { justify-content: flex-start; }
+    }
+  </style>
+</head>
+<body>
+  <div class="main-container">
+    <header class="header">
+      <div class="back-link-container">
+        <a href="/" class="back-link">&larr; Back to demos</a>
+      </div>
+      <h1 class="header-title">API Keys</h1>
+      <p class="header-subtitle">Create and manage parent keys for Ozwell users.</p>
+    </header>
+
+    <section class="section">
+      <h3>Admin key</h3>
+      <p>Only parent keys tagged as <strong>admin</strong> can access this page.</p>
+      <div class="row">
+        <input id="admin-key-input" class="key-input" type="password" placeholder="ozw_your-admin-key" autocomplete="off" />
+        <button id="validate-btn" class="primary">Validate</button>
+      </div>
+      <div id="auth-status" class="status"></div>
+    </section>
+
+    <div id="stats" class="stats">
+      <div class="stat-card">
+        <div class="stat-label">Active keys</div>
+        <div id="active-count" class="stat-value">0</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Revoked keys</div>
+        <div id="revoked-count" class="stat-value">0</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Total keys</div>
+        <div id="total-count" class="stat-value">0</div>
+      </div>
+    </div>
+
+    <section id="create-section" class="section admin-only">
+      <div class="section-header">
+        <div>
+          <h3>Create key</h3>
+          <p>Create a new parent key and copy it immediately.</p>
+        </div>
+      </div>
+      <div class="row wrap">
+        <input id="new-key-name" class="name-input" type="text" placeholder="Key name, e.g. Aaron Demo Key" />
+        <input id="new-key-owner" class="owner-input" type="text" placeholder="Owner" />
+        <select id="new-key-role" class="role-select">
+          <option value="user">User</option>
+          <option value="admin">Admin</option>
+        </select>
+        <button id="create-key-btn" class="primary">Create key</button>
+      </div>
+      <div id="new-key-box" class="new-key-box">
+        New key created. Copy it now.
+        <span id="new-key-value" class="new-key-value"></span>
+      </div>
+    </section>
+
+    <section id="keys-section" class="section admin-only">
+      <div class="section-header">
+        <div>
+          <h3>Parent keys</h3>
+          <p>Rename keys, change owner/role, revoke access, and scan current ownership.</p>
+        </div>
+        <button id="refresh-btn">Refresh</button>
+      </div>
+      <div id="keys-empty" class="empty">No keys found.</div>
+      <div class="table-wrap">
+        <table id="keys-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Owner</th>
+              <th>Role</th>
+              <th>Key hint</th>
+              <th>Status</th>
+              <th>Created</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="keys-tbody"></tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    const referenceBaseUrl = '__REFERENCE_BASE_URL__';
+    const normalizedBase = referenceBaseUrl.replace(/\/$/, '');
+
+    const adminKeyInput = document.getElementById('admin-key-input');
+    const validateBtn = document.getElementById('validate-btn');
+    const authStatus = document.getElementById('auth-status');
+    const stats = document.getElementById('stats');
+    const activeCount = document.getElementById('active-count');
+    const revokedCount = document.getElementById('revoked-count');
+    const totalCount = document.getElementById('total-count');
+    const createSection = document.getElementById('create-section');
+    const keysSection = document.getElementById('keys-section');
+    const refreshBtn = document.getElementById('refresh-btn');
+    const createKeyBtn = document.getElementById('create-key-btn');
+    const newKeyName = document.getElementById('new-key-name');
+    const newKeyOwner = document.getElementById('new-key-owner');
+    const newKeyRole = document.getElementById('new-key-role');
+    const newKeyBox = document.getElementById('new-key-box');
+    const newKeyValue = document.getElementById('new-key-value');
+    const keysEmpty = document.getElementById('keys-empty');
+    const keysTable = document.getElementById('keys-table');
+    const keysTbody = document.getElementById('keys-tbody');
+
+    let validated = false;
+    let keys = [];
+
+    function authHeaders(extra) {
+      return { Authorization: `Bearer ${adminKeyInput.value.trim()}`, ...(extra || {}) };
+    }
+
+    function setStatus(message, type) {
+      authStatus.textContent = message;
+      authStatus.className = 'status' + (type ? ` ${type}` : '');
+    }
+
+    function setAdminVisible(visible) {
+      stats.classList.toggle('visible', visible);
+      createSection.classList.toggle('visible', visible);
+      keysSection.classList.toggle('visible', visible);
+    }
+
+    function formatDate(value) {
+      if (!value) return '-';
+      const date = typeof value === 'number' ? new Date(value * 1000) : new Date(value);
+      if (Number.isNaN(date.getTime())) return String(value);
+      return date.toLocaleString();
+    }
+
+    async function requestJson(path, options) {
+      const resp = await fetch(normalizedBase + path, options);
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok) {
+        throw new Error(data.error?.message || `Request failed (${resp.status})`);
+      }
+      return data;
+    }
+
+    async function validateKey() {
+      const key = adminKeyInput.value.trim();
+      if (!key) {
+        setStatus('Enter a key first.', 'error');
+        return;
+      }
+
+      setStatus('Validating...');
+      try {
+        await requestJson('/v1/admin/api-keys', { headers: { Authorization: `Bearer ${key}` } });
+        validated = true;
+        setStatus('Valid admin key.', 'ok');
+        setAdminVisible(true);
+        await loadKeys();
+      } catch (err) {
+        validated = false;
+        setAdminVisible(false);
+        setStatus(err.message, 'error');
+      }
+    }
+
+    async function loadKeys() {
+      if (!validated) return;
+      setStatus('Loading keys...');
+      try {
+        const data = await requestJson('/v1/admin/api-keys', { headers: authHeaders() });
+        keys = data.data || [];
+        renderKeys();
+        setStatus('Keys loaded.', 'ok');
+      } catch (err) {
+        keys = [];
+        renderKeys();
+        setStatus(err.message, 'error');
+      }
+    }
+
+    async function createKey() {
+      const name = newKeyName.value.trim();
+      if (!name) {
+        setStatus('Enter a key name first.', 'error');
+        return;
+      }
+
+      try {
+        const data = await requestJson('/v1/admin/api-keys', {
+          method: 'POST',
+          headers: authHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify({
+            name,
+            owner: newKeyOwner.value.trim(),
+            role: newKeyRole.value
+          })
+        });
+        newKeyValue.textContent = data.key || '';
+        newKeyBox.classList.add('visible');
+        newKeyName.value = '';
+        newKeyOwner.value = '';
+        newKeyRole.value = 'user';
+        await loadKeys();
+      } catch (err) {
+        setStatus(err.message, 'error');
+      }
+    }
+
+    async function editKey(id) {
+      const key = keys.find(k => k.id === id);
+      if (!key) return;
+      const name = prompt('Key name', key.name || '');
+      if (name == null) return;
+      const owner = prompt('Owner', key.owner || '');
+      if (owner == null) return;
+      const role = prompt('Role: user or admin', key.role || 'user');
+      if (role == null) return;
+      const normalizedRole = role.trim().toLowerCase();
+      if (!['user', 'admin'].includes(normalizedRole)) {
+        setStatus('Role must be user or admin.', 'error');
+        return;
+      }
+
+      try {
+        await requestJson(`/v1/admin/api-keys/${encodeURIComponent(id)}`, {
+          method: 'PATCH',
+          headers: authHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify({
+            name: name.trim(),
+            owner: owner.trim(),
+            role: normalizedRole
+          })
+        });
+        await loadKeys();
+      } catch (err) {
+        setStatus(err.message, 'error');
+      }
+    }
+
+    async function revokeKey(id, name) {
+      if (!confirm(`Revoke "${name || id}"? This key will stop working immediately.`)) return;
+
+      try {
+        await requestJson(`/v1/admin/api-keys/${encodeURIComponent(id)}/revoke`, {
+          method: 'POST',
+          headers: authHeaders()
+        });
+        await loadKeys();
+      } catch (err) {
+        setStatus(err.message, 'error');
+      }
+    }
+
+    function renderStats() {
+      const active = keys.filter(k => !k.revoked_at).length;
+      activeCount.textContent = String(active);
+      revokedCount.textContent = String(keys.length - active);
+      totalCount.textContent = String(keys.length);
+    }
+
+    function renderKeys() {
+      keysTbody.innerHTML = '';
+      keysEmpty.classList.toggle('visible', keys.length === 0);
+      keysTable.style.display = keys.length ? 'table' : 'none';
+
+      for (const key of keys) {
+        const revoked = !!key.revoked_at;
+        const tr = document.createElement('tr');
+
+        const name = document.createElement('td');
+        name.className = 'name-cell';
+        name.textContent = key.name || '(unnamed)';
+
+        const owner = document.createElement('td');
+        owner.textContent = key.owner || '-';
+
+        const role = document.createElement('td');
+        const roleBadge = document.createElement('span');
+        roleBadge.className = 'badge ' + (key.role === 'admin' ? 'admin' : 'user');
+        roleBadge.textContent = key.role === 'admin' ? 'Admin' : 'User';
+        role.appendChild(roleBadge);
+
+        const hint = document.createElement('td');
+        hint.className = 'key-hint';
+        hint.textContent = key.key_hint || '-';
+
+        const status = document.createElement('td');
+        const statusBadge = document.createElement('span');
+        statusBadge.className = 'badge ' + (revoked ? 'revoked' : 'active');
+        statusBadge.textContent = revoked ? 'Revoked' : 'Active';
+        status.appendChild(statusBadge);
+
+        const created = document.createElement('td');
+        created.textContent = formatDate(key.created_at);
+
+        const actions = document.createElement('td');
+        const actionWrap = document.createElement('div');
+        actionWrap.className = 'actions';
+
+        const edit = document.createElement('button');
+        edit.textContent = 'Edit';
+        edit.disabled = revoked;
+        edit.addEventListener('click', () => editKey(key.id));
+
+        const revoke = document.createElement('button');
+        revoke.className = 'danger';
+        revoke.textContent = 'Revoke';
+        revoke.disabled = revoked;
+        revoke.addEventListener('click', () => revokeKey(key.id, key.name));
+
+        actionWrap.appendChild(edit);
+        actionWrap.appendChild(revoke);
+        actions.appendChild(actionWrap);
+
+        tr.appendChild(name);
+        tr.appendChild(owner);
+        tr.appendChild(role);
+        tr.appendChild(hint);
+        tr.appendChild(status);
+        tr.appendChild(created);
+        tr.appendChild(actions);
+        keysTbody.appendChild(tr);
+      }
+
+      renderStats();
+    }
+
+    adminKeyInput.addEventListener('input', () => {
+      validated = false;
+      keys = [];
+      setAdminVisible(false);
+      setStatus('');
+    });
+    validateBtn.addEventListener('click', validateKey);
+    refreshBtn.addEventListener('click', loadKeys);
+    createKeyBtn.addEventListener('click', createKey);
+  </script>
+</body>
+</html>

--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -156,6 +156,9 @@ instructions: |
   <div class="main-container">
     <!-- Header -->
     <header class="header">
+      <a href="/keys.html" class="admin-console-link">
+        Admin Console
+      </a>
       <h1 class="header-title">Ozwell Chatbot Client Demo</h1>
       <p class="header-subtitle">
         Embedded chat with tool execution via MCP JSON-RPC and postMessage

--- a/landing-page/server.js
+++ b/landing-page/server.js
@@ -73,6 +73,14 @@ app.get('/register.html', (req, res) => {
   res.type('html').send(renderHtml('register.html'));
 });
 
+app.get('/keys.html', (req, res) => {
+  res.type('html').send(renderHtml('keys.html'));
+});
+
+app.get('/keys-demo.html', (req, res) => {
+  res.type('html').send(renderHtml('keys-demo.html'));
+});
+
 app.get('*', (req, res, next) => {
   if (req.path === '/' || req.path === '') {
     return res.type('html').send(renderHtml('landing.html'));

--- a/reference-server/src/routes/admin-api-keys.ts
+++ b/reference-server/src/routes/admin-api-keys.ts
@@ -1,7 +1,8 @@
 import { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 import crypto from 'crypto';
-import { agentStore, ApiKeyRole } from '../storage/agents';
-import { createError, extractToken, generateId, isValidApiKey, KEY_PREFIX } from '../util';
+import * as yaml from 'yaml';
+import { agentStore, Agent, ApiKeyRole } from '../storage/agents';
+import { createError, extractToken, formatAgentKeyHint, generateId, isValidApiKey, KEY_PREFIX } from '../util';
 
 async function adminKeyAuth(request: FastifyRequest, reply: FastifyReply): Promise<void> {
     const authorization = request.headers.authorization;
@@ -46,8 +47,45 @@ function parseRole(value: unknown): ApiKeyRole | null {
 
 function publicKeyView(key: ReturnType<typeof agentStore.getApiKeyById>) {
     if (!key) return null;
-    const { key: _fullKey, ...rest } = key;
-    return rest;
+    return {
+        id: key.id,
+        name: key.name,
+        owner: key.owner,
+        key_hint: key.key_hint,
+        role: key.role,
+        created_at: key.created_at,
+        revoked_at: key.revoked_at,
+        created_by: key.created_by,
+    };
+}
+
+function publicAgentView(agent: Agent) {
+    let parsed: { name?: unknown; model?: unknown } = {};
+    try {
+        const value = yaml.parse(agent.yaml);
+        if (value && typeof value === 'object') {
+            parsed = value as { name?: unknown; model?: unknown };
+        }
+    } catch {
+        parsed = {};
+    }
+
+    return {
+        id: agent.id,
+        key_hint: formatAgentKeyHint(agent.agent_key),
+        name: typeof parsed.name === 'string' && parsed.name.trim() ? parsed.name : 'Unnamed agent',
+        model: typeof parsed.model === 'string' && parsed.model.trim() ? parsed.model : null,
+        created_at: agent.created_at,
+    };
+}
+
+function publicKeyViewWithAgents(key: ReturnType<typeof agentStore.getApiKeyById>) {
+    const view = publicKeyView(key);
+    if (!view) return null;
+    return {
+        ...view,
+        agents: agentStore.listByParent(view.id).map(publicAgentView),
+    };
 }
 
 const adminApiKeysRoute: FastifyPluginAsync = async (fastify) => {
@@ -69,7 +107,7 @@ const adminApiKeysRoute: FastifyPluginAsync = async (fastify) => {
     }, async () => {
         return {
             object: 'list',
-            data: agentStore.listApiKeys().map(publicKeyView),
+            data: agentStore.listApiKeys().map(publicKeyViewWithAgents),
         };
     });
 

--- a/reference-server/src/routes/admin-api-keys.ts
+++ b/reference-server/src/routes/admin-api-keys.ts
@@ -1,0 +1,179 @@
+import { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
+import crypto from 'crypto';
+import { agentStore, ApiKeyRole } from '../storage/agents';
+import { createError, extractToken, generateId, isValidApiKey, KEY_PREFIX } from '../util';
+
+async function adminKeyAuth(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const authorization = request.headers.authorization;
+    if (!authorization || !/^bearer\s+/i.test(authorization)) {
+        reply.code(401).send(createError('Authorization header must use Bearer scheme', 'authentication_error', null, 'missing_api_key'));
+        return;
+    }
+
+    const token = extractToken(authorization);
+    if (!token) {
+        reply.code(401).send(createError('Missing API key', 'authentication_error', null, 'missing_api_key'));
+        return;
+    }
+
+    if (!isValidApiKey(token)) {
+        reply.code(401).send(createError('Invalid API key format', 'authentication_error', null, 'invalid_api_key'));
+        return;
+    }
+
+    const apiKey = agentStore.lookupApiKey(token);
+    if (!apiKey) {
+        reply.code(401).send(createError('Invalid API key', 'authentication_error', null, 'invalid_api_key'));
+        return;
+    }
+
+    if (apiKey.role !== 'admin') {
+        reply.code(403).send(createError('Admin API key required', 'authentication_error', null, 'insufficient_permissions'));
+        return;
+    }
+
+    request.apiKey = apiKey;
+}
+
+function generateParentKey(): string {
+    return `${KEY_PREFIX}${crypto.randomBytes(24).toString('hex')}`;
+}
+
+function parseRole(value: unknown): ApiKeyRole | null {
+    if (value == null) return 'user';
+    return value === 'admin' || value === 'user' ? value : null;
+}
+
+function publicKeyView(key: ReturnType<typeof agentStore.getApiKeyById>) {
+    if (!key) return null;
+    const { key: _fullKey, ...rest } = key;
+    return rest;
+}
+
+const adminApiKeysRoute: FastifyPluginAsync = async (fastify) => {
+    const authHeaders = {
+        type: 'object',
+        properties: { authorization: { type: 'string' } },
+        required: ['authorization']
+    };
+
+    const keyIdParam = {
+        type: 'object',
+        properties: { key_id: { type: 'string' } },
+        required: ['key_id']
+    };
+
+    fastify.get('/v1/admin/api-keys', {
+        schema: { headers: authHeaders, tags: ['Admin'], summary: 'List parent API keys' },
+        preHandler: adminKeyAuth
+    }, async () => {
+        return {
+            object: 'list',
+            data: agentStore.listApiKeys().map(publicKeyView),
+        };
+    });
+
+    fastify.post<{ Body: { name?: string; owner?: string; role?: string } }>('/v1/admin/api-keys', {
+        schema: {
+            headers: authHeaders,
+            tags: ['Admin'],
+            summary: 'Create a parent API key',
+            body: {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' },
+                    owner: { type: 'string' },
+                    role: { type: 'string', enum: ['admin', 'user'] }
+                },
+                required: ['name']
+            }
+        },
+        preHandler: adminKeyAuth
+    }, async (request, reply) => {
+        const name = request.body?.name?.trim();
+        if (!name) {
+            reply.code(400);
+            return createError("'name' is required", 'invalid_request_error');
+        }
+
+        const role = parseRole(request.body?.role);
+        if (!role) {
+            reply.code(400);
+            return createError("'role' must be 'admin' or 'user'", 'invalid_request_error');
+        }
+
+        const created = agentStore.createApiKey({
+            id: generateId('api-key'),
+            name,
+            owner: request.body?.owner?.trim() || null,
+            key: generateParentKey(),
+            role,
+            created_by: request.apiKey?.id || null,
+        });
+
+        reply.code(201);
+        reply.header('Cache-Control', 'no-store');
+        return created;
+    });
+
+    fastify.patch<{ Params: { key_id: string }; Body: { name?: string; owner?: string | null; role?: string } }>('/v1/admin/api-keys/:key_id', {
+        schema: {
+            headers: authHeaders,
+            params: keyIdParam,
+            tags: ['Admin'],
+            summary: 'Update parent API key metadata',
+        },
+        preHandler: adminKeyAuth
+    }, async (request, reply) => {
+        const existing = agentStore.getApiKeyById(request.params.key_id);
+        if (!existing) {
+            reply.code(404);
+            return createError('API key not found', 'invalid_request_error');
+        }
+        if (existing.revoked_at) {
+            reply.code(400);
+            return createError('Cannot update a revoked API key', 'invalid_request_error');
+        }
+
+        const name = request.body?.name?.trim() || existing.name;
+        const role = parseRole(request.body?.role ?? existing.role);
+        if (!role) {
+            reply.code(400);
+            return createError("'role' must be 'admin' or 'user'", 'invalid_request_error');
+        }
+
+        const updated = agentStore.updateApiKey(request.params.key_id, {
+            name,
+            owner: request.body?.owner == null ? existing.owner : request.body.owner.trim() || null,
+            role,
+        });
+        return publicKeyView(updated);
+    });
+
+    fastify.post<{ Params: { key_id: string } }>('/v1/admin/api-keys/:key_id/revoke', {
+        schema: {
+            headers: authHeaders,
+            params: keyIdParam,
+            tags: ['Admin'],
+            summary: 'Revoke a parent API key',
+        },
+        preHandler: adminKeyAuth
+    }, async (request, reply) => {
+        const existing = agentStore.getApiKeyById(request.params.key_id);
+        if (!existing) {
+            reply.code(404);
+            return createError('API key not found', 'invalid_request_error');
+        }
+
+        const revoked = agentStore.revokeApiKey(request.params.key_id);
+        if (!revoked) {
+            reply.code(400);
+            return createError('API key is already revoked', 'invalid_request_error');
+        }
+
+        reply.header('Cache-Control', 'no-store');
+        return publicKeyView(revoked);
+    });
+};
+
+export default adminApiKeysRoute;

--- a/reference-server/src/routes/agents.ts
+++ b/reference-server/src/routes/agents.ts
@@ -9,6 +9,7 @@ declare module 'fastify' {
         apiKey?: {
             id: string;
             name: string;
+            role?: string;
         };
     }
 }

--- a/reference-server/src/server.ts
+++ b/reference-server/src/server.ts
@@ -14,6 +14,7 @@ import responsesRoute from './routes/responses';
 import embeddingsRoute from './routes/embeddings';
 import filesRoute from './routes/files';
 import agentsRoute from './routes/agents';
+import adminApiKeysRoute from './routes/admin-api-keys';
 import { getDatabase, initializeAuthTables, seedDemoData, seedMockAgent } from './storage/agents';
 // Import schemas for OpenAPI generation
 import * as schemas from '../../spec';
@@ -141,6 +142,7 @@ async function buildServer() {
   await fastify.register(embeddingsRoute);
   await fastify.register(filesRoute);
   await fastify.register(agentsRoute);  // Agent registration CRUD
+  await fastify.register(adminApiKeysRoute);  // Admin parent-key management
 
   // Serve public assets (documentation, misc)
   await fastify.register(fastifyStatic, {

--- a/reference-server/src/server.ts
+++ b/reference-server/src/server.ts
@@ -30,7 +30,7 @@ async function buildServer() {
   await fastify.register(cors, {
     origin: true,
     credentials: true,
-    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   });
 
   // Register multipart for file uploads

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import path from 'path';
-import { getKeyHint } from '../util';
+import { formatApiKeyHint } from '../util';
 
 interface DbAgentRow {
     id: string;
@@ -46,24 +46,40 @@ export function initializeAuthTables(db: Database.Database): void {
       );
       CREATE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key);
     `);
+    ensureColumn(db, 'api_keys', 'owner', 'TEXT');
+    ensureColumn(db, 'api_keys', 'role', "TEXT NOT NULL DEFAULT 'user'");
+    ensureColumn(db, 'api_keys', 'revoked_at', 'TEXT');
+    ensureColumn(db, 'api_keys', 'created_by', 'TEXT');
     console.log('[auth] Auth tables initialized');
+}
+
+function ensureColumn(db: Database.Database, table: string, column: string, definition: string): void {
+    const columns = db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[];
+    if (!columns.some(c => c.name === column)) {
+        db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+    }
 }
 
 export function seedDemoData(db: Database.Database): void {
     const demoKeyId = 'demo-key';
     const existing = db.prepare('SELECT id FROM api_keys WHERE id = ?').get(demoKeyId);
     if (existing) {
+        db.prepare(`
+          UPDATE api_keys
+          SET key_hint = ?, owner = COALESCE(owner, ?), role = ?
+          WHERE id = ?
+        `).run(formatApiKeyHint(DEMO_API_KEY), 'Local Demo', 'admin', demoKeyId);
         console.log('[auth] Demo data already exists');
         return;
     }
 
     const now = new Date().toISOString();
-    const keyHint = getKeyHint(DEMO_API_KEY);
+    const keyHint = formatApiKeyHint(DEMO_API_KEY);
 
     db.prepare(`
-      INSERT INTO api_keys (id, name, key, key_hint, created_at)
-      VALUES (?, ?, ?, ?, ?)
-    `).run(demoKeyId, 'Demo Key', DEMO_API_KEY, keyHint, now);
+      INSERT INTO api_keys (id, name, key, key_hint, created_at, owner, role)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(demoKeyId, 'Demo Key', DEMO_API_KEY, keyHint, now, 'Local Demo', 'admin');
 
     console.log('[auth] Demo API key seeded');
 }
@@ -103,6 +119,20 @@ export interface Agent {
     created_at: number;
 }
 
+export type ApiKeyRole = 'admin' | 'user';
+
+export interface ApiKeyRecord {
+    id: string;
+    name: string;
+    owner: string | null;
+    key: string;
+    key_hint: string;
+    role: ApiKeyRole;
+    created_at: string;
+    revoked_at: string | null;
+    created_by: string | null;
+}
+
 export class AgentStore {
     private db: Database.Database;
     private stmtInsert: Database.Statement;
@@ -113,6 +143,11 @@ export class AgentStore {
     private stmtRotateKey: Database.Statement;
     private stmtDeleteOwned: Database.Statement;
     private stmtGetOwned: Database.Statement;
+    private stmtListApiKeys: Database.Statement;
+    private stmtInsertApiKey: Database.Statement;
+    private stmtGetApiKeyById: Database.Statement;
+    private stmtUpdateApiKey: Database.Statement;
+    private stmtRevokeApiKey: Database.Statement;
     // Lazy-prepared: api_keys table is created after import by initializeAuthTables()
     private _stmtLookupApiKey: Database.Statement | null = null;
     private _stmtValidateKey: Database.Statement | null = null;
@@ -138,6 +173,30 @@ export class AgentStore {
         `);
         this.stmtDeleteOwned = this.db.prepare('DELETE FROM agents WHERE id = ? AND parent_key = ?');
         this.stmtGetOwned = this.db.prepare('SELECT * FROM agents WHERE id = ? AND parent_key = ?');
+        this.stmtListApiKeys = this.db.prepare(`
+          SELECT id, name, owner, key, key_hint, role, created_at, revoked_at, created_by
+          FROM api_keys
+          ORDER BY revoked_at IS NOT NULL, created_at DESC
+        `);
+        this.stmtInsertApiKey = this.db.prepare(`
+          INSERT INTO api_keys (id, name, owner, key, key_hint, role, created_at, created_by)
+          VALUES (@id, @name, @owner, @key, @key_hint, @role, @created_at, @created_by)
+        `);
+        this.stmtGetApiKeyById = this.db.prepare(`
+          SELECT id, name, owner, key, key_hint, role, created_at, revoked_at, created_by
+          FROM api_keys
+          WHERE id = ?
+        `);
+        this.stmtUpdateApiKey = this.db.prepare(`
+          UPDATE api_keys
+          SET name = @name, owner = @owner, role = @role
+          WHERE id = @id AND revoked_at IS NULL
+        `);
+        this.stmtRevokeApiKey = this.db.prepare(`
+          UPDATE api_keys
+          SET revoked_at = @revoked_at
+          WHERE id = @id AND revoked_at IS NULL
+        `);
     }
 
     private initTable() {
@@ -152,6 +211,7 @@ export class AgentStore {
       CREATE INDEX IF NOT EXISTS idx_agents_agent_key ON agents(agent_key);
       CREATE INDEX IF NOT EXISTS idx_agents_parent_key ON agents(parent_key);
     `);
+        initializeAuthTables(this.db);
     }
 
     /** Check if a token is a valid parent or agent key (single query) */
@@ -159,6 +219,7 @@ export class AgentStore {
         if (!this._stmtValidateKey) {
             this._stmtValidateKey = this.db.prepare(`
               SELECT 1 FROM api_keys WHERE key = ?
+                AND revoked_at IS NULL
               UNION ALL
               SELECT 1 FROM agents WHERE agent_key = ?
               LIMIT 1
@@ -167,12 +228,50 @@ export class AgentStore {
         return !!this._stmtValidateKey.get(token, token);
     }
 
-    /** Look up a parent API key — returns { id, name } or undefined */
-    lookupApiKey(key: string): { id: string; name: string } | undefined {
+    /** Look up an active parent API key. */
+    lookupApiKey(key: string): Pick<ApiKeyRecord, 'id' | 'name' | 'role'> | undefined {
         if (!this._stmtLookupApiKey) {
-            this._stmtLookupApiKey = this.db.prepare('SELECT id, name FROM api_keys WHERE key = ?');
+            this._stmtLookupApiKey = this.db.prepare('SELECT id, name, role FROM api_keys WHERE key = ? AND revoked_at IS NULL');
         }
-        return this._stmtLookupApiKey.get(key) as { id: string; name: string } | undefined;
+        return this._stmtLookupApiKey.get(key) as Pick<ApiKeyRecord, 'id' | 'name' | 'role'> | undefined;
+    }
+
+    listApiKeys(): ApiKeyRecord[] {
+        return this.stmtListApiKeys.all() as ApiKeyRecord[];
+    }
+
+    createApiKey(params: {
+        id: string;
+        name: string;
+        owner: string | null;
+        key: string;
+        role: ApiKeyRole;
+        created_by: string | null;
+    }): ApiKeyRecord {
+        const created_at = new Date().toISOString();
+        const key_hint = formatApiKeyHint(params.key);
+        const record = { ...params, key_hint, created_at, revoked_at: null };
+        this.stmtInsertApiKey.run(record);
+        return record;
+    }
+
+    updateApiKey(id: string, updates: { name: string; owner: string | null; role: ApiKeyRole }): ApiKeyRecord | null {
+        const existing = this.getApiKeyById(id);
+        if (!existing || existing.revoked_at) return null;
+        this.stmtUpdateApiKey.run({ id, ...updates });
+        return this.getApiKeyById(id);
+    }
+
+    revokeApiKey(id: string): ApiKeyRecord | null {
+        const existing = this.getApiKeyById(id);
+        if (!existing || existing.revoked_at) return null;
+        this.stmtRevokeApiKey.run({ id, revoked_at: new Date().toISOString() });
+        return this.getApiKeyById(id);
+    }
+
+    getApiKeyById(id: string): ApiKeyRecord | null {
+        const row = this.stmtGetApiKeyById.get(id) as ApiKeyRecord | undefined;
+        return row ?? null;
     }
 
     createAgent(params: { id: string; agent_key: string; parent_key: string; yaml: string }): Agent {

--- a/reference-server/src/util/index.ts
+++ b/reference-server/src/util/index.ts
@@ -14,6 +14,11 @@ export function formatAgentKeyHint(key: string): string {
   return `${AGENT_KEY_PREFIX}key-...${getKeyHint(key)}`;
 }
 
+/** Format a parent API key as a display hint: ozw_...XXXX */
+export function formatApiKeyHint(key: string): string {
+  return `${KEY_PREFIX}...${getKeyHint(key)}`;
+}
+
 /** Check if a key has a valid parent key prefix */
 export function isValidApiKey(key: string): boolean {
   return key.startsWith(KEY_PREFIX);

--- a/reference-server/test/admin-api-keys.test.js
+++ b/reference-server/test/admin-api-keys.test.js
@@ -128,3 +128,65 @@ test('admin API keys route — non-admin parent key cannot manage keys', async (
         stopServer(server, tmp);
     }
 });
+
+test('admin API keys route — list includes agents created by each parent key', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+
+        const createKey = await jsonFetch('/v1/admin/api-keys', {
+            method: 'POST',
+            headers: headers(DEMO_KEY, { 'Content-Type': 'application/json' }),
+            body: JSON.stringify({ name: 'Agent Owner Key', owner: 'Agent Owner', role: 'user' })
+        });
+        assert.equal(createKey.response.status, 201);
+
+        const createAgent = await jsonFetch('/v1/agents', {
+            method: 'POST',
+            headers: headers(createKey.body.key, { 'Content-Type': 'application/yaml' }),
+            body: [
+                'name: Intake Assistant',
+                'instructions: Help with intake questions.',
+                'model: gpt-4.1-mini',
+                ''
+            ].join('\n')
+        });
+        assert.equal(createAgent.response.status, 201);
+
+        const list = await jsonFetch('/v1/admin/api-keys', { headers: headers() });
+        assert.equal(list.response.status, 200);
+
+        const row = list.body.data.find(k => k.id === createKey.body.id);
+        assert.ok(row, 'created key appears in admin key list');
+        assert.ok(Array.isArray(row.agents), 'admin key row includes agents array');
+        assert.equal(row.agents.length, 1);
+        assert.equal(row.agents[0].id, createAgent.body.agent_id);
+        assert.equal(row.agents[0].name, 'Intake Assistant');
+        assert.equal(row.agents[0].model, 'gpt-4.1-mini');
+        assert.equal(row.agents[0].key_hint, createAgent.body.key_hint);
+        assert.equal(row.agents[0].agent_key, undefined, 'admin key list does not expose full agent keys');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('admin API keys route — CORS preflight allows editing parent keys', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+
+        const response = await fetch(`${BASE}/v1/admin/api-keys/demo-key`, {
+            method: 'OPTIONS',
+            headers: {
+                Origin: 'http://localhost:8080',
+                'Access-Control-Request-Method': 'PATCH',
+                'Access-Control-Request-Headers': 'authorization,content-type',
+            },
+        });
+
+        assert.equal(response.status, 204);
+        assert.match(response.headers.get('access-control-allow-methods') || '', /\bPATCH\b/);
+    } finally {
+        stopServer(server, tmp);
+    }
+});

--- a/reference-server/test/admin-api-keys.test.js
+++ b/reference-server/test/admin-api-keys.test.js
@@ -1,0 +1,130 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const DEMO_KEY = 'ozw_demo_localhost_key_for_testing';
+const PORT = 3336;
+const BASE = `http://localhost:${PORT}`;
+
+async function waitForReady(maxMs = 10_000) {
+    const start = Date.now();
+    while (Date.now() - start < maxMs) {
+        try {
+            const r = await fetch(`${BASE}/health`);
+            if (r.status === 200) return;
+        } catch { /* not ready */ }
+        await delay(200);
+    }
+    throw new Error('server never became ready');
+}
+
+function startServer() {
+    const tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-admin-keys-test-'));
+    const dbPath = path.join(tmp, 'ozwell.db');
+    const server = spawn('npm', ['run', 'dev'], {
+        cwd: process.cwd(),
+        stdio: 'pipe',
+        detached: true,
+        env: { ...process.env, PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development' }
+    });
+    return { server, tmp };
+}
+
+function stopServer(server, tmp) {
+    try { process.kill(-server.pid, 'SIGKILL'); } catch { /* ignore */ }
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+function headers(key = DEMO_KEY, extra = {}) {
+    return { Authorization: `Bearer ${key}`, ...extra };
+}
+
+async function jsonFetch(pathname, options = {}) {
+    const response = await fetch(`${BASE}${pathname}`, options);
+    const body = await response.json().catch(() => ({}));
+    return { response, body };
+}
+
+test('admin API keys route — admin can create, list, rename, and revoke parent keys', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+
+        const create = await jsonFetch('/v1/admin/api-keys', {
+            method: 'POST',
+            headers: headers(DEMO_KEY, { 'Content-Type': 'application/json' }),
+            body: JSON.stringify({ name: 'Aaron Demo Key', owner: 'Aaron', role: 'user' })
+        });
+        assert.equal(create.response.status, 201);
+        assert.match(create.body.key, /^ozw_/);
+        assert.equal(create.body.name, 'Aaron Demo Key');
+        assert.equal(create.body.owner, 'Aaron');
+        assert.equal(create.body.role, 'user');
+
+        const createdKey = create.body.key;
+
+        const list = await jsonFetch('/v1/admin/api-keys', { headers: headers() });
+        assert.equal(list.response.status, 200);
+        const row = list.body.data.find(k => k.id === create.body.id);
+        assert.ok(row, 'created key appears in list');
+        assert.equal(row.key, undefined, 'list does not expose full key');
+        assert.equal(row.key_hint, create.body.key_hint);
+        assert.equal(row.revoked_at, null);
+
+        const rename = await jsonFetch(`/v1/admin/api-keys/${encodeURIComponent(create.body.id)}`, {
+            method: 'PATCH',
+            headers: headers(DEMO_KEY, { 'Content-Type': 'application/json' }),
+            body: JSON.stringify({ name: 'Aaron Prod Key', owner: 'Anshul', role: 'admin' })
+        });
+        assert.equal(rename.response.status, 200);
+        assert.equal(rename.body.name, 'Aaron Prod Key');
+        assert.equal(rename.body.owner, 'Anshul');
+        assert.equal(rename.body.role, 'admin');
+
+        const revoke = await jsonFetch(`/v1/admin/api-keys/${encodeURIComponent(create.body.id)}/revoke`, {
+            method: 'POST',
+            headers: headers()
+        });
+        assert.equal(revoke.response.status, 200);
+        assert.ok(revoke.body.revoked_at);
+
+        const validate = await jsonFetch('/v1/keys/validate', {
+            headers: headers(createdKey)
+        });
+        assert.equal(validate.response.status, 401, 'revoked key no longer validates');
+
+        const createAgent = await jsonFetch('/v1/agents', {
+            method: 'POST',
+            headers: headers(createdKey, { 'Content-Type': 'application/yaml' }),
+            body: 'name: Blocked\ninstructions: should not work\n'
+        });
+        assert.equal(createAgent.response.status, 401, 'revoked key cannot manage agents');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('admin API keys route — non-admin parent key cannot manage keys', async () => {
+    const { server, tmp } = startServer();
+    try {
+        await waitForReady();
+
+        const create = await jsonFetch('/v1/admin/api-keys', {
+            method: 'POST',
+            headers: headers(DEMO_KEY, { 'Content-Type': 'application/json' }),
+            body: JSON.stringify({ name: 'Regular User Key', owner: 'User', role: 'user' })
+        });
+        assert.equal(create.response.status, 201);
+
+        const denied = await jsonFetch('/v1/admin/api-keys', {
+            headers: headers(create.body.key)
+        });
+        assert.equal(denied.response.status, 403);
+    } finally {
+        stopServer(server, tmp);
+    }
+});


### PR DESCRIPTION
## Summary
- add an admin-only key management page for parent API keys
- add admin API routes to list, create, update, and revoke parent keys
- add owner/role/revocation metadata to stored parent keys
- show agents created under each parent key in the admin console
- allow admins to edit key name, user name, and role from an in-page dialog
- add regression coverage for admin access, non-admin blocking, revoked-key behavior, agent listing, and PATCH CORS

## Validation
- git diff --check
- node --test test/admin-api-keys.test.js
- npm test from reference-server
- npm run build from reference-server
- landing-page npm test
- root npm test
- root npm run build --workspaces --if-present
- act reference-server CI
- act landing-page e2e
- act deploy-demo build

Closes #147
Closes #153
Closes #154