### PR TITLE
Fix manager auth for new SSO proxy headers (key on email)

### DIFF
--- a/reference-server/src/routes/agents.ts
+++ b/reference-server/src/routes/agents.ts
@@ -61,16 +61,22 @@ function readHeader(request: FastifyRequest, name: string): string | undefined {
     return value;
 }
 
+// Header names are env-configurable so a future SSO/proxy change is a config
+// change, not a code change (per MIE infra guidance). Defaults match the
+// current authentik / oauth2-proxy scheme.
 function readForwardedIdentity(request: FastifyRequest): ManagerIdentity | null {
-    const externalUserId = readHeader(request, 'x-user-id');
-    if (!externalUserId) return null;
+    const externalUserId = readHeader(request, process.env.MANAGER_USER_HEADER || 'x-user');
+    const email = readHeader(request, process.env.MANAGER_EMAIL_HEADER || 'x-email');
+    // Email is the primary identity key (stable across IdP/header changes), so
+    // it is required. Both the old and new proxy schemes forward it.
+    if (!email) return null;
     return {
-        external_user_id: externalUserId,
-        username: readHeader(request, 'x-username'),
-        first_name: readHeader(request, 'x-user-first-name'),
-        last_name: readHeader(request, 'x-user-last-name'),
-        email: readHeader(request, 'x-email'),
-        groups: readHeader(request, 'x-groups'),
+        external_user_id: externalUserId || email,
+        username: readHeader(request, process.env.MANAGER_USERNAME_HEADER || 'x-preferred-username'),
+        first_name: readHeader(request, process.env.MANAGER_FIRSTNAME_HEADER || 'x-user-first-name'),
+        last_name: readHeader(request, process.env.MANAGER_LASTNAME_HEADER || 'x-user-last-name'),
+        email,
+        groups: readHeader(request, process.env.MANAGER_GROUPS_HEADER || 'x-groups'),
     };
 }
 

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -265,6 +265,15 @@ function adminExternalUserIds(): Set<string> {
     );
 }
 
+function adminEmails(): Set<string> {
+    return new Set(
+        (process.env.ADMIN_EMAILS || '')
+            .split(',')
+            .map(value => value.trim().toLowerCase())
+            .filter(Boolean),
+    );
+}
+
 export class AgentStore {
     private db: Database.Database;
     private stmtInsert: Database.Statement;
@@ -353,6 +362,35 @@ export class AgentStore {
     }
 
     upsertManagerUser(identity: ManagerIdentity): ManagerUser {
+        // Match existing users by email — stable across IdP/proxy changes. When
+        // the forwarded id value changes (e.g. old numeric id -> new OIDC sub),
+        // re-link the existing row and migrate external_user_id in place so the
+        // user keeps their id, parent key, agents, and admin status.
+        const fields = {
+            external_user_id: identity.external_user_id,
+            username: identity.username ?? null,
+            first_name: identity.first_name ?? null,
+            last_name: identity.last_name ?? null,
+            email: identity.email ?? null,
+            groups: identity.groups ?? null,
+        };
+
+        const existing = identity.email ? this.getManagerUserByEmail(identity.email) : null;
+        if (existing) {
+            this.db.prepare(`
+              UPDATE users SET
+                external_user_id = @external_user_id,
+                username = @username,
+                first_name = @first_name,
+                last_name = @last_name,
+                email = @email,
+                groups = @groups,
+                last_seen_at = datetime('now')
+              WHERE id = @id
+            `).run({ id: existing.id, ...fields });
+            return this.getManagerUserByEmail(identity.email!)!;
+        }
+
         this.db.prepare(`
           INSERT INTO users (id, external_user_id, username, first_name, last_name, email, groups, last_seen_at)
           VALUES (@id, @external_user_id, @username, @first_name, @last_name, @email, @groups, datetime('now'))
@@ -363,20 +401,17 @@ export class AgentStore {
             email = excluded.email,
             groups = excluded.groups,
             last_seen_at = datetime('now')
-        `).run({
-            id: managerUserId(identity.external_user_id),
-            external_user_id: identity.external_user_id,
-            username: identity.username ?? null,
-            first_name: identity.first_name ?? null,
-            last_name: identity.last_name ?? null,
-            email: identity.email ?? null,
-            groups: identity.groups ?? null,
-        });
+        `).run({ id: managerUserId(identity.external_user_id), ...fields });
         return this.getManagerUserByExternalId(identity.external_user_id)!;
     }
 
     getManagerUserByExternalId(externalUserId: string): ManagerUser | null {
         const row = this.db.prepare('SELECT * FROM users WHERE external_user_id = ?').get(externalUserId) as DbManagerUserRow | undefined;
+        return row ? toManagerUser(row) : null;
+    }
+
+    getManagerUserByEmail(email: string): ManagerUser | null {
+        const row = this.db.prepare('SELECT * FROM users WHERE email = ? COLLATE NOCASE').get(email) as DbManagerUserRow | undefined;
         return row ? toManagerUser(row) : null;
     }
 
@@ -417,7 +452,8 @@ export class AgentStore {
     ensureManagerUserProvisioned(identity: ManagerIdentity): { user: ManagerUser; parentKey: ParentApiKey } {
         const provision = this.db.transaction((managerIdentity: ManagerIdentity) => {
             let user = this.upsertManagerUser(managerIdentity);
-            const bootstrapAdmin = adminExternalUserIds().has(user.external_user_id);
+            const bootstrapAdmin = adminExternalUserIds().has(user.external_user_id)
+                || (user.email ? adminEmails().has(user.email.toLowerCase()) : false);
             if (user.status !== 'active' || (bootstrapAdmin && !user.is_admin)) {
                 this.db.prepare('UPDATE users SET status = ?, is_admin = CASE WHEN ? THEN 1 ELSE is_admin END WHERE id = ?')
                     .run('active', bootstrapAdmin ? 1 : 0, user.id);


### PR DESCRIPTION
Fixes #223.

## Problem
The MIE console auth was swapped to a new authentik/oauth2-proxy that forwards different header names (`x-user`, `x-preferred-username`) and a new opaque id value. Our code read `x-user-id` → null → every manager call 401'd with **"Missing trusted forwarded identity."**

## Fix (backend only — `reference-server`)
- `readForwardedIdentity` reads **env-configurable** header names, defaulting to the new scheme; requires `x-email`.
- Manager users are **keyed on email** (stable across IdP/header changes). On login an existing user is matched by email and their `external_user_id` is migrated **in place** — preserving user id, parent key, agents, and admin status.
- Admin bootstrap can also key on email via `ADMIN_EMAILS`.
- `ozwell-manager` frontend unchanged.

## Testing
Ran against a copy of the dev2 DB (9 real users):
- existing user via new headers → 200, re-linked in place, no duplicate, admin + agents preserved
- brand-new user → provisions cleanly
- missing email → 401
- verified end-to-end through the real manager UI (logged in as existing admin, agents visible)

## Rollout
Targets `dev` so it rides release #222 to prod. Needs to land before Monday's release.