### PR TITLE
Update React wrapper for current widget spec

### DIFF
--- a/docs/frontend/react.md
+++ b/docs/frontend/react.md
@@ -21,11 +21,8 @@ function App() {
   return (
     <div>
       <h1>My App</h1>
-      {/* apiKey and agentId are coming soon - use endpoint for now */}
       <OzwellChat
-        endpoint="/v1/chat/completions"
-        // apiKey="ozw_scoped_xxxxxxxx"  // Coming soon
-        // agentId="agent_xxxxxxxx"      // Coming soon
+        apiKey="agnt_key-xxxxxxxx"
       />
     </div>
   );
@@ -44,15 +41,14 @@ The main chat widget component.
 import { OzwellChat } from '@ozwell/react';
 
 <OzwellChat
-  apiKey="ozw_scoped_xxxxxxxx"
-  agentId="agent_xxxxxxxx"
+  apiKey="agnt_key-xxxxxxxx"
   theme="auto"
   position="bottom-right"
   primaryColor="#4f46e5"
   width="400px"
   height="600px"
   autoOpen={false}
-  greeting="Hello! How can I help?"
+  welcomeMessage="Hello! How can I help?"
   placeholder="Type a message..."
   onReady={() => console.log('Ready')}
   onOpen={() => console.log('Opened')}
@@ -65,22 +61,23 @@ import { OzwellChat } from '@ozwell/react';
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `apiKey` | `string` | — | Scoped API key (coming soon, will be required) |
-| `agentId` | `string` | — | Agent ID (coming soon, will be required) |
+| `apiKey` | `string` | — | Ozwell auth key. Prefer `agnt_key-*` for configured agents; use `ozw_*` with explicit `system`, `tools`, and other config |
+| `agentId` | `string` | — | Deprecated; current widget uses `apiKey` for configured agents |
 | `endpoint` | `string` | — | API endpoint URL |
 | `model` | `string` | — | Model name (optional, auto-selected if not specified) |
 | `system` | `string` | — | System prompt for the assistant |
 | `welcomeMessage` | `string` | — | Welcome message shown when chat opens |
 | `title` | `string` | — | Chat widget title |
+| `thinkingEnabled` | `boolean` | `false` | Show reasoning/thinking UI when supported by the model |
+| `thinkingDefaultMode` | `0 \| 1 \| 2 \| 3` | `2` | Reasoning display mode: None, Peek, Smart, Expanded |
+| `exposeUnreadEvent` | `boolean` | `false` | Opt in to `ozwell-chat-unread` events from the loader |
 | `theme` | `'light' \| 'dark' \| 'auto'` | `'auto'` | Color theme (coming soon) |
 | `position` | `'bottom-right' \| 'bottom-left'` | `'bottom-right'` | Widget position (coming soon) |
 | `primaryColor` | `string` | `'#4f46e5'` | Accent color (coming soon) |
 | `width` | `string \| number` | `360` | Chat window width |
 | `height` | `string \| number` | `420` | Chat window height |
 | `autoOpen` | `boolean` | `false` | Open on mount (coming soon) |
-| `greeting` | `string` | Agent default | Initial message |
 | `placeholder` | `string` | `'Type a message...'` | Input placeholder |
-| `context` | `Record<string, unknown>` | `{}` | Context data for agent |
 | `tools` | `OzwellTool[]` | `[]` | MCP tools available to the AI |
 | `debug` | `boolean` | `false` | Enable debug mode |
 | `openaiApiKey` | `string` | — | OpenAI API key (for direct OpenAI endpoint) |
@@ -90,8 +87,7 @@ import { OzwellChat } from '@ozwell/react';
 | `onReady` | `() => void` | — | Widget ready callback |
 | `onOpen` | `() => void` | — | Chat opened callback |
 | `onClose` | `() => void` | — | Chat closed callback |
-| `onInsert` | `(data: { text: string; close: boolean }) => void` | — | User inserts text to parent page |
-| `onToolCall` | `(tool, args, sendResult) => void` | — | Tool call handler (see below) |
+| `onToolCall` | `(tool, args, sendResult, sendError?) => void` | — | Tool call handler (see below) |
 | `onUserShare` | `(data: unknown) => void` | — | User shared data callback (requires widget support - coming soon) |
 | `onError` | `(error: OzwellError) => void` | — | Error callback (works for mount errors, more error types coming soon) |
 
@@ -140,45 +136,41 @@ interface UseOzwellReturn {
   open: () => void;
   close: () => void;
   toggle: () => void;
-  sendMessage: (content: string) => void;  // Not yet implemented
-  setContext: (context: Record<string, unknown>) => void;
+  sendMessage: (content: string) => void;
   iframe: HTMLIFrameElement | null;
 }
 ```
 
-> **Note:** `sendMessage` is not yet implemented in the vanilla widget. It will log a warning if called.
+> **Note:** `sendMessage` posts the current widget `send-message` JSON-RPC command into the iframe. The widget must already be mounted and ready.
 
 ---
 
 ## Examples
 
-### With Context Data
-
-Pass user information and page context to the agent:
+### With Agent Key
 
 ```tsx
 import { OzwellChat } from '@ozwell/react';
-import { useUser } from './auth';
-import { useLocation } from 'react-router-dom';
 
 function App() {
-  const user = useUser();
-  const location = useLocation();
-  
   return (
     <OzwellChat
-      endpoint="/v1/chat/completions"
-      // apiKey="ozw_scoped_xxxxxxxx"  // Coming soon
-      // agentId="agent_xxxxxxxx"      // Coming soon
-      context={{
-        userId: user?.id,
-        email: user?.email,
-        page: location.pathname,
-        timestamp: Date.now()
-      }}
+      apiKey="agnt_key-xxxxxxxx"
+      thinkingEnabled={true}
+      thinkingDefaultMode={2}
     />
   );
 }
+```
+
+### With Ozwell API Key
+
+```tsx
+<OzwellChat
+  apiKey="ozw_..."
+  system="You are a helpful assistant."
+  tools={tools}
+/>
 ```
 
 ### Custom Trigger Button
@@ -228,8 +220,7 @@ function App() {
   return (
     <OzwellChat
       endpoint="/v1/chat/completions"
-      // apiKey="ozw_scoped_xxxxxxxx"  // Coming soon
-      // agentId="agent_xxxxxxxx"      // Coming soon
+      apiKey="agnt_key-xxxxxxxx"
       onOpen={() => {
         analytics.track('Chat Opened');
       }}
@@ -358,9 +349,7 @@ The package includes full TypeScript definitions:
 import type { OzwellChatProps, OzwellError } from '@ozwell/react';
 
 const config: OzwellChatProps = {
-  endpoint: '/v1/chat/completions',
-  // apiKey: 'ozw_scoped_xxxxxxxx',  // Coming soon
-  // agentId: 'agent_xxxxxxxx',      // Coming soon
+  apiKey: 'agnt_key-xxxxxxxx',
   // theme: 'dark',                  // Coming soon
   onUserShare: (data: unknown) => {
     // Only fires when user explicitly shares (coming soon)
@@ -382,23 +371,8 @@ const config: OzwellChatProps = {
 ### Widget Not Appearing
 
 1. Ensure the component is mounted in the DOM
-2. Check that the `endpoint` prop is correct (or `apiKey`/`agentId` once available)
+2. Check that the `endpoint` or `apiKey` prop is correct
 3. Look for console errors
-
-### Context Not Updating
-
-The `context` prop is not deeply compared. To trigger updates:
-
-```tsx
-// ❌ Won't trigger update (same object reference)
-const context = { page: location.pathname };
-
-// ✅ Will trigger update (new object)
-const context = useMemo(
-  () => ({ page: location.pathname }),
-  [location.pathname]
-);
-```
 
 ### Multiple Instances
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -40,27 +40,28 @@ function App() {
 }
 ```
 
-> **Note:** This package wraps the existing Ozwell widget. API key authentication and agent configuration are coming soon. Currently uses local endpoint configuration.
+> **Note:** This package wraps the framework-neutral Ozwell embed widget. Prefer `apiKey="agnt_key-..."` for configured agents. You can also use `apiKey="ozw_..."` directly when you provide `system`, `tools`, and other config yourself.
 
 ## Feature Support
 
 ### Currently Available
 - Custom endpoints (`endpoint` prop)
+- Configured agents via `apiKey="agnt_key-..."`
+- Direct Ozwell API keys via `apiKey="ozw_..."` with explicit config
 - Model selection (`model` prop)
 - MCP tool/function calling (`tools` prop, `onToolCall` callback)
-- Context updates (`context` prop)
 - System prompts (`system` prop)
 - Welcome messages (`welcomeMessage` prop)
+- Reasoning UI controls (`thinkingEnabled`, `thinkingDefaultMode`)
 - Debug mode (`debug` prop)
 - OpenAI API compatibility (`openaiApiKey` prop)
 - Custom headers (`headers` prop)
 - Auto-open on AI reply (`autoOpenOnReply` prop)
-- Lifecycle callbacks (`onReady`, `onOpen`, `onClose`, `onInsert`)
+- Lifecycle callbacks (`onReady`, `onOpen`, `onClose`)
 - Error callback for mount errors (`onError` - partial)
 
 ### Coming Soon
-- Scoped API keys (`apiKey` prop)
-- Agent management (`agentId` prop)
+- Separate agent-id configuration (`agentId` prop)
 - Theme customization (`theme`, `primaryColor` props)
 - Position control (`position` prop)
 - Auto-open behavior (`autoOpen` prop)
@@ -175,13 +176,13 @@ The `onToolCall` callback receives:
 - `args` - The arguments passed to the tool
 - `sendResult` - A function to send the result back to the AI
 
-This handles all the postMessage complexity internally, so you just focus on your tool logic.
+The React wrapper listens to the loader's `ozwell-tool-call` DOM event and handles the MCP response callback for you, so you just focus on your tool logic.
 
 ## Documentation
 
 For full documentation, see [React Integration Guide](../../docs/frontend/react.md).
 
-> **Note:** The documentation describes the planned API including `apiKey` and `agentId` props. The current implementation supports `endpoint` and `tools` configuration matching the vanilla JS widget.
+> **Note:** The current embed widget uses `apiKey` for configured agents. `agentId` is kept as a deprecated type for older examples but is not used by the widget.
 
 ## Development
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
-    "test": "echo \"Tests coming soon\"",
+    "test": "tsc -p tsconfig.test.json --noEmit",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },

--- a/packages/react/src/OzwellChat.tsx
+++ b/packages/react/src/OzwellChat.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import type { OzwellChatProps, OzwellConfig, ScriptLoadStatus } from './types';
+import type {
+  OzwellChatProps,
+  OzwellConfig,
+  OzwellToolCallEventDetail,
+  ScriptLoadStatus,
+} from './types';
 
 /**
  * OzwellChat - React component wrapper for Ozwell chat widget
@@ -41,11 +46,12 @@ export function OzwellChat(props: OzwellChatProps) {
     headers,
     widgetUrl,
     autoOpenOnReply,
+    exposeUnreadEvent,
+    thinkingEnabled,
+    thinkingDefaultMode,
 
-    // Future props (not yet implemented in vanilla widget)
-    // These are accepted but ignored until backend support is added
     apiKey,
-    agentId,
+    agentId: _agentId,
     theme: _theme, // Prefix with _ to indicate intentionally unused
     position: _position,
     primaryColor: _primaryColor,
@@ -56,7 +62,7 @@ export function OzwellChat(props: OzwellChatProps) {
     onOpen,
     onClose,
     onToolCall,
-    onUserShare,
+    onUserShare: _onUserShare,
     onError,
 
     // React-specific
@@ -147,16 +153,17 @@ export function OzwellChat(props: OzwellChatProps) {
       openaiApiKey,
       headers,
       widgetUrl,
+      thinkingEnabled,
+      thinkingDefaultMode,
 
       // Layout config
       defaultUI,
       autoMount: false, // Prevent auto-mount, we'll mount manually
       autoOpenOnReply,
+      exposeUnreadEvent,
 
-      // Future props - passed to widget for forward compatibility
-      // When scoped API keys land (PR #53), these will work without React package changes
+      // Current embed uses apiKey for both direct API keys and agnt_key-* agent keys.
       apiKey,
-      agentId,
     };
 
     // Only add containerId if NOT using default UI
@@ -226,87 +233,78 @@ export function OzwellChat(props: OzwellChatProps) {
     widgetUrl,
     defaultUI,
     autoOpenOnReply,
+    exposeUnreadEvent,
+    thinkingEnabled,
+    thinkingDefaultMode,
     width,
     height,
     apiKey,
-    agentId,
     onReady,
     onError,
   ]);
 
-  // Listen for widget events via postMessage (single listener for all events)
+  // Listen for loader DOM events exposed by the current embed contract.
   useEffect(() => {
     if (!isWidgetReady) {
       return;
     }
 
-    const handleMessage = (event: MessageEvent) => {
-      // Validate message comes from our widget iframe
-      const iframe = window.OzwellChat?.iframe;
-      if (iframe && event.source !== iframe.contentWindow) {
-        return;
-      }
-
-      const data = event.data;
-
-      if (!data || typeof data !== 'object' || data.source !== 'ozwell-chat-widget') {
-        return;
-      }
-
-      switch (data.type) {
-        case 'closed':
-          onClose?.();
-          break;
-
-        case 'opened':
-          onOpen?.();
-          break;
-
-        case 'user-share':
-          onUserShare?.(data.payload);
-          break;
-
-        case 'error':
-          onError?.(data.payload);
-          break;
-
-        case 'tool_call':
-          if (onToolCall) {
-            const { tool, tool_call_id, payload: args } = data;
-
-            // Create sendResult function that handles postMessage internally
-            const sendResult = (result: unknown) => {
-              const iframe = window.OzwellChat?.iframe;
-
-              if (iframe?.contentWindow) {
-                // Use specific origin instead of wildcard for security
-                const targetOrigin = iframe.src ? new URL(iframe.src).origin : '*';
-                iframe.contentWindow.postMessage(
-                  {
-                    source: 'ozwell-chat-parent',
-                    type: 'tool_result',
-                    tool_call_id,
-                    result,
-                  },
-                  targetOrigin
-                );
-              } else {
-                console.error('[OzwellChat] Could not find widget iframe to send tool result');
-              }
-            };
-
-            onToolCall(tool, args || {}, sendResult);
-          }
-          break;
-      }
+    const handleClosed = () => {
+      onClose?.();
     };
 
-    window.addEventListener('message', handleMessage);
+    const handleToolCall = (event: Event) => {
+      if (!onToolCall) return;
+      const { detail } = event as CustomEvent<OzwellToolCallEventDetail>;
+      if (!detail || typeof detail.name !== 'string') return;
+      onToolCall(
+        detail.name,
+        detail.arguments || {},
+        detail.respond,
+        detail.error
+      );
+    };
+
+    document.addEventListener('ozwell-chat-closed', handleClosed);
+    document.addEventListener('ozwell-tool-call', handleToolCall);
 
     return () => {
-      window.removeEventListener('message', handleMessage);
+      document.removeEventListener('ozwell-chat-closed', handleClosed);
+      document.removeEventListener('ozwell-tool-call', handleToolCall);
     };
-  }, [isWidgetReady, onClose, onOpen, onUserShare, onError, onToolCall]);
+  }, [isWidgetReady, onClose, onToolCall]);
+
+  // The loader does not emit an open event yet. Track default UI visibility so
+  // React callers still get onOpen/onClose when the built-in button is used.
+  useEffect(() => {
+    if (!isWidgetReady || !defaultUI || (!onOpen && !onClose)) {
+      return;
+    }
+
+    const wrapper = document.getElementById('ozwell-chat-wrapper');
+    if (!wrapper) {
+      return;
+    }
+
+    let wasOpen = wrapper.classList.contains('visible');
+
+    const observer = new MutationObserver(() => {
+      const isOpen = wrapper.classList.contains('visible');
+      if (isOpen === wasOpen) return;
+      wasOpen = isOpen;
+      if (isOpen) {
+        onOpen?.();
+      } else {
+        onClose?.();
+      }
+    });
+
+    observer.observe(wrapper, { attributes: true, attributeFilter: ['class'] });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isWidgetReady, defaultUI, onOpen, onClose]);
 
   // Render container div (only if not using default UI)
   if (defaultUI) {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -29,5 +29,6 @@ export type {
   OzwellParentMessage,
   OzwellToolCallMessage,
   OzwellToolResultMessage,
+  OzwellToolCallEventDetail,
   ScriptLoadStatus,
 } from './types';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -95,12 +95,19 @@ export interface OzwellConfig {
   /** Auto-open chat window when AI replies (default: false) */
   autoOpenOnReply?: boolean;
 
-  // Planned Features (Documented but not yet implemented)
+  /** Dispatch ozwell-chat-unread DOM events when assistant replies while closed (default: false) */
+  exposeUnreadEvent?: boolean;
 
-  /** Scoped API key for authentication */
+  /** Display model reasoning/thinking tokens in the widget UI (default: false) */
+  thinkingEnabled?: boolean;
+
+  /** Reasoning display mode: 0=None, 1=Peek, 2=Smart, 3=Expanded */
+  thinkingDefaultMode?: 0 | 1 | 2 | 3;
+
+  /** Ozwell auth key. Prefer agnt_key-* for configured agents; use ozw_* with explicit config. */
   apiKey?: string;
 
-  /** Agent ID for agent-specific configuration */
+  /** @deprecated The current embed widget uses apiKey for configured agents. */
   agentId?: string;
 }
 
@@ -147,7 +154,8 @@ export interface OzwellChatProps extends Omit<OzwellConfig, 'autoMount'> {
   onToolCall?: (
     tool: string,
     args: Record<string, unknown>,
-    sendResult: (result: unknown) => void
+    sendResult: (result: unknown) => void,
+    sendError?: (message: string) => void
   ) => void;
 
   // Future Callbacks (Documented but not yet implemented)
@@ -258,6 +266,20 @@ export interface OzwellChatAPI {
 }
 
 /**
+ * Detail payload from the loader's ozwell-tool-call DOM event.
+ */
+export interface OzwellToolCallEventDetail {
+  /** Tool function name, with any internal postMessage namespace removed */
+  name: string;
+  /** Tool arguments from the MCP tools/call request */
+  arguments: Record<string, unknown>;
+  /** Send a successful tool result back through the loader's MCP transport */
+  respond: (result: unknown) => void;
+  /** Send a tool error back through the loader's MCP transport */
+  error?: (message: string) => void;
+}
+
+/**
  * Extend Window interface for TypeScript
  */
 declare global {
@@ -281,7 +303,7 @@ export type ScriptLoadStatus = 'idle' | 'loading' | 'ready' | 'error';
  */
 export interface OzwellWidgetMessage {
   source: 'ozwell-chat-widget';
-  type: 'ready' | 'request-config' | 'closed' | 'opened' | 'tool_call' | 'assistant_response' | 'user-share' | 'error';
+  type: 'ready' | 'request-config' | 'closed' | 'assistant_response' | 'user-share' | 'error';
   payload?: unknown;
 }
 

--- a/packages/react/src/useOzwell.ts
+++ b/packages/react/src/useOzwell.ts
@@ -152,18 +152,20 @@ export function useOzwell(): UseOzwellReturn {
       return;
     }
 
-    const iframeWindow = window.OzwellChat?.iframe?.contentWindow;
+    const iframe = window.OzwellChat?.iframe;
+    const iframeWindow = iframe?.contentWindow;
     if (!iframeWindow) {
       console.warn('[useOzwell] Widget iframe not available');
       return;
     }
+    const targetOrigin = iframe.src ? new URL(iframe.src).origin : window.location.origin;
 
     iframeWindow.postMessage({
       jsonrpc: '2.0',
       id: Date.now(),
       method: 'send-message',
       params: { content },
-    }, '*');
+    }, targetOrigin);
   }, [isReady]);
 
   return {

--- a/packages/react/src/useOzwell.ts
+++ b/packages/react/src/useOzwell.ts
@@ -34,8 +34,10 @@ export function useOzwell(): UseOzwellReturn {
   useEffect(() => {
     // Check if already ready
     if (window.OzwellChat) {
-      setIsReady(true);
-      setIframe(window.OzwellChat.iframe);
+      window.OzwellChat.ready().then(() => {
+        setIsReady(true);
+        setIframe(window.OzwellChat?.iframe || null);
+      });
       return;
     }
 
@@ -58,38 +60,39 @@ export function useOzwell(): UseOzwellReturn {
       return;
     }
 
-    const handleMessage = (event: MessageEvent) => {
-      // Validate message comes from our widget iframe
-      const widgetIframe = window.OzwellChat?.iframe;
-      if (widgetIframe && event.source !== widgetIframe.contentWindow) {
-        return;
-      }
+    const wrapper = document.getElementById('ozwell-chat-wrapper');
 
-      const data = event.data;
-
-      if (!data || typeof data !== 'object' || data.source !== 'ozwell-chat-widget') {
-        return;
-      }
-
-      // Track open/close state
-      if (data.type === 'opened') {
-        setIsOpen(true);
-        setHasUnread(false); // Clear unread when opened
-      } else if (data.type === 'closed') {
-        setIsOpen(false);
+    const syncOpenState = () => {
+      const nextIsOpen = window.OzwellChat?.isOpen ?? wrapper?.classList.contains('visible') ?? false;
+      setIsOpen(nextIsOpen);
+      if (nextIsOpen) {
+        setHasUnread(false);
       }
     };
+
+    syncOpenState();
 
     // Listen for unread notification events from the loader
     const handleUnread = () => {
       setHasUnread(true);
     };
 
-    window.addEventListener('message', handleMessage);
+    const handleClosed = () => {
+      setIsOpen(false);
+    };
+
+    let observer: MutationObserver | undefined;
+    if (wrapper) {
+      observer = new MutationObserver(syncOpenState);
+      observer.observe(wrapper, { attributes: true, attributeFilter: ['class'] });
+    }
+
+    document.addEventListener('ozwell-chat-closed', handleClosed);
     document.addEventListener('ozwell-chat-unread', handleUnread);
 
     return () => {
-      window.removeEventListener('message', handleMessage);
+      observer?.disconnect();
+      document.removeEventListener('ozwell-chat-closed', handleClosed);
       document.removeEventListener('ozwell-chat-unread', handleUnread);
     };
   }, [isReady]);
@@ -105,6 +108,8 @@ export function useOzwell(): UseOzwellReturn {
     }
 
     window.OzwellChat?.open?.();
+    setIsOpen(window.OzwellChat?.isOpen ?? true);
+    setHasUnread(false);
   }, [isReady]);
 
   /**
@@ -118,6 +123,7 @@ export function useOzwell(): UseOzwellReturn {
     }
 
     window.OzwellChat?.close?.();
+    setIsOpen(window.OzwellChat?.isOpen ?? false);
   }, [isReady]);
 
   /**
@@ -132,9 +138,8 @@ export function useOzwell(): UseOzwellReturn {
   }, [isOpen, open, close]);
 
   /**
-   * Send a message programmatically
-   * Note: Not yet implemented in vanilla widget
-   * Future: Will send message via widget API
+   * Send a message programmatically.
+   * The iframe supports the current JSON-RPC send-message method.
    */
   const sendMessage = useCallback((content: string) => {
     if (!isReady) {
@@ -147,11 +152,18 @@ export function useOzwell(): UseOzwellReturn {
       return;
     }
 
-    // Placeholder for future implementation
-    console.warn('[useOzwell] sendMessage() not yet implemented in vanilla widget');
+    const iframeWindow = window.OzwellChat?.iframe?.contentWindow;
+    if (!iframeWindow) {
+      console.warn('[useOzwell] Widget iframe not available');
+      return;
+    }
 
-    // Future implementation:
-    // window.OzwellChat?.sendMessage?.(content);
+    iframeWindow.postMessage({
+      jsonrpc: '2.0',
+      id: Date.now(),
+      method: 'send-message',
+      params: { content },
+    }, '*');
   }, [isReady]);
 
   return {

--- a/packages/react/test/contract-types.ts
+++ b/packages/react/test/contract-types.ts
@@ -1,0 +1,59 @@
+import type {
+  OzwellChatProps,
+  OzwellConfig,
+  OzwellToolCallEventDetail,
+  UseOzwellReturn,
+} from '../src';
+
+const config: OzwellConfig = {
+  apiKey: 'agnt_key-test',
+  thinkingEnabled: true,
+  thinkingDefaultMode: 2,
+  exposeUnreadEvent: true,
+};
+
+const props: OzwellChatProps = {
+  apiKey: 'agnt_key-test',
+  thinkingEnabled: true,
+  thinkingDefaultMode: 1,
+  exposeUnreadEvent: true,
+  onToolCall: (tool, args, sendResult, sendError) => {
+    tool.toUpperCase();
+    Object.keys(args);
+    sendResult({ success: true });
+    sendError?.('failed');
+  },
+};
+
+const directKeyProps: OzwellChatProps = {
+  apiKey: 'ozw_test',
+  system: 'You are a helpful assistant.',
+  tools: [],
+};
+
+const detail: OzwellToolCallEventDetail = {
+  name: 'update_form',
+  arguments: { email: 'a@example.com' },
+  respond: (result) => {
+    JSON.stringify(result);
+  },
+  error: (message) => {
+    message.toUpperCase();
+  },
+};
+
+const hookReturn: Pick<UseOzwellReturn, 'sendMessage'> = {
+  sendMessage: (content) => {
+    content.toUpperCase();
+  },
+};
+
+// @ts-expect-error thinkingDefaultMode only supports 0=None, 1=Peek, 2=Smart, 3=Expanded.
+const invalidMode: OzwellConfig['thinkingDefaultMode'] = 4;
+
+void config;
+void props;
+void directKeyProps;
+void detail;
+void hookReturn;
+void invalidMode;

--- a/packages/react/tsconfig.test.json
+++ b/packages/react/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test/**/*"]
+}


### PR DESCRIPTION
## Summary
- update @ozwell/react config/types for current widget fields, including reasoning controls and configured-agent apiKey usage
- switch tool handling to the loader's ozwell-tool-call DOM event contract
- wire useOzwell sendMessage to the widget JSON-RPC send-message command
- refresh React docs and add a type-contract test

## Verification
- npm test
- npm run lint
- npm run build

Refs #106.
Stacked on #136.