### PR TITLE
fix: chat reliability for parent-key + page-side tools on strict providers

### DIFF
--- a/.github/workflows/landing-page-e2e.yml
+++ b/.github/workflows/landing-page-e2e.yml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Start reference server
         working-directory: ./reference-server
+        env:
+          ALLOW_MOCK: 'true'  # no LLM configured in CI — e2e relies on deterministic mock responses
         run: |
           npm start > /tmp/reference-server.log 2>&1 &
           echo $! > /tmp/reference-server.pid

--- a/.github/workflows/test-reference-server.yml
+++ b/.github/workflows/test-reference-server.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Test reference server
         working-directory: ${{ inputs.working-directory }}
+        env:
+          ALLOW_MOCK: 'true'  # mock-agent + fallback tests need mock responses enabled
         run: npm test
         continue-on-error: true  # In case test script doesn't exist yet
 

--- a/docs/backend/agents.md
+++ b/docs/backend/agents.md
@@ -157,7 +157,7 @@ Create a new agent with a YAML configuration wrapped in JSON.
 | `model` | string | No | Model ID (default: server's configured model). On the LLM backend, if the model doesn't exist on the current provider, the server falls back to `LLM_MODEL`. |
 | `temperature` | number | No | Sampling temperature 0-2 (default: `0.7`) |
 | `tools` | array | No | Server-side tool definitions. Each entry can be a name string or an object with `name`, `description`, and `inputSchema` fields. These are always available to the agent. Page-provided tools are separate and controlled by `pageTools`. |
-| `pageTools` | string or object | No | Controls which page-provided tools (via `postMessage:`) the agent can call. `all` (default) — accept everything. `{ restricted: [...] }` — only these page tools. `{ blocked: [...] }` — all page tools except these. |
+| `pageTools` | string or object | No | Controls which page-provided tools (via `postMessage_` prefix) the agent can call. `all` (default) — accept everything. `{ restricted: [...] }` — only these page tools. `{ blocked: [...] }` — all page tools except these. |
 | `behavior` | object | No | Optional tone and rules (e.g., `tone`, `rules` array) |
 
 #### Example

--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -95,7 +95,7 @@ When the AI calls a tool, the loader dispatches an `ozwell-tool-call` event. Lis
 
 ### Tool Namespacing
 
-Page-provided tools are automatically prefixed with `postMessage:` on the wire so they can't collide with tools the agent server implements natively. This is transparent to your page — the prefix is added by the loader when the widget discovers tools, and stripped before your `ozwell-tool-call` handler fires. You never see the prefix in your code.
+Page-provided tools are automatically prefixed with `postMessage_` on the wire so they can't collide with tools the agent server implements natively. This is transparent to your page — the prefix is added by the loader when the widget discovers tools, and stripped before your `ozwell-tool-call` handler fires. You never see the prefix in your code.
 
 ### Controlling Page Tools
 

--- a/reference-server/.env.example
+++ b/reference-server/.env.example
@@ -79,5 +79,6 @@ OLLAMA_BASE_URL=http://localhost:11434
 # demos without an LLM.
 # ALLOW_MOCK=true
 #
-# Model name reported in mock responses (cosmetic; mock output ignores it).
+# Fallback/default model used when no backend-specific model is selected or when
+# a configured model is unavailable. Mock responses always report model: "ozwell-mock".
 # DEFAULT_MODEL=gpt-4o-mini

--- a/reference-server/.env.example
+++ b/reference-server/.env.example
@@ -62,7 +62,22 @@ OLLAMA_BASE_URL=http://localhost:11434
 # Common models: llama3.2:latest, llama3.1:latest, mistral:latest, qwen2.5-coder:3b
 
 # ============================================
-# FALLBACK
+# OUTPUT LIMIT
 # ============================================
-# Model name used in mock responses when no backend is available.
+# No output cap by default — the provider's own default applies.
+# Set LLM_MAX_TOKENS to impose a server-wide ceiling on completion length.
+# A client that sends its own max_tokens always overrides this.
+# LLM_MAX_TOKENS=4096
+
+# ============================================
+# MOCK RESPONSES
+# ============================================
+# Mock responses are OFF by default, so a real LLM/Ollama failure surfaces as a
+# 503 error instead of a fake reply. Set ALLOW_MOCK=true to return deterministic
+# mock responses when no backend is configured, the backend errors, or an agent
+# is declared type: mock. Keep this OFF in production; enable for local dev or
+# demos without an LLM.
+# ALLOW_MOCK=true
+#
+# Model name reported in mock responses (cosmetic; mock output ignores it).
 # DEFAULT_MODEL=gpt-4o-mini

--- a/reference-server/README.md
+++ b/reference-server/README.md
@@ -5,7 +5,7 @@ An OpenAI-compatible Fastify server that provides a reference implementation of 
 ## Features
 
 - **Full OpenAI API Compatibility**: Wire-compatible with OpenAI's API specification
-- **Multi-Backend LLM Support**: Connects to OpenAI, Portkey Gateway, Ollama, or falls back to deterministic mock responses
+- **Multi-Backend LLM Support**: Connects to OpenAI, Portkey Gateway, Ollama, or opt-in deterministic mock responses
 - **MCP Host**: Built-in WebSocket endpoint (`/mcp/ws`) and embeddable chat widget
 - **Streaming Support**: Server-Sent Events (SSE) for both `/v1/responses` and `/v1/chat/completions`
 - **File Management**: Complete file upload, download, and management system
@@ -515,7 +515,7 @@ If the client sends a `model` field in the request, it is used as-is. Otherwise 
 |---------|-----------------|----------------|------------------------------------------------------|
 | LLM     | `LLM_MODEL`    | `gpt-4o-mini`  | `gpt-4.1-mini`, `gpt-4o`, `claude-sonnet-4-20250514` |
 | Ollama  | `OLLAMA_MODEL`  | auto-detect    | `llama3.1:latest`, `mistral:latest`                  |
-| Mock    | `DEFAULT_MODEL` | `gpt-4o-mini`  | cosmetic — mock ignores it                           |
+| Mock    | `DEFAULT_MODEL` | `gpt-4o-mini`  | fallback/default selection; mock responses report `ozwell-mock` |
 
 **Model fallback (LLM backend only):** If the agent's model doesn't exist on the current provider (e.g. an Ollama model when using OpenAI), the server automatically retries with `LLM_MODEL` and the chat widget shows a toast notification explaining the switch.
 

--- a/reference-server/README.md
+++ b/reference-server/README.md
@@ -261,12 +261,14 @@ The server will start at `http://localhost:3000`
 
 **Watch Demo:** [YouTube Short](https://youtube.com/shorts/mqcoEoQzQMM?si=FLa_dq_4y2TeO_48)
 
-The demo runs in mock AI mode by default (keyword-based pattern matching via `/mock/chat`). To use real LLM responses, configure a backend in your `.env` file:
+To get real AI responses, configure a backend in your `.env` file:
 
 - **Any provider:** Set `LLM_BASE_URL` and `LLM_API_KEY` to point at OpenAI, Portkey Gateway, or any OpenAI-compatible API.
 - **Ollama:** Set `OLLAMA_BASE_URL` to a local or remote Ollama instance.
 
 No code changes needed — just set the environment variables and restart.
+
+For local dev or demos without a backend, set `ALLOW_MOCK=true` to use deterministic mock responses (keyword pattern matching). Mock is off by default, so without it an unconfigured server returns a 503. See [Mock responses](#mock-responses-allow_mock) below.
 
 See [embed/README.md](embed/README.md) for full documentation.
 
@@ -517,19 +519,29 @@ If the client sends a `model` field in the request, it is used as-is. Otherwise 
 
 **Model fallback (LLM backend only):** If the agent's model doesn't exist on the current provider (e.g. an Ollama model when using OpenAI), the server automatically retries with `LLM_MODEL` and the chat widget shows a toast notification explaining the switch.
 
+**Output limit:** No completion-token cap by default — the provider's own default applies. Set `LLM_MAX_TOKENS` to impose a server-wide ceiling. A client that sends its own `max_tokens` always overrides the env value.
+
 ### Backend Selection
 
 The server auto-detects which backend to use at startup:
 
 1. **LLM Backend** — if `LLM_BASE_URL` is set, all requests go through it (OpenAI, Portkey Gateway, etc.)
 2. **Ollama** — if `LLM_BASE_URL` is not set and Ollama is reachable at `OLLAMA_BASE_URL`
-3. **Mock responses** — fallback when neither backend is available (deterministic, no AI)
+3. **Mock responses** — only if `ALLOW_MOCK=true` (see below); otherwise the request returns a 503
 
 Only one backend is active at a time. Setting both `LLM_BASE_URL` and `OLLAMA_BASE_URL` is fine — LLM takes priority.
 
-### Mock response labeling
+### Mock responses (`ALLOW_MOCK`)
 
-Every mock response — whether from a `type: mock` agent or a fallback path — includes a `warning` field on the JSON body (non-stream) or an SSE `event: warning` chunk emitted before content (stream), so callers can always detect the response did not come from a real LLM:
+Mock responses are **off by default**. When no backend is configured, the backend errors, or an agent is `type: mock`, the server returns a `503` so the failure stays visible:
+
+```json
+{ "error": { "message": "No LLM response available (llm_error) and mock responses are disabled. Set ALLOW_MOCK=true to return deterministic mock responses.", "type": "server_error" } }
+```
+
+Set `ALLOW_MOCK=true` to enable deterministic mock replies instead (useful for local dev, demos, and CI without an LLM). Keep it **off in production** so real failures aren't masked by fake answers.
+
+When enabled, every mock response — whether from a `type: mock` agent or a fallback path — includes a `warning` field on the JSON body (non-stream) or an SSE `event: warning` chunk emitted before content (stream), and the response `model` is set to `ozwell-mock`, so callers can always detect the response did not come from a real LLM:
 
 ```json
 {

--- a/reference-server/embed/ozwell-loader.js
+++ b/reference-server/embed/ozwell-loader.js
@@ -65,7 +65,7 @@
   };
 
   const EMPTY_SCHEMA = { type: 'object', properties: {} };
-  const PAGE_TOOL_PREFIX = 'postMessage:';
+  const PAGE_TOOL_PREFIX = 'postMessage_';
   const TOOL_RESPONSE_TIMEOUT_MS = 29000;
 
   function readGlobalConfig() {
@@ -232,7 +232,7 @@
     iframeWindow.postMessage(message, '*');
   }
 
-  /** Add postMessage: prefix to a page tool so it can't collide with server-side tools. */
+  /** Add postMessage_ prefix to a page tool so it can't collide with server-side tools. */
   function prefixPageTool(tool) {
     return { ...tool, name: PAGE_TOOL_PREFIX + tool.name };
   }
@@ -300,7 +300,7 @@
           postJsonRpc(message);
         }
 
-        // Strip postMessage: prefix so page handlers see the original name
+        // Strip postMessage_ prefix so page handlers see the original name
         const toolName = rawToolName && rawToolName.startsWith(PAGE_TOOL_PREFIX)
           ? rawToolName.slice(PAGE_TOOL_PREFIX.length)
           : rawToolName;

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -263,6 +263,12 @@ function buildFallbackWarning(originalModel: string, fallbackModel: string) {
   };
 }
 
+// Identifier used as the `model` field on every mock response so callers can immediately
+// distinguish a deterministic mock from a real LLM answer (mirrors how the fallback path
+// sets the response `model` to the actual fallback model rather than the originally
+// requested one). The original requested model is preserved on the warning payload.
+const MOCK_MODEL_ID = 'ozwell-mock';
+
 // Marks every mock response so callers (and the chat widget) can always tell a deterministic
 // mock from a real LLM answer. Three reasons cover all paths that emit a mock body.
 function buildMockWarning(reason: 'no_backend' | 'llm_error' | 'mock_agent', model: string) {
@@ -326,7 +332,7 @@ function dispatchMockNonStream(
     id: generateId('chatcmpl'),
     object: 'chat.completion' as const,
     created: Math.floor(Date.now() / 1000),
-    model,
+    model: MOCK_MODEL_ID,
     choices: [{ index: 0, message: assistantMsg, finish_reason: finishReason }],
     usage: {
       prompt_tokens: promptTokens,
@@ -361,7 +367,7 @@ function dispatchMockStream(
 
   const writeChunk = (delta: Record<string, unknown>, finish: string | null = null) => {
     reply.raw.write(`data: ${JSON.stringify({
-      id, object: 'chat.completion.chunk', created, model,
+      id, object: 'chat.completion.chunk', created, model: MOCK_MODEL_ID,
       choices: [{ index: 0, delta, finish_reason: finish }],
     })}\n\n`);
   };

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -284,6 +284,13 @@ function buildMockWarning(reason: 'no_backend' | 'llm_error' | 'mock_agent', mod
 const LLM_PROVIDER = process.env.LLM_PROVIDER || '';
 const LLM_MODEL = process.env.LLM_MODEL || 'gpt-4o-mini';
 const FALLBACK_MODEL = process.env.DEFAULT_MODEL || 'gpt-4o-mini';
+// Mock responses are OFF by default — keep real LLM errors visible in production.
+// Set ALLOW_MOCK=true to return deterministic mock replies (no LLM configured,
+// LLM errored, or an agent declares type: mock).
+const MOCK_ENABLED = process.env.ALLOW_MOCK === 'true';
+// No output cap by default. LLM_MAX_TOKENS sets a server-wide ceiling; a client
+// that sends its own max_tokens always overrides this.
+const LLM_MAX_TOKENS = process.env.LLM_MAX_TOKENS ? Number(process.env.LLM_MAX_TOKENS) : undefined;
 
 // Pre-construct LLM clients once (reused across all requests)
 const llmClient = isLLMBackendConfigured()
@@ -389,6 +396,34 @@ function dispatchMockStream(
   writeChunk({}, finishReason);
   reply.raw.write('data: [DONE]\n\n');
   reply.raw.end();
+}
+
+// Single decision point for every mock path (mock_agent, no_backend, llm_error).
+// When ALLOW_MOCK is off, return a real 503 instead of a deterministic mock so
+// failures stay visible. All three call sites are reached before any response
+// headers are sent, so a JSON error is always safe here.
+// Returns a value to `return` for the non-stream case; streams end internally.
+function respondMockOrError(
+  reason: Parameters<typeof buildMockWarning>[0],
+  model: string,
+  messages: NonNullableMessage[],
+  stream: boolean,
+  reply: FastifyReply,
+  origin: string | undefined,
+) {
+  if (!MOCK_ENABLED) {
+    reply.code(503);
+    return createError(
+      `No LLM response available (${reason}) and mock responses are disabled. Set ALLOW_MOCK=true to return deterministic mock responses.`,
+      'server_error',
+    );
+  }
+  const warning = buildMockWarning(reason, model);
+  if (stream) {
+    dispatchMockStream(messages, model, reply, origin, warning);
+    return undefined;
+  }
+  return dispatchMockNonStream(messages, model, warning);
 }
 
 const chatRoute: FastifyPluginAsync = async (fastify) => {
@@ -530,12 +565,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
         mockMessages.unshift({ role: 'system', content: agentConfig.systemPrompt });
       }
       const mockModel = agentConfig.model || 'mock';
-      const warning = buildMockWarning('mock_agent', mockModel);
-      if (stream) {
-        dispatchMockStream(mockMessages, mockModel, reply, request.headers.origin, warning);
-        return;
-      }
-      return dispatchMockNonStream(mockMessages, mockModel, warning);
+      return respondMockOrError('mock_agent', mockModel, mockMessages, stream, reply, request.headers.origin);
     }
 
     // Backend selection priority:
@@ -554,6 +584,8 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
     const model = agentConfig?.model || requestedModel || DEFAULT_MODEL;
     // Agent-configured temperature takes precedence over client request
     const temperature = agentConfig?.temperature ?? requestedTemperature;
+    // Client-sent max_tokens wins; otherwise apply the server ceiling (if any); else no cap.
+    const effectiveMaxTokens = max_tokens ?? LLM_MAX_TOKENS;
 
     request.log.info({ backend, llmConfigured, ollamaAvailable, model, requestedModel, agentModel: agentConfig?.model, agentTemperature: agentConfig?.temperature }, 'Chat request backend selection');
 
@@ -612,14 +644,9 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
       });
     }
 
-    // No backend reachable — fall through to deterministic mock so client always gets a valid response.
+    // No backend reachable — deterministic mock (if enabled) so client gets a valid response.
     if (backend === 'fallback') {
-      const warning = buildMockWarning('no_backend', model);
-      if (stream) {
-        dispatchMockStream(normalizedMessages, model, reply, request.headers.origin, warning);
-        return;
-      }
-      return dispatchMockNonStream(normalizedMessages, model, warning);
+      return respondMockOrError('no_backend', model, normalizedMessages, stream, reply, request.headers.origin);
     }
 
     // Use a real LLM backend
@@ -632,7 +659,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
         const requestOptions: ChatCompletionRequestWithTools = {
           model,
           messages: normalizedMessages as unknown as ChatCompletionRequest['messages'],
-          ...(max_tokens && { max_tokens }),
+          ...(effectiveMaxTokens && { max_tokens: effectiveMaxTokens }),
           ...(temperature !== undefined && { temperature }),
           ...(response_format && { response_format }),
         };
@@ -836,7 +863,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
             const retryRequest = {
               model: DEFAULT_MODEL,
               messages: normalizedMessages as unknown as ChatCompletionRequest['messages'],
-              ...(max_tokens && { max_tokens }),
+              ...(effectiveMaxTokens && { max_tokens: effectiveMaxTokens }),
               ...(temperature !== undefined && { temperature }),
               ...(response_format && { response_format }),
               ...(filteredTools && filteredTools.length > 0 && { tools: filteredTools as ToolDef[] }),
@@ -868,14 +895,9 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
       }
     }
 
-    // LLM error final fallback: dispatch deterministic mock so the client always gets a valid response.
-    // Warning marker tells caller the configured LLM failed — never silent.
-    const warning = buildMockWarning('llm_error', model);
-    if (stream) {
-      dispatchMockStream(normalizedMessages, model, reply, request.headers.origin, warning);
-      return;
-    }
-    return dispatchMockNonStream(normalizedMessages, model, warning);
+    // LLM error final fallback: deterministic mock (if enabled), else a real 503.
+    // Reached only from the non-stream path — streaming failures end the stream above.
+    return respondMockOrError('llm_error', model, normalizedMessages, stream, reply, request.headers.origin);
   });
 };
 

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginAsync, FastifyReply } from 'fastify';
-import { validateAuth, createError, generateId, countTokens, isOllamaAvailable, getOllamaDefaultModel, isAgentKey, extractToken, isLLMBackendConfigured } from '../util';
+import { validateAuth, createError, generateId, countTokens, isOllamaAvailable, getOllamaDefaultModel, isAgentKey, extractToken, isLLMBackendConfigured, parsePositiveEnvNumber } from '../util';
 import { agentStore, type PageToolsPolicy } from '../storage/agents';
 import * as yaml from 'yaml';
 import OzwellAI from 'ozwellai';
@@ -279,17 +279,6 @@ function buildMockWarning(reason: 'no_backend' | 'llm_error' | 'mock_agent', mod
   return { type: 'mock_response' as const, reason, model, message: messages[reason] };
 }
 
-function parsePositiveEnvNumber(name: string): number | undefined {
-  const value = process.env[name];
-  if (!value) return undefined;
-
-  const parsed = Number(value);
-  if (Number.isFinite(parsed) && parsed > 0) return parsed;
-
-  console.warn(`[config] Ignoring ${name}=${JSON.stringify(value)}; expected a positive number.`);
-  return undefined;
-}
-
 // Hoist static env reads (these never change at runtime)
 const LLM_PROVIDER = process.env.LLM_PROVIDER || '';
 const LLM_MODEL = process.env.LLM_MODEL || 'gpt-4o-mini';
@@ -337,7 +326,6 @@ function buildMockAssistant(messages: NonNullableMessage[]) {
 
 function dispatchMockNonStream(
   messages: NonNullableMessage[],
-  model: string,
   warning: MockWarning,
 ) {
   const { assistantMsg, finishReason } = buildMockAssistant(messages);
@@ -362,7 +350,6 @@ function dispatchMockNonStream(
 
 function dispatchMockStream(
   messages: NonNullableMessage[],
-  model: string,
   reply: FastifyReply,
   origin: string | undefined,
   warning: MockWarning,
@@ -421,6 +408,15 @@ function respondMockOrError(
   reply: FastifyReply,
   origin: string | undefined,
 ) {
+  const warning = buildMockWarning(reason, model);
+  if (reason === 'mock_agent') {
+    if (stream) {
+      dispatchMockStream(messages, reply, origin, warning);
+      return undefined;
+    }
+    return dispatchMockNonStream(messages, warning);
+  }
+
   if (!MOCK_ENABLED) {
     reply.code(503);
     return createError(
@@ -428,12 +424,11 @@ function respondMockOrError(
       'server_error',
     );
   }
-  const warning = buildMockWarning(reason, model);
   if (stream) {
-    dispatchMockStream(messages, model, reply, origin, warning);
+    dispatchMockStream(messages, reply, origin, warning);
     return undefined;
   }
-  return dispatchMockNonStream(messages, model, warning);
+  return dispatchMockNonStream(messages, warning);
 }
 
 const chatRoute: FastifyPluginAsync = async (fastify) => {
@@ -622,10 +617,11 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
     // Tools arriving from the widget use two namespaces:
     //   • bare names       — server-side tools (defined in the agent's tools array)
     //   • postMessage_name — page-provided tools (prefixed by the loader)
+    //   • postMessage:name — legacy page tools from cached loaders during deploys
     //
     // allowedTools (from agent.tools) gates bare-name tools.
-    // pageTools policy gates postMessage_-prefixed tools.
-    const PM_PREFIX = 'postMessage_';
+    // pageTools policy gates prefixed page tools.
+    const PM_PREFIXES = ['postMessage_', 'postMessage:'];
     let filteredTools = tools;
     if (agentConfig !== null && tools) {
       const allowed = agentConfig.allowedTools;          // null = no server tools defined
@@ -635,9 +631,10 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
         if (!t || t.type !== 'function' || !t.function || typeof t.function.name !== 'string') return false;
         const name = t.function.name;
 
-        if (name.startsWith(PM_PREFIX)) {
+        const pagePrefix = PM_PREFIXES.find((prefix) => name.startsWith(prefix));
+        if (pagePrefix) {
           // Page tool — apply pageTools policy
-          const bare = name.slice(PM_PREFIX.length);
+          const bare = name.slice(pagePrefix.length);
           if (pagePolicy === 'all') return true;
           if (typeof pagePolicy === 'object' && 'restricted' in pagePolicy) {
             return pagePolicy.restricted.includes(bare);

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -573,11 +573,11 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
     // --- Agent: filter tools ---
     // Tools arriving from the widget use two namespaces:
     //   • bare names       — server-side tools (defined in the agent's tools array)
-    //   • postMessage:name — page-provided tools (prefixed by the loader)
+    //   • postMessage_name — page-provided tools (prefixed by the loader)
     //
     // allowedTools (from agent.tools) gates bare-name tools.
-    // pageTools policy gates postMessage:-prefixed tools.
-    const PM_PREFIX = 'postMessage:';
+    // pageTools policy gates postMessage_-prefixed tools.
+    const PM_PREFIX = 'postMessage_';
     let filteredTools = tools;
     if (agentConfig !== null && tools) {
       const allowed = agentConfig.allowedTools;          // null = no server tools defined

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -543,7 +543,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
     // Determine default model based on backend
     const DEFAULT_MODEL = llmConfigured ? LLM_MODEL : ollamaAvailable ? getOllamaDefaultModel() : FALLBACK_MODEL;
 
-    const { model: requestedModel, messages, tools, stream = false, max_tokens = 150, temperature: requestedTemperature = 0.7, response_format } = body as ChatCompletionRequestWithTools & { response_format?: { type: string } };
+    const { model: requestedModel, messages, tools, stream = false, max_tokens, temperature: requestedTemperature = 0.7, response_format } = body as ChatCompletionRequestWithTools & { response_format?: { type: string } };
     // Agent-configured model takes precedence, then client request, then server default
     const model = agentConfig?.model || requestedModel || DEFAULT_MODEL;
     // Agent-configured temperature takes precedence over client request

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -264,9 +264,8 @@ function buildFallbackWarning(originalModel: string, fallbackModel: string) {
 }
 
 // Identifier used as the `model` field on every mock response so callers can immediately
-// distinguish a deterministic mock from a real LLM answer (mirrors how the fallback path
-// sets the response `model` to the actual fallback model rather than the originally
-// requested one). The original requested model is preserved on the warning payload.
+// distinguish a deterministic mock from a real LLM answer. Mock warnings keep the selected
+// model that triggered the mock response.
 const MOCK_MODEL_ID = 'ozwell-mock';
 
 // Marks every mock response so callers (and the chat widget) can always tell a deterministic
@@ -280,6 +279,17 @@ function buildMockWarning(reason: 'no_backend' | 'llm_error' | 'mock_agent', mod
   return { type: 'mock_response' as const, reason, model, message: messages[reason] };
 }
 
+function parsePositiveEnvNumber(name: string): number | undefined {
+  const value = process.env[name];
+  if (!value) return undefined;
+
+  const parsed = Number(value);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+
+  console.warn(`[config] Ignoring ${name}=${JSON.stringify(value)}; expected a positive number.`);
+  return undefined;
+}
+
 // Hoist static env reads (these never change at runtime)
 const LLM_PROVIDER = process.env.LLM_PROVIDER || '';
 const LLM_MODEL = process.env.LLM_MODEL || 'gpt-4o-mini';
@@ -290,7 +300,7 @@ const FALLBACK_MODEL = process.env.DEFAULT_MODEL || 'gpt-4o-mini';
 const MOCK_ENABLED = process.env.ALLOW_MOCK === 'true';
 // No output cap by default. LLM_MAX_TOKENS sets a server-wide ceiling; a client
 // that sends its own max_tokens always overrides this.
-const LLM_MAX_TOKENS = process.env.LLM_MAX_TOKENS ? Number(process.env.LLM_MAX_TOKENS) : undefined;
+const LLM_MAX_TOKENS = parsePositiveEnvNumber('LLM_MAX_TOKENS');
 
 // Pre-construct LLM clients once (reused across all requests)
 const llmClient = isLLMBackendConfigured()

--- a/reference-server/src/routes/responses.ts
+++ b/reference-server/src/routes/responses.ts
@@ -1,5 +1,7 @@
 import { FastifyPluginAsync } from 'fastify';
-import { validateAuth, createError, SimpleTextGenerator, generateId, countTokens } from '../util';
+import { validateAuth, createError, SimpleTextGenerator, generateId, countTokens, parsePositiveEnvNumber } from '../util';
+
+const LLM_MAX_TOKENS = parsePositiveEnvNumber('LLM_MAX_TOKENS');
 
 const responsesRoute: FastifyPluginAsync = async (fastify) => {
   // POST /v1/responses
@@ -32,6 +34,7 @@ const responsesRoute: FastifyPluginAsync = async (fastify) => {
 
     const body = request.body as any;
     const { model, input, stream = false, max_tokens, temperature = 0.7 } = body;
+    const effectiveMaxTokens = max_tokens ?? LLM_MAX_TOKENS;
 
     // Validate model
     const supportedModels = ['gpt-4o', 'gpt-4o-mini'];
@@ -62,7 +65,7 @@ const responsesRoute: FastifyPluginAsync = async (fastify) => {
       reply.raw.write(`event: start\ndata: ${JSON.stringify({ id: requestId, model, created })}\n\n`);
 
       // Send content events
-      const generator = SimpleTextGenerator.generateStream(input, max_tokens);
+      const generator = SimpleTextGenerator.generateStream(input, effectiveMaxTokens);
       let fullOutput = '';
       
       for (const token of generator) {
@@ -100,7 +103,7 @@ const responsesRoute: FastifyPluginAsync = async (fastify) => {
     }
 
     // Non-streaming response
-    const output = SimpleTextGenerator.generate(input, max_tokens, temperature);
+    const output = SimpleTextGenerator.generate(input, effectiveMaxTokens, temperature);
     const inputTokens = countTokens(input);
     const outputTokens = countTokens(output);
 

--- a/reference-server/src/routes/responses.ts
+++ b/reference-server/src/routes/responses.ts
@@ -31,7 +31,7 @@ const responsesRoute: FastifyPluginAsync = async (fastify) => {
     }
 
     const body = request.body as any;
-    const { model, input, stream = false, max_tokens = 150, temperature = 0.7 } = body;
+    const { model, input, stream = false, max_tokens, temperature = 0.7 } = body;
 
     // Validate model
     const supportedModels = ['gpt-4o', 'gpt-4o-mini'];

--- a/reference-server/src/server.ts
+++ b/reference-server/src/server.ts
@@ -63,7 +63,7 @@ async function buildServer() {
           description: 'Local development',
         },
         {
-          url: 'https://ozwell-dev-refserver.opensource.mieweb.org',
+          url: 'https://ozwellapi.os.mieweb.org',
           description: 'Development server',
         },
       ],

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -87,7 +87,7 @@ export function seedMockAgent(): void {
 // ── Agent model ─────────────────────────────────────────────────────
 
 /**
- * pageTools policy gates the postMessage:-prefixed tools an agent may call.
+ * pageTools policy gates the postMessage_-prefixed tools an agent may call.
  * Stored inside the agent YAML blob; chat.ts reads it after parsing.
  */
 export type PageToolsPolicy =

--- a/reference-server/src/util/index.ts
+++ b/reference-server/src/util/index.ts
@@ -19,6 +19,17 @@ export function isValidApiKey(key: string): boolean {
   return key.startsWith(KEY_PREFIX);
 }
 
+export function parsePositiveEnvNumber(name: string): number | undefined {
+  const value = process.env[name];
+  if (!value) return undefined;
+
+  const parsed = Number(value);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+
+  console.warn(`[config] Ignoring ${name}=${JSON.stringify(value)}; expected a positive number.`);
+  return undefined;
+}
+
 /**
  * Simple deterministic text generator for predictable testing
  * Uses a basic Markov chain approach with predefined patterns

--- a/reference-server/src/util/index.ts
+++ b/reference-server/src/util/index.ts
@@ -63,7 +63,7 @@ export class SimpleTextGenerator {
     " I'm here if you have more questions.",
   ];
 
-  static generate(prompt: string, maxTokens: number = 150, _temperature: number = 0.7): string {
+  static generate(prompt: string, maxTokens?: number, _temperature: number = 0.7): string {
     // Create a seed based on the prompt for deterministic output
     const seed = this.hashString(prompt) % 1000000;
     const rng = this.seededRandom(seed);
@@ -73,7 +73,7 @@ export class SimpleTextGenerator {
     let response = this.RESPONSES[responseIndex];
 
     // Calculate target length based on maxTokens (rough estimate: 1 token ≈ 4 characters)
-    const targetLength = Math.min(maxTokens * 4, 500);
+    const targetLength = maxTokens === undefined ? 500 : maxTokens * 4;
 
     // Add continuations if we need more length
     while (response.length < targetLength * 0.7) {
@@ -95,14 +95,14 @@ export class SimpleTextGenerator {
     response += this.ENDINGS[endingIndex];
 
     // Trim to approximate token limit
-    if (response.length > targetLength) {
+    if (maxTokens !== undefined && response.length > targetLength) {
       response = response.substring(0, targetLength - 10) + "...";
     }
 
     return response;
   }
 
-  static *generateStream(prompt: string, maxTokens: number = 150): Generator<string> {
+  static *generateStream(prompt: string, maxTokens?: number): Generator<string> {
     const fullResponse = this.generate(prompt, maxTokens);
     const words = fullResponse.split(' ');
     

--- a/reference-server/test/mock-agent.test.js
+++ b/reference-server/test/mock-agent.test.js
@@ -34,7 +34,7 @@ before(async () => {
         cwd: process.cwd(),
         stdio: 'pipe',
         detached: true,
-        env: { ...process.env, PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development', ALLOW_MOCK: 'true' }
+        env: { ...process.env, PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development', ALLOW_MOCK: '' }
     });
     await waitForReady();
 });

--- a/reference-server/test/mock-agent.test.js
+++ b/reference-server/test/mock-agent.test.js
@@ -34,7 +34,7 @@ before(async () => {
         cwd: process.cwd(),
         stdio: 'pipe',
         detached: true,
-        env: { ...process.env, PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development' }
+        env: { ...process.env, PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development', ALLOW_MOCK: 'true' }
     });
     await waitForReady();
 });


### PR DESCRIPTION
Tracks #167.

- Drop `max_tokens=150` default in `chat.ts` and `responses.ts` so reasoning models and long responses aren't truncated. Refs #168.
- Rename page-tool prefix `postMessage:` → `postMessage_`. The colon violated OpenAI's tool-name regex `^[a-zA-Z0-9_-]{1,64}$`. Closes #169.
- Label mock responses with `ozwell-mock` model id instead of echoing the requested model. Refs #170.

Cached widget JS still emits the old colon prefix; clients need one loader reload after deploy.

Tests: `npm test` 22/22, both relevant act workflows green, manual curl coverage of plain chat / new + legacy prefix / streaming / multi-turn / max_tokens cap behaviour.