### PR TITLE
feat: Enhance multimodal content handling for images and documents

### DIFF
--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -1,6 +1,14 @@
 // Minimal type definitions for JSR publishing
 // Full spec available at: https://github.com/mieweb/ozwellai-api/tree/main/spec
 
+/** A single multimodal content part (OpenAI-compatible). */
+export type ContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: { url: string; detail?: 'auto' | 'low' | 'high' } };
+
+/** Message content: plain text, or an array of content parts (text + images). */
+export type MessageContent = string | ContentPart[];
+
 /**
  * Request object for chat completion API calls.
  * Compatible with OpenAI's chat completion format.
@@ -12,8 +20,8 @@ export interface ChatCompletionRequest {
   messages: Array<{
     /** The role of the messages author */
     role: 'system' | 'user' | 'assistant' | 'function' | 'tool';
-    /** The contents of the message */
-    content: string;
+    /** The contents of the message — text string or multimodal content parts */
+    content: MessageContent;
     /** The name of the author of this message */
     name?: string;
   }>;

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -4,9 +4,10 @@
 /** A single multimodal content part (OpenAI-compatible). */
 export type ContentPart =
   | { type: 'text'; text: string }
-  | { type: 'image_url'; image_url: { url: string; detail?: 'auto' | 'low' | 'high' } };
+  | { type: 'image_url'; image_url: { url: string; detail?: 'auto' | 'low' | 'high' } }
+  | { type: 'file'; file: { file_data: string; filename?: string } };
 
-/** Message content: plain text, or an array of content parts (text + images). */
+/** Message content: plain text, or an array of content parts (text + images + files). */
 export type MessageContent = string | ContentPart[];
 
 /**

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -22,7 +22,7 @@ type ToolFunction = {
 type ToolDef = { type: 'function'; function: ToolFunction };
 type ToolCall = { id: string; type: 'function'; function: { name: string; arguments: string } };
 type ChatCompletionRequestWithTools = ChatCompletionRequest & { tools?: ToolDef[] };
-type NonNullableMessage = { role: Message['role']; content: string; name?: Message['name']; tool_calls?: ToolCall[]; tool_call_id?: string };
+type NonNullableMessage = { role: Message['role']; content: NonNullable<Message['content']>; name?: Message['name']; tool_calls?: ToolCall[]; tool_call_id?: string };
 
 // JSON Schema type for tool function parameters
 type JSONSchemaParameters = {
@@ -409,7 +409,15 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
               additionalProperties: true,
               properties: {
                 role: { type: 'string' },
-                content: { type: 'string' },
+                // Content may be a plain string (text) or an array of
+                // multimodal content parts (text + image_url) for vision.
+                content: {
+                  anyOf: [
+                    { type: 'string' },
+                    { type: 'array', items: { type: 'object' } },
+                    { type: 'null' },
+                  ],
+                },
                 tool_calls: { type: 'array' },
                 tool_call_id: { type: 'string' }
               },

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -63,6 +63,27 @@ type ChatMessage = {
   tool_calls?: ToolCall[];
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isValidMessageContent(content: unknown): boolean {
+  if (content == null || typeof content === 'string') return true;
+  if (!Array.isArray(content)) return false;
+
+  return content.every((part) => {
+    if (!isRecord(part)) return false;
+    if (part.type === 'text') return typeof part.text === 'string';
+    if (part.type === 'image_url') {
+      return isRecord(part.image_url) && typeof part.image_url.url === 'string';
+    }
+    if (part.type === 'file') {
+      return isRecord(part.file) && typeof part.file.file_data === 'string';
+    }
+    return false;
+  });
+}
+
 // Helper: try to detect tool calls from JSON content and convert to ToolCall[]
 function tryExtractToolCallsFromContent(content: string | undefined, tools?: ToolDef[] | undefined): ToolCall[] | null {
   if (!content) return null;
@@ -469,6 +490,15 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
     }
 
     const body = request.body as ChatCompletionRequestWithTools;
+    const invalidMessageIndex = (body.messages as Message[]).findIndex((m) => !isValidMessageContent(m.content));
+    if (invalidMessageIndex !== -1) {
+      reply.code(400);
+      return createError(
+        `Invalid messages[${invalidMessageIndex}].content`,
+        'invalid_request_error',
+        `messages[${invalidMessageIndex}].content`
+      );
+    }
 
     // --- Agent key resolution ---
     let agentConfig: { systemPrompt: string; allowedTools: string[] | null; pageTools: PageToolsPolicy; model: string | null; temperature: number | null; type: 'mock' | null } | null = null;

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -5,7 +5,7 @@ import * as yaml from 'yaml';
 import OzwellAI from 'ozwellai';
 import type { ChatCompletionRequest as ClientChatCompletionRequest } from 'ozwellai';
 import type { ChatCompletionRequest, Message } from '../../../spec/index';
-import { generateMockResponse, extractUserMessage, hasToolResult, extractToolResult, type ChatMessage as MockChatMessage } from './mock-chat';
+import { generateMockResponse, extractUserMessage, hasToolResult, extractToolResult, contentToText, type ChatMessage as MockChatMessage } from './mock-chat';
 
 // SSE Heartbeat Configuration
 // Send keepalive every 25s to prevent 60s Nginx timeout
@@ -318,7 +318,7 @@ function dispatchMockNonStream(
   warning: MockWarning,
 ) {
   const { assistantMsg, finishReason } = buildMockAssistant(messages);
-  const promptText = messages.map((m) => m.content).join(' ');
+  const promptText = messages.map((m) => contentToText(m.content)).join(' ');
   const completionText = assistantMsg.content || JSON.stringify(assistantMsg.tool_calls || []);
   const promptTokens = countTokens(promptText);
   const completionTokens = countTokens(completionText);
@@ -411,13 +411,18 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
                 role: { type: 'string' },
                 // Content may be a plain string (text) or an array of
                 // multimodal content parts (text + image_url) for vision.
-                content: {
-                  anyOf: [
-                    { type: 'string' },
-                    { type: 'array', items: { type: 'object' } },
-                    { type: 'null' },
-                  ],
-                },
+                //
+                // NOTE: We intentionally leave this schema unconstrained (no
+                // `type`/`anyOf`). Fastify's default ajv runs with
+                // `coerceTypes: true`, which unwraps a single-element array
+                // (`[x]` -> `x`) while attempting the scalar `string` branch of
+                // an `anyOf`. That mutation corrupted the payload and made
+                // single-part content arrays (e.g. one image_url) fail
+                // validation with FST_ERR_VALIDATION. An empty schema accepts
+                // string | array | object | null without any coercion; the
+                // route normalizes content at runtime (see normalizedMessages
+                // and contentToText).
+                content: {},
                 tool_calls: { type: 'array' },
                 tool_call_id: { type: 'string' }
               },

--- a/reference-server/src/routes/mock-chat.ts
+++ b/reference-server/src/routes/mock-chat.ts
@@ -2,9 +2,42 @@
 // Used by the chat route to bypass the LLM for `type: mock` agents
 // and as a final fallback when no LLM backend is reachable.
 
+// A single multimodal content part (OpenAI-compatible). Only the text portion
+// is meaningful for the deterministic mock; image parts are ignored.
+export interface ContentPart {
+  type?: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+// Message content may be a plain string or an array of multimodal parts
+// (text + image_url) for vision requests.
+export type MessageContent = string | ContentPart[];
+
 export interface ChatMessage {
   role: string;
-  content: string;
+  content: MessageContent;
+}
+
+// Flatten a message's content into a plain string. Strings pass through; arrays
+// of content parts are reduced to their concatenated `text` fields. This keeps
+// downstream string operations (e.g. toLowerCase, JSON.parse) safe when callers
+// send multimodal content arrays.
+export function contentToText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === 'string') return part;
+        if (part && typeof part === 'object' && typeof (part as ContentPart).text === 'string') {
+          return (part as ContentPart).text as string;
+        }
+        return '';
+      })
+      .filter(Boolean)
+      .join(' ');
+  }
+  return '';
 }
 
 export interface ToolCall {
@@ -19,7 +52,9 @@ export interface ToolCall {
 export function extractUserMessage(messages: ChatMessage[]): string {
   // Get the last user message
   const lastUserMsg = messages.filter(msg => msg.role === 'user').pop();
-  return lastUserMsg?.content || '';
+  // Content may be a multimodal array (text + image_url); flatten to text so
+  // callers can safely run string operations on the result.
+  return contentToText(lastUserMsg?.content);
 }
 
 export function hasToolResult(messages: ChatMessage[]): boolean {
@@ -37,10 +72,11 @@ export function extractToolResult(messages: ChatMessage[]): Record<string, unkno
   const toolMsg = toolMessages[toolMessages.length - 1];
   if (!toolMsg) return null;
 
+  const raw = contentToText(toolMsg.content);
   try {
-    return JSON.parse(toolMsg.content);
+    return JSON.parse(raw);
   } catch {
-    return { message: toolMsg.content };
+    return { message: raw };
   }
 }
 

--- a/reference-server/src/server.ts
+++ b/reference-server/src/server.ts
@@ -18,8 +18,17 @@ import { getDatabase, initializeAuthTables, seedDemoData, seedMockAgent } from '
 // Import schemas for OpenAPI generation
 import * as schemas from '../../spec';
 
+const DEFAULT_BODY_LIMIT_MB = 50;
+
+function getBodyLimitBytes(): number {
+  const raw = parseInt(process.env.BODY_LIMIT_MB || `${DEFAULT_BODY_LIMIT_MB}`, 10);
+  const mb = Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_BODY_LIMIT_MB;
+  return mb * 1024 * 1024;
+}
+
 const fastify = Fastify({
   logger: process.env.NODE_ENV !== 'production',
+  bodyLimit: getBodyLimitBytes(),
 });
 
 async function buildServer() {

--- a/reference-server/test/multimodal-content.test.js
+++ b/reference-server/test/multimodal-content.test.js
@@ -164,3 +164,18 @@ test('multimodal content — file content part streams without crashing', async 
     const text = await r.text();
     assert.ok(text.includes('data: [DONE]'), 'stream terminates with [DONE]');
 });
+
+test('multimodal content — invalid object content is rejected', async () => {
+    const r = await fetch(`${BASE}/v1/chat/completions`, {
+        method: 'POST',
+        headers: H,
+        body: JSON.stringify({
+            messages: [{ role: 'user', content: { unexpected: 'object' } }],
+        }),
+    });
+
+    assert.equal(r.status, 400);
+    const j = await r.json();
+    assert.equal(j.error.type, 'invalid_request_error');
+    assert.equal(j.error.param, 'messages[0].content');
+});

--- a/reference-server/test/multimodal-content.test.js
+++ b/reference-server/test/multimodal-content.test.js
@@ -120,3 +120,47 @@ test('multimodal content — image_url-only array does not crash and returns a r
     assert.equal(j.choices[0].message.role, 'assistant');
     assert.equal(typeof j.choices[0].message.content, 'string');
 });
+
+test('multimodal content — file content part (PDF as base64 data URL) is accepted', async () => {
+    const body = JSON.stringify({
+        messages: [
+            {
+                role: 'user',
+                content: [
+                    { type: 'text', text: 'Analyze this document' },
+                    { type: 'file', file: { file_data: 'data:application/pdf;base64,JVBERi0xLjQK', filename: 'test.pdf' } },
+                ],
+            },
+        ],
+    });
+
+    const r = await fetch(`${BASE}/v1/chat/completions`, { method: 'POST', headers: H, body });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.object, 'chat.completion');
+    assert.equal(j.choices[0].message.role, 'assistant');
+});
+
+test('multimodal content — file content part streams without crashing', async () => {
+    const r = await fetch(`${BASE}/v1/chat/completions`, {
+        method: 'POST',
+        headers: H,
+        body: JSON.stringify({
+            stream: true,
+            messages: [
+                {
+                    role: 'user',
+                    content: [
+                        { type: 'text', text: 'Summarize this file' },
+                        { type: 'file', file: { file_data: 'data:text/csv;base64,bmFtZSxhZ2UKSm9obiwyNQ==', filename: 'data.csv' } },
+                    ],
+                },
+            ],
+        }),
+    });
+
+    assert.equal(r.status, 200);
+    assert.match(r.headers.get('content-type') || '', /text\/event-stream/);
+    const text = await r.text();
+    assert.ok(text.includes('data: [DONE]'), 'stream terminates with [DONE]');
+});

--- a/reference-server/test/multimodal-content.test.js
+++ b/reference-server/test/multimodal-content.test.js
@@ -1,0 +1,122 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+// Keep MOCK_KEY in sync with MOCK_AGENT_KEY in src/storage/agents.ts.
+// Test file is plain JS (no TS imports) so the constant cannot be pulled directly.
+const MOCK_KEY = 'agnt_key-mock-test';
+const PORT = 3335;
+const BASE = `http://localhost:${PORT}`;
+
+let server;
+let tmp;
+
+async function waitForReady(maxMs = 10_000) {
+    const start = Date.now();
+    while (Date.now() - start < maxMs) {
+        try {
+            const r = await fetch(`${BASE}/health`);
+            if (r.status === 200) return;
+        } catch { /* not ready */ }
+        await delay(200);
+    }
+    throw new Error('server never became ready');
+}
+
+before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-multimodal-test-'));
+    const dbPath = path.join(tmp, 'ozwell.db');
+    server = spawn('npm', ['run', 'dev'], {
+        cwd: process.cwd(),
+        stdio: 'pipe',
+        detached: true,
+        env: { ...process.env, PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development' }
+    });
+    await waitForReady();
+});
+
+after(() => {
+    try { process.kill(-server.pid, 'SIGKILL'); } catch { /* ignore */ }
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+const H = { 'Content-Type': 'application/json', 'Authorization': `Bearer ${MOCK_KEY}` };
+
+// A tiny 1x1 transparent PNG as a data URL — a real image_url payload shape.
+const SAMPLE_IMAGE_URL =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC';
+
+test('multimodal content — array of text + image_url is accepted (no 400/validation error)', async () => {
+    const body = JSON.stringify({
+        messages: [
+            {
+                role: 'user',
+                content: [
+                    { type: 'text', text: 'hello' },
+                    { type: 'image_url', image_url: { url: SAMPLE_IMAGE_URL } },
+                ],
+            },
+        ],
+    });
+
+    const r = await fetch(`${BASE}/v1/chat/completions`, { method: 'POST', headers: H, body });
+    // Must NOT reject with 400 FST_ERR_VALIDATION.
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.object, 'chat.completion');
+    assert.equal(j.choices[0].message.role, 'assistant');
+    // The text part ("hello") should drive the deterministic greeting reply,
+    // proving the content array was flattened to text rather than crashing on
+    // `userMessage.toLowerCase is not a function`.
+    assert.match(j.choices[0].message.content, /Hello/);
+});
+
+test('multimodal content — streaming array request completes without crashing', async () => {
+    const r = await fetch(`${BASE}/v1/chat/completions`, {
+        method: 'POST',
+        headers: H,
+        body: JSON.stringify({
+            stream: true,
+            messages: [
+                {
+                    role: 'user',
+                    content: [
+                        { type: 'text', text: 'hello' },
+                        { type: 'image_url', image_url: { url: SAMPLE_IMAGE_URL } },
+                    ],
+                },
+            ],
+        }),
+    });
+
+    assert.equal(r.status, 200);
+    assert.match(r.headers.get('content-type') || '', /text\/event-stream/);
+
+    const text = await r.text();
+    assert.ok(text.includes('data: [DONE]'), 'stream terminates with [DONE]');
+    assert.ok(text.includes('"finish_reason":"stop"'), 'final chunk has stop');
+});
+
+test('multimodal content — image_url-only array does not crash and returns a response', async () => {
+    const body = JSON.stringify({
+        messages: [
+            {
+                role: 'user',
+                content: [
+                    { type: 'image_url', image_url: { url: SAMPLE_IMAGE_URL } },
+                ],
+            },
+        ],
+    });
+
+    const r = await fetch(`${BASE}/v1/chat/completions`, { method: 'POST', headers: H, body });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.object, 'chat.completion');
+    assert.equal(j.choices[0].message.role, 'assistant');
+    assert.equal(typeof j.choices[0].message.content, 'string');
+});

--- a/spec/index.ts
+++ b/spec/index.ts
@@ -16,9 +16,17 @@ export const ImageContentPartSchema = z.object({
   }),
 });
 
-export const ContentPartSchema = z.union([TextContentPartSchema, ImageContentPartSchema]);
+export const FileContentPartSchema = z.object({
+  type: z.literal('file'),
+  file: z.object({
+    file_data: z.string(),
+    filename: z.string().optional(),
+  }),
+});
 
-// Message content: a string, or an array of content parts (text + images).
+export const ContentPartSchema = z.union([TextContentPartSchema, ImageContentPartSchema, FileContentPartSchema]);
+
+// Message content: a string, or an array of content parts (text + images + files).
 export const MessageContentSchema = z.union([z.string(), z.array(ContentPartSchema)]);
 
 // Common schemas
@@ -191,6 +199,7 @@ export const ChatCompletionChunkSchema = z.object({
 
 export type TextContentPart = z.infer<typeof TextContentPartSchema>;
 export type ImageContentPart = z.infer<typeof ImageContentPartSchema>;
+export type FileContentPart = z.infer<typeof FileContentPartSchema>;
 export type ContentPart = z.infer<typeof ContentPartSchema>;
 export type MessageContent = z.infer<typeof MessageContentSchema>;
 export type Message = z.infer<typeof MessageSchema>;

--- a/spec/index.ts
+++ b/spec/index.ts
@@ -1,9 +1,30 @@
 import { z } from 'zod';
 
+// Multimodal content parts (OpenAI-compatible).
+// A message's `content` may be a plain string, or an array of typed parts
+// to support vision (image) inputs alongside text.
+export const TextContentPartSchema = z.object({
+  type: z.literal('text'),
+  text: z.string(),
+});
+
+export const ImageContentPartSchema = z.object({
+  type: z.literal('image_url'),
+  image_url: z.object({
+    url: z.string(),
+    detail: z.enum(['auto', 'low', 'high']).optional(),
+  }),
+});
+
+export const ContentPartSchema = z.union([TextContentPartSchema, ImageContentPartSchema]);
+
+// Message content: a string, or an array of content parts (text + images).
+export const MessageContentSchema = z.union([z.string(), z.array(ContentPartSchema)]);
+
 // Common schemas
 export const MessageSchema = z.object({
   role: z.enum(['system', 'user', 'assistant', 'function', 'tool']),
-  content: z.string().nullable(),
+  content: MessageContentSchema.nullable(),
   name: z.string().optional(),
   function_call: z.object({
     name: z.string(),
@@ -168,6 +189,10 @@ export const ChatCompletionChunkSchema = z.object({
   })),
 });
 
+export type TextContentPart = z.infer<typeof TextContentPartSchema>;
+export type ImageContentPart = z.infer<typeof ImageContentPartSchema>;
+export type ContentPart = z.infer<typeof ContentPartSchema>;
+export type MessageContent = z.infer<typeof MessageContentSchema>;
 export type Message = z.infer<typeof MessageSchema>;
 export type Model = z.infer<typeof ModelSchema>;
 export type ChatCompletionRequest = z.infer<typeof ChatCompletionRequestSchema>;


### PR DESCRIPTION
This pull request adds support for multimodal (text + image) message content throughout the API, types, server, and tests. The main changes introduce a new `ContentPart` type, update message schemas to allow arrays of text and image parts, and ensure the server correctly handles and flattens these for downstream processing. It also adds comprehensive tests to verify multimodal content handling and increases the default body size limit for uploads.

**Multimodal Content Support**

* Introduced `ContentPart` and `MessageContent` types to represent messages as either plain strings or arrays of text/image parts in both the TypeScript client (`clients/typescript/src/types.ts`) and OpenAPI schema (`spec/index.ts`). [[1]](diffhunk://#diff-0dc27fcb56edd907a3ee9dddd2fff3220678e57a5ef8079ceb28e09f2f374b8aR4-R11) [[2]](diffhunk://#diff-0dc27fcb56edd907a3ee9dddd2fff3220678e57a5ef8079ceb28e09f2f374b8aL15-R24) [[3]](diffhunk://#diff-70123c69fe25a2e4a74dd88e7a41361317ca5a8c4c446e9e92736f4d06a46f33R3-R27) [[4]](diffhunk://#diff-70123c69fe25a2e4a74dd88e7a41361317ca5a8c4c446e9e92736f4d06a46f33R192-R195)
* Updated server-side mock chat logic and types to support and safely flatten multimodal content arrays into strings for deterministic mock responses and tool result extraction (`reference-server/src/routes/mock-chat.ts`). [[1]](diffhunk://#diff-b8c9cfb4a70073983ac07ec466f1f48cb48308418898fd554b284a1f247c47a2R5-R40) [[2]](diffhunk://#diff-b8c9cfb4a70073983ac07ec466f1f48cb48308418898fd554b284a1f247c47a2L22-R57) [[3]](diffhunk://#diff-b8c9cfb4a70073983ac07ec466f1f48cb48308418898fd554b284a1f247c47a2R75-R79)
* Modified the chat route validation schema to accept any type for `content`, preventing Fastify's coercion from corrupting single-element arrays, and normalized content at runtime (`reference-server/src/routes/chat.ts`). [[1]](diffhunk://#diff-408b134147669a039abd89372b4076900c55f01f56a216362368df407258c811L8-R8) [[2]](diffhunk://#diff-408b134147669a039abd89372b4076900c55f01f56a216362368df407258c811L25-R25) [[3]](diffhunk://#diff-408b134147669a039abd89372b4076900c55f01f56a216362368df407258c811L321-R321) [[4]](diffhunk://#diff-408b134147669a039abd89372b4076900c55f01f56a216362368df407258c811L412-R425)

**Testing and Validation**

* Added new integration tests to ensure multimodal content (text + image arrays) is accepted, processed correctly, and does not cause validation or runtime errors (`reference-server/test/multimodal-content.test.js`).

**Server Configuration**

* Increased the default HTTP body size limit to 50MB and made it configurable via environment variable to support large image uploads (`reference-server/src/server.ts`).