### PR TITLE
chore: enable manual refserver deploys and remove SSH placeholder

### DIFF
--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -1,6 +1,7 @@
 name: Deploy Reference Server
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -82,11 +82,6 @@ jobs:
 
           mkdir -p ~/.ssh
 
-          # Placeholder fallback: Aaron expects the deploy key to be installed on the self-hosted runner.
-          # If runner-level SSH is not available, uncomment these lines and set OZWELL_REFSERVER_SSH_PRIVATE_KEY.
-          # echo "${{ secrets.OZWELL_REFSERVER_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
-          # chmod 600 ~/.ssh/id_ed25519
-
           deploy_hostname="${DEPLOY_HOST#*@}"
           ssh-keyscan "$deploy_hostname" >> ~/.ssh/known_hosts
 


### PR DESCRIPTION
## Summary

- enable manual reference-server deployments with `workflow_dispatch`
- remove the commented SSH private-key fallback from the reference-server deploy workflow
- rely on the SSH setup already installed on the self-hosted runner

## Impact

The workflow can now be started manually from GitHub Actions and no longer advertises an unused secret-based fallback.

## Validation

- parsed `.github/workflows/deploy-reference-server.yml` as YAML
- confirmed `workflow_dispatch` is configured alongside the existing `push` trigger
- confirmed the requested fallback block is absent
- ran `git diff --check`
- ran `act -n -W .github/workflows/deploy-reference-server.yml`
