### PR TITLE
Fix refserver deploy workspace install

### DIFF
--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -9,6 +9,9 @@ on:
       - 'reference-server/**'
       - 'clients/typescript/**'
       - 'spec/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/build-deploy-package.sh'
       - '.github/workflows/deploy-reference-server.yml'
 
 concurrency:
@@ -30,6 +33,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: |
+            package-lock.json
             spec/package-lock.json
             clients/typescript/package-lock.json
             reference-server/package-lock.json
@@ -117,9 +121,9 @@ jobs:
             rm -rf reference-server/dist clients/typescript/dist spec/dist
             tar -xzf /tmp/reference-server-build.tar.gz
 
-            cd reference-server
-            npm ci --omit=dev
+            npm ci --omit=dev --workspace reference-server --include-workspace-root=false
 
+            cd reference-server
             touch .env
             if grep -q '^PORT=' .env; then
               sed -i 's/^PORT=.*/PORT=8000/' .env

--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -100,22 +100,40 @@ jobs:
           DEPLOY_HOST: ${{ vars.OZWELL_REFSERVER_DEPLOY_HOST || 'ozwell-phxdc-node1' }}
           # Placeholder path from Aaron; keep as a var so it can be changed without editing the workflow.
           DEPLOY_PATH: ${{ vars.OZWELL_REFSERVER_DEPLOY_PATH || '/storage/apps/ozwellai-api' }}
-          # Placeholder pending Aaron's final service command: sudo systemctl vs systemctl --user.
-          RESTART_COMMAND: ${{ vars.OZWELL_REFSERVER_RESTART_COMMAND || 'sudo systemctl restart refserver' }}
+          ENV_FILE: ${{ vars.OZWELL_REFSERVER_ENV_FILE || '/storage/apps/env/ozwellai-api.env' }}
+          START_SCRIPT: ${{ vars.OZWELL_REFSERVER_START_SCRIPT || '/storage/apps/env/start-ozwellai-api.sh' }}
+          SERVICE_USER: ${{ vars.OZWELL_REFSERVER_SERVICE_USER || 'ozwell' }}
+          NODE_BIN: ${{ vars.OZWELL_REFSERVER_NODE_BIN || '/usr/bin/node' }}
+          RESTART_COMMAND: ${{ vars.OZWELL_REFSERVER_RESTART_COMMAND || 'sudo systemctl restart ozwellai-api' }}
         run: |
           set -euo pipefail
-          ssh "$DEPLOY_HOST" "DEPLOY_PATH='$DEPLOY_PATH' RESTART_COMMAND='$RESTART_COMMAND' bash -s" <<'REMOTE'
+          ssh "$DEPLOY_HOST" "DEPLOY_PATH='$DEPLOY_PATH' ENV_FILE='$ENV_FILE' START_SCRIPT='$START_SCRIPT' SERVICE_USER='$SERVICE_USER' NODE_BIN='$NODE_BIN' RESTART_COMMAND='$RESTART_COMMAND' bash -s" <<'REMOTE'
             set -euo pipefail
 
             deploy_path="${DEPLOY_PATH:-/storage/apps/ozwellai-api}"
+            env_file="${ENV_FILE:-/storage/apps/env/ozwellai-api.env}"
+            start_script="${START_SCRIPT:-/storage/apps/env/start-ozwellai-api.sh}"
+            service_user="${SERVICE_USER:-ozwell}"
+            node_bin="${NODE_BIN:-/usr/bin/node}"
             case "$deploy_path" in
               "~") deploy_path="$HOME" ;;
               "~/"*) deploy_path="$HOME/${deploy_path#~/}" ;;
+            esac
+            case "$env_file" in
+              "~") env_file="$HOME" ;;
+              "~/"*) env_file="$HOME/${env_file#~/}" ;;
+            esac
+            case "$start_script" in
+              "~") start_script="$HOME" ;;
+              "~/"*) start_script="$HOME/${start_script#~/}" ;;
             esac
 
             mkdir -p "$deploy_path/reference-server"
             mkdir -p "$deploy_path/clients/typescript"
             mkdir -p "$deploy_path/spec"
+            mkdir -p "$deploy_path/data"
+            mkdir -p "$deploy_path/reference-server/data"
+            sudo chown -R "$service_user:$service_user" "$deploy_path/data" "$deploy_path/reference-server/data"
             cd "$deploy_path"
 
             rm -rf reference-server/dist clients/typescript/dist spec/dist
@@ -123,13 +141,26 @@ jobs:
 
             npm ci --omit=dev --workspace reference-server --include-workspace-root=false
 
-            cd reference-server
-            touch .env
-            if grep -q '^PORT=' .env; then
-              sed -i 's/^PORT=.*/PORT=8000/' .env
-            else
-              printf '\nPORT=8000\n' >> .env
-            fi
+            sudo mkdir -p "$(dirname "$env_file")"
+            sudo touch "$env_file"
+
+            set_env_var() {
+              key="$1"
+              value="$2"
+              if sudo grep -q "^${key}=" "$env_file"; then
+                sudo sed -i "s|^${key}=.*|${key}=${value}|" "$env_file"
+              else
+                printf '\n%s=%s\n' "$key" "$value" | sudo tee -a "$env_file" >/dev/null
+              fi
+            }
+
+            set_env_var PORT 8000
+            set_env_var NODE_ENV production
+            set_env_var DB_PATH "$deploy_path/data/ozwell.db"
+
+            sudo mkdir -p "$(dirname "$start_script")"
+            printf '#!/bin/bash\ncd %s/reference-server\nexec %s %s/reference-server/dist/reference-server/src/server.js\n' "$deploy_path" "$node_bin" "$deploy_path" | sudo tee "$start_script" >/dev/null
+            sudo chmod +x "$start_script"
 
             eval "$RESTART_COMMAND"
             rm /tmp/reference-server-build.tar.gz

--- a/scripts/build-deploy-package.sh
+++ b/scripts/build-deploy-package.sh
@@ -16,6 +16,10 @@ mkdir -p "$DEPLOY_DIR/reference-server"
 mkdir -p "$DEPLOY_DIR/clients/typescript"
 mkdir -p "$DEPLOY_DIR/spec"
 
+# Copy workspace root manifests so remote npm ci uses the root lockfile.
+cp "$PROJECT_ROOT/package.json" "$DEPLOY_DIR/"
+cp "$PROJECT_ROOT/package-lock.json" "$DEPLOY_DIR/"
+
 # Copy spec (needed as local dependency)
 echo "  Copying spec..."
 cp -r "$PROJECT_ROOT/spec/dist" "$DEPLOY_DIR/spec/"


### PR DESCRIPTION
## Summary
- package the root workspace `package.json` and `package-lock.json` with the refserver deploy artifact
- run the remote production install from the extracted workspace root with `--workspace reference-server`
- add the root lockfile and packaging script to the deploy workflow trigger/cache inputs

## Root Cause
The deploy job extracted only the reference server package and then ran `npm ci --omit=dev` inside `reference-server`. That made npm use the standalone `reference-server/package-lock.json`, which is stale relative to the workspace root lockfile and caused the workflow to fail before the service restart.

## Validation
- `git diff --check`
- workflow YAML parse
- deploy-shaped `/tmp` fixture: `npm ci --omit=dev --workspace reference-server --include-workspace-root=false --dry-run`
