### PR TITLE
Update refserver deploy workflow for systemd target

### DIFF
--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -66,47 +66,62 @@ jobs:
         with:
           name: reference-server-build
 
-      # v0.1.7
+      - name: Set up SSH
+        env:
+          DEPLOY_HOST: ${{ vars.OZWELL_REFSERVER_DEPLOY_HOST }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$DEPLOY_HOST" ]]; then
+            echo "OZWELL_REFSERVER_DEPLOY_HOST is required (format: user@hostname)"
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+          deploy_hostname="${DEPLOY_HOST#*@}"
+          ssh-keyscan "$deploy_hostname" >> ~/.ssh/known_hosts
+
       - name: Upload to server
-        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634
-        with:
-          host: ${{ vars.OZWELL_PROD_HOST }}
-          port: 2061
-          username: ${{ vars.OZWELL_PROD_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: reference-server-build.tar.gz
-          target: /tmp/
+        env:
+          DEPLOY_HOST: ${{ vars.OZWELL_REFSERVER_DEPLOY_HOST }}
+        run: rsync -ruva --progress reference-server-build.tar.gz "$DEPLOY_HOST:/tmp/"
 
-      # v1.0.0
       - name: Extract and restart service
-        uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
-        with:
-          host: ${{ vars.OZWELL_PROD_HOST }}
-          port: 2061
-          username: ${{ vars.OZWELL_PROD_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: |
-            set -e
+        env:
+          DEPLOY_HOST: ${{ vars.OZWELL_REFSERVER_DEPLOY_HOST }}
+          DEPLOY_PATH: ${{ vars.OZWELL_REFSERVER_DEPLOY_PATH || '~/ozwellai-api' }}
+          RESTART_COMMAND: ${{ vars.OZWELL_REFSERVER_RESTART_COMMAND || 'sudo systemctl restart refserver' }}
+        run: |
+          set -euo pipefail
+          ssh "$DEPLOY_HOST" "DEPLOY_PATH='$DEPLOY_PATH' RESTART_COMMAND='$RESTART_COMMAND' bash -s" <<'REMOTE'
+            set -euo pipefail
 
-            # Ensure directory structure exists (no git repo needed)
-            mkdir -p ~/ozwellai-api/reference-server
-            mkdir -p ~/ozwellai-api/clients/typescript
-            mkdir -p ~/ozwellai-api/spec
-            cd ~/ozwellai-api
+            deploy_path="${DEPLOY_PATH:-~/ozwellai-api}"
+            case "$deploy_path" in
+              "~") deploy_path="$HOME" ;;
+              "~/"*) deploy_path="$HOME/${deploy_path#~/}" ;;
+            esac
 
-            # Clean old build outputs to prevent stale files
+            mkdir -p "$deploy_path/reference-server"
+            mkdir -p "$deploy_path/clients/typescript"
+            mkdir -p "$deploy_path/spec"
+            cd "$deploy_path"
+
             rm -rf reference-server/dist clients/typescript/dist spec/dist
-
-            # Extract the pre-built package
             tar -xzf /tmp/reference-server-build.tar.gz
 
-            # Install production dependencies only (no build needed)
             cd reference-server
             npm ci --omit=dev
 
-            # Restart service
-            pm2 restart refserver
-            pm2 save
+            touch .env
+            if grep -q '^PORT=' .env; then
+              sed -i 's/^PORT=.*/PORT=8000/' .env
+            else
+              printf '\nPORT=8000\n' >> .env
+            fi
 
-            # Cleanup
+            eval "$RESTART_COMMAND"
             rm /tmp/reference-server-build.tar.gz
+          REMOTE

--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -58,7 +58,9 @@ jobs:
   deploy:
     name: Deploy to ozwell-prod refserver
     needs: build
-    runs-on: ubuntu-latest
+    # Placeholder pending Aaron's exact self-hosted runner labels.
+    # Expected target server name from Aaron: ozwell-phxdc-node1.
+    runs-on: [self-hosted, ozwell-phxdc-node1]
 
     steps:
       - name: Download build artifact
@@ -66,39 +68,46 @@ jobs:
         with:
           name: reference-server-build
 
-      - name: Set up SSH
+      - name: Prepare SSH host
         env:
-          DEPLOY_HOST: ${{ vars.OZWELL_REFSERVER_DEPLOY_HOST }}
+          # Placeholder pending Aaron's exact deploy host value.
+          # Aaron's build-dev.yaml pattern uses user@hostname; runner-local SSH may only need ozwell-phxdc-node1.
+          DEPLOY_HOST: ${{ vars.OZWELL_REFSERVER_DEPLOY_HOST || 'ozwell-phxdc-node1' }}
         run: |
           set -euo pipefail
           if [[ -z "$DEPLOY_HOST" ]]; then
-            echo "OZWELL_REFSERVER_DEPLOY_HOST is required (format: user@hostname)"
+            echo "OZWELL_REFSERVER_DEPLOY_HOST is required (format: user@hostname or runner SSH host alias)"
             exit 1
           fi
 
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
+
+          # Placeholder fallback: Aaron expects the deploy key to be installed on the self-hosted runner.
+          # If runner-level SSH is not available, uncomment these lines and set OZWELL_REFSERVER_SSH_PRIVATE_KEY.
+          # echo "${{ secrets.OZWELL_REFSERVER_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          # chmod 600 ~/.ssh/id_ed25519
 
           deploy_hostname="${DEPLOY_HOST#*@}"
           ssh-keyscan "$deploy_hostname" >> ~/.ssh/known_hosts
 
       - name: Upload to server
         env:
-          DEPLOY_HOST: ${{ vars.OZWELL_REFSERVER_DEPLOY_HOST }}
+          DEPLOY_HOST: ${{ vars.OZWELL_REFSERVER_DEPLOY_HOST || 'ozwell-phxdc-node1' }}
         run: rsync -ruva --progress reference-server-build.tar.gz "$DEPLOY_HOST:/tmp/"
 
       - name: Extract and restart service
         env:
-          DEPLOY_HOST: ${{ vars.OZWELL_REFSERVER_DEPLOY_HOST }}
-          DEPLOY_PATH: ${{ vars.OZWELL_REFSERVER_DEPLOY_PATH || '~/ozwellai-api' }}
+          DEPLOY_HOST: ${{ vars.OZWELL_REFSERVER_DEPLOY_HOST || 'ozwell-phxdc-node1' }}
+          # Placeholder path from Aaron; keep as a var so it can be changed without editing the workflow.
+          DEPLOY_PATH: ${{ vars.OZWELL_REFSERVER_DEPLOY_PATH || '/storage/apps/ozwellai-api' }}
+          # Placeholder pending Aaron's final service command: sudo systemctl vs systemctl --user.
           RESTART_COMMAND: ${{ vars.OZWELL_REFSERVER_RESTART_COMMAND || 'sudo systemctl restart refserver' }}
         run: |
           set -euo pipefail
           ssh "$DEPLOY_HOST" "DEPLOY_PATH='$DEPLOY_PATH' RESTART_COMMAND='$RESTART_COMMAND' bash -s" <<'REMOTE'
             set -euo pipefail
 
-            deploy_path="${DEPLOY_PATH:-~/ozwellai-api}"
+            deploy_path="${DEPLOY_PATH:-/storage/apps/ozwellai-api}"
             case "$deploy_path" in
               "~") deploy_path="$HOME" ;;
               "~/"*) deploy_path="$HOME/${deploy_path#~/}" ;;


### PR DESCRIPTION
## Summary
- replace the reference-server deploy's Appleboy SCP/SSH actions with direct SSH setup, rsync upload, and ssh remote execution
- remove the custom SSH port and PM2 restart path from the reference-server deploy
- wire the deployed refserver runtime to PORT=8000 and make the systemd restart command configurable

## Notes
- Demo-site deployment is intentionally unchanged; it still needs a later follow-up for the new refserver URL.
- Aaron still needs to confirm the runner label, deploy host/path, and whether the restart command should use passwordless sudo or user-level systemd.

## Validation
- python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-reference-server.yml')); print('yaml ok')"
- rg -n "appleboy|pm2|port: 2061" .github/workflows/deploy-reference-server.yml
- git diff --check -- .github/workflows/deploy-reference-server.yml
- act -n -W .github/workflows/deploy-reference-server.yml

Fixes #214