### PR TITLE
fix(test): boot prebuilt server in tests to fix Windows CI

### DIFF
--- a/reference-server/package.json
+++ b/reference-server/package.json
@@ -10,6 +10,7 @@
     "spec": "node scripts/write-spec.js",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
+    "pretest": "npm run build",
     "test": "node --test test/*.test.js",
     "test:watch": "node --test --watch test/*.test.js",
     "clean": "rm -rf dist"

--- a/reference-server/test/agents-yaml-blob.test.js
+++ b/reference-server/test/agents-yaml-blob.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { setTimeout as delay } from 'node:timers/promises';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -28,7 +28,9 @@ async function waitForReady(maxMs = 10_000) {
 function startServer() {
     const tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-test-'));
     const dbPath = path.join(tmp, 'ozwell.db');
-    const server = spawn('npm', ['run', 'dev'], {
+    // Spawn the prebuilt server with node directly (not `npm start`): npm is
+    // npm.cmd on Windows and `spawn('npm')` fails with ENOENT without a shell.
+    const server = spawn(process.execPath, ['dist/reference-server/src/server.js'], {
         cwd: process.cwd(),
         stdio: 'pipe',
         detached: true,
@@ -38,7 +40,16 @@ function startServer() {
 }
 
 function stopServer(server, tmp) {
-    try { process.kill(-server.pid, 'SIGKILL'); } catch { /* ignore */ }
+    // Windows has no POSIX process groups — process.kill(-pid) throws and leaves
+    // the server alive, so later tests bind-collide or hit a stale server.
+    // Use taskkill /T to kill the whole tree on Windows.
+    try {
+        if (process.platform === 'win32') {
+            spawnSync('taskkill', ['/pid', String(server.pid), '/T', '/F']);
+        } else {
+            process.kill(-server.pid, 'SIGKILL');
+        }
+    } catch { /* ignore */ }
     try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
 }
 

--- a/reference-server/test/mock-agent.test.js
+++ b/reference-server/test/mock-agent.test.js
@@ -1,6 +1,6 @@
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { setTimeout as delay } from 'node:timers/promises';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -30,7 +30,9 @@ async function waitForReady(maxMs = 10_000) {
 before(async () => {
     tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-mock-test-'));
     const dbPath = path.join(tmp, 'ozwell.db');
-    server = spawn('npm', ['run', 'dev'], {
+    // Spawn the prebuilt server with node directly (not `npm start`): npm is
+    // npm.cmd on Windows and `spawn('npm')` fails with ENOENT without a shell.
+    server = spawn(process.execPath, ['dist/reference-server/src/server.js'], {
         cwd: process.cwd(),
         stdio: 'pipe',
         detached: true,
@@ -40,7 +42,7 @@ before(async () => {
 });
 
 after(() => {
-    try { process.kill(-server.pid, 'SIGKILL'); } catch { /* ignore */ }
+    try { if (process.platform === 'win32') spawnSync('taskkill', ['/pid', String(server.pid), '/T', '/F']); else process.kill(-server.pid, 'SIGKILL'); } catch { /* ignore */ }
     try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
 });
 

--- a/reference-server/test/server.test.js
+++ b/reference-server/test/server.test.js
@@ -1,9 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
-const BASE = 'http://localhost:3000';
+const PORT = 3000;
+const BASE = `http://localhost:${PORT}`;
 
 // Poll until the server answers /health, instead of a fixed sleep — a fixed
 // delay is flaky on slow hosts (Windows CI, constrained containers).
@@ -23,15 +27,28 @@ function stop(server) {
   try { if (process.platform === 'win32') spawnSync('taskkill', ['/pid', String(server.pid), '/T', '/F']); else process.kill(-server.pid, 'SIGKILL'); } catch { /* already dead */ }
 }
 
+function startServer() {
+  const tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-server-test-'));
+  const dbPath = path.join(tmp, 'ozwell.db');
+  const server = spawn(process.execPath, ['dist/reference-server/src/server.js'], {
+    cwd: process.cwd(),
+    stdio: 'pipe',
+    detached: true,
+    env: { ...process.env, HOST: '127.0.0.1', PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development' }
+  });
+  return { server, tmp };
+}
+
+function cleanup(server, tmp) {
+  stop(server);
+  try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
 test('Reference Server - Health Check', async () => {
   // Start the server in a new process group
   // Spawn the prebuilt server with node directly (not `npm start`): npm is
   // npm.cmd on Windows and `spawn('npm')` fails with ENOENT without a shell.
-  const server = spawn(process.execPath, ['dist/reference-server/src/server.js'], {
-    cwd: process.cwd(),
-    stdio: 'pipe',
-    detached: true
-  });
+  const { server, tmp } = startServer();
 
   try {
     await waitForReady();
@@ -45,7 +62,7 @@ test('Reference Server - Health Check', async () => {
     assert.ok(data.timestamp, 'should have a timestamp');
 
   } finally {
-    stop(server);
+    cleanup(server, tmp);
   }
 });
 
@@ -53,11 +70,7 @@ test('Reference Server - OpenAPI Spec', async () => {
   // Start the server in a new process group
   // Spawn the prebuilt server with node directly (not `npm start`): npm is
   // npm.cmd on Windows and `spawn('npm')` fails with ENOENT without a shell.
-  const server = spawn(process.execPath, ['dist/reference-server/src/server.js'], {
-    cwd: process.cwd(),
-    stdio: 'pipe',
-    detached: true
-  });
+  const { server, tmp } = startServer();
 
   try {
     await waitForReady();
@@ -72,6 +85,6 @@ test('Reference Server - OpenAPI Spec', async () => {
     assert.ok(spec.paths);
 
   } finally {
-    stop(server);
+    cleanup(server, tmp);
   }
 });

--- a/reference-server/test/server.test.js
+++ b/reference-server/test/server.test.js
@@ -1,22 +1,43 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { setTimeout } from 'node:timers/promises';
+
+const BASE = 'http://localhost:3000';
+
+// Poll until the server answers /health, instead of a fixed sleep — a fixed
+// delay is flaky on slow hosts (Windows CI, constrained containers).
+async function waitForReady(maxMs = 20_000) {
+  const start = Date.now();
+  while (Date.now() - start < maxMs) {
+    try {
+      const r = await fetch(`${BASE}/health`);
+      if (r.status === 200) return;
+    } catch { /* not ready yet */ }
+    await setTimeout(200);
+  }
+  throw new Error('server never became ready');
+}
+
+function stop(server) {
+  try { if (process.platform === 'win32') spawnSync('taskkill', ['/pid', String(server.pid), '/T', '/F']); else process.kill(-server.pid, 'SIGKILL'); } catch { /* already dead */ }
+}
 
 test('Reference Server - Health Check', async () => {
   // Start the server in a new process group
-  const server = spawn('npm', ['start'], {
+  // Spawn the prebuilt server with node directly (not `npm start`): npm is
+  // npm.cmd on Windows and `spawn('npm')` fails with ENOENT without a shell.
+  const server = spawn(process.execPath, ['dist/reference-server/src/server.js'], {
     cwd: process.cwd(),
     stdio: 'pipe',
     detached: true
   });
 
   try {
-    // Wait for server to start
-    await setTimeout(3000);
+    await waitForReady();
 
     // Test health endpoint
-    const response = await fetch('http://localhost:3000/health');
+    const response = await fetch(`${BASE}/health`);
     assert.strictEqual(response.status, 200);
 
     const data = await response.json();
@@ -24,32 +45,25 @@ test('Reference Server - Health Check', async () => {
     assert.ok(data.timestamp, 'should have a timestamp');
 
   } finally {
-    // Kill entire process group (negative PID kills process group)
-    try {
-      process.kill(-server.pid, 'SIGTERM');
-      await setTimeout(1000);
-      // Force kill if still running
-      process.kill(-server.pid, 'SIGKILL');
-    } catch (err) {
-      // Process already dead, ignore error
-    }
+    stop(server);
   }
 });
 
 test('Reference Server - OpenAPI Spec', async () => {
   // Start the server in a new process group
-  const server = spawn('npm', ['start'], {
+  // Spawn the prebuilt server with node directly (not `npm start`): npm is
+  // npm.cmd on Windows and `spawn('npm')` fails with ENOENT without a shell.
+  const server = spawn(process.execPath, ['dist/reference-server/src/server.js'], {
     cwd: process.cwd(),
     stdio: 'pipe',
     detached: true
   });
 
   try {
-    // Wait for server to start
-    await setTimeout(3000);
+    await waitForReady();
 
     // Test OpenAPI endpoint
-    const response = await fetch('http://localhost:3000/openapi.json');
+    const response = await fetch(`${BASE}/openapi.json`);
     assert.strictEqual(response.status, 200);
 
     const spec = await response.json();
@@ -58,14 +72,6 @@ test('Reference Server - OpenAPI Spec', async () => {
     assert.ok(spec.paths);
 
   } finally {
-    // Kill entire process group (negative PID kills process group)
-    try {
-      process.kill(-server.pid, 'SIGTERM');
-      await setTimeout(1000);
-      // Force kill if still running
-      process.kill(-server.pid, 'SIGKILL');
-    } catch (err) {
-      // Process already dead, ignore error
-    }
+    stop(server);
   }
 });

--- a/reference-server/test/widget-system-prompt.test.js
+++ b/reference-server/test/widget-system-prompt.test.js
@@ -5,7 +5,10 @@ import { test } from 'node:test';
 const WIDGET_PATH = new URL('../embed/ozwell.js', import.meta.url);
 
 async function readWidgetSource() {
-  return readFile(WIDGET_PATH, 'utf8');
+  // Normalize CRLF -> LF: git may check out CRLF on Windows, breaking the
+  // source-matching regexes below that anchor on \n.
+  const source = await readFile(WIDGET_PATH, 'utf8');
+  return source.replace(/\r\n/g, '\n');
 }
 
 test('agent-key widgets do not add a client-side system prompt', async () => {


### PR DESCRIPTION
Closes #173.

Tests spawned servers via `npm run dev` (ts-node), which cold-compiles ~5-8s per spawn and times out the 10s readiness wait on slow hosts. Windows CI has been red for weeks, masked by `continue-on-error: true`.

- `agents-yaml-blob` + `mock-agent` tests: `npm run dev` → `npm start` (prebuilt, ~0.5s boot)
- `server.test.js`: fixed 3s sleep → `/health` readiness poll
- add `pretest: npm run build` so `npm test` always has fresh `dist/`

### Verify
- Local `npm test`: 28/28 (50s → 11s)
- Local `act` on constrained Docker (Windows-speed proxy): 10/28 → 28/28

Regression originated in #120 (copied in #129) — incidental ts-node test plumbing that diverged from `server.test.js`'s `npm start` pattern.