### PR TITLE
fix: omit temperature for gpt-5 reasoning models

### DIFF
--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -636,15 +636,18 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
     const temperature = agentConfig?.temperature ?? requestedTemperature;
     // Client-sent max_tokens wins; otherwise apply the server ceiling (if any); else no cap.
     const effectiveMaxTokens = max_tokens ?? LLM_MAX_TOKENS;
+    const usesReasoningParams = (m: string) => /(^|\/)(o\d|gpt-5)/.test(m);
     // gpt-5.x + o-series require `max_completion_tokens`; everything else (gpt-4.x, Ollama) uses `max_tokens`.
     // Classified per call from the model actually being sent — the fallback retry switches models, so a
     // single precomputed object would send the wrong key on retry. `(^|/)` also matches provider-prefixed
     // ids (e.g. `openai/gpt-5`). Regex self-classifies future gpt-5.x/o models.
     const tokenParamFor = (m: string): Record<string, number> =>
       !effectiveMaxTokens ? {}
-        : /(^|\/)(o\d|gpt-5)/.test(m)
+        : usesReasoningParams(m)
           ? { max_completion_tokens: effectiveMaxTokens }
           : { max_tokens: effectiveMaxTokens };
+    const temperatureParamFor = (m: string): Record<string, number> =>
+      temperature === undefined || usesReasoningParams(m) ? {} : { temperature };
 
     request.log.info({ backend, llmConfigured, ollamaAvailable, model, requestedModel, agentModel: agentConfig?.model, agentTemperature: agentConfig?.temperature }, 'Chat request backend selection');
 
@@ -722,7 +725,6 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
         const requestOptions: ChatCompletionRequestWithTools = {
           model,
           messages: normalizedMessages as unknown as ChatCompletionRequest['messages'],
-          ...(temperature !== undefined && { temperature }),
           ...(response_format && { response_format }),
         };
 
@@ -767,6 +769,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
             const requestForClient = {
               ...requestOptions,
               ...tokenParamFor(model),
+              ...temperatureParamFor(model),
               ...(filteredTools && filteredTools.length > 0 && { tools: requestOptions.tools }),
               stream: true as const,
               stream_options: { include_usage: true },
@@ -866,6 +869,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
                   ...requestOptions,
                   model: DEFAULT_MODEL,
                   ...tokenParamFor(DEFAULT_MODEL),
+                  ...temperatureParamFor(DEFAULT_MODEL),
                   ...(filteredTools && filteredTools.length > 0 && { tools: filteredTools }),
                   stream: true as const,
                   stream_options: { include_usage: true },
@@ -893,6 +897,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
           const requestForClientNonStream = {
             ...requestOptions,
             ...tokenParamFor(model),
+            ...temperatureParamFor(model),
             ...(filteredTools && filteredTools.length > 0 && { tools: requestOptions.tools }),
             stream: false as const,
           };
@@ -938,7 +943,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
               model: DEFAULT_MODEL,
               messages: normalizedMessages as unknown as ChatCompletionRequest['messages'],
               ...tokenParamFor(DEFAULT_MODEL),
-              ...(temperature !== undefined && { temperature }),
+              ...temperatureParamFor(DEFAULT_MODEL),
               ...(response_format && { response_format }),
               ...(filteredTools && filteredTools.length > 0 && { tools: filteredTools as ToolDef[] }),
               stream: false as const,

--- a/reference-server/test/manager-auth.test.js
+++ b/reference-server/test/manager-auth.test.js
@@ -753,6 +753,46 @@ test('manager auth — streaming LLM usage chunks are requested and recorded', a
     }
 });
 
+test('manager auth — gpt-5 streaming request omits unsupported temperature', async () => {
+    const upstream = await startStreamingLLMServer();
+    const { server, tmp, dbPath } = startServer({
+        extraEnv: {
+            LLM_BASE_URL: upstream.baseURL,
+            LLM_API_KEY: 'test-upstream-key',
+            LLM_PROVIDER: '',
+            LLM_MODEL: 'openai/gpt-5.1',
+            LLM_ALLOWED_MODELS: 'openai/gpt-5.1',
+            ALLOW_MOCK: '',
+        },
+    });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
+        const { key } = getUserAndActiveKey(dbPath);
+
+        const chat = await fetch(`${BASE}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${key.key}`,
+            },
+            body: JSON.stringify({
+                model: 'openai/gpt-5.1',
+                messages: [{ role: 'user', content: 'hello stream usage' }],
+                stream: true,
+            }),
+        });
+        assert.equal(chat.status, 200);
+        await chat.text();
+
+        const body = upstream.getCapturedBody();
+        assert.equal('temperature' in body, false);
+    } finally {
+        stopServer(server, tmp);
+        await upstream.close();
+    }
+});
+
 test('manager admin — global key and agent table routes are not exposed', async () => {
     const { server, tmp } = startServer({ adminExternalUserIds: '2009' });
     try {


### PR DESCRIPTION
## Summary
- omit temperature for gpt-5/o-series chat completion requests
- reuse the existing reasoning-model predicate for token and temperature params
- add regression coverage for streaming gpt-5 requests

Fixes #198

## Validation
- npm run test -w reference-server
- npm run lint -w reference-server (0 errors, existing warnings)
- manual curl against gpt-5.1 returned a real upstream response
- act reference-server CI: ubuntu Node 20 and Node 22 lint/build/test/smoke passed