### PR TITLE
feat: add widget composer model selector

### DIFF
--- a/reference-server/embed/src/WidgetApp.tsx
+++ b/reference-server/embed/src/WidgetApp.tsx
@@ -34,6 +34,15 @@ const DEFAULT_PARENT_SYSTEM_PROMPT = 'You are a helpful assistant. Answer clearl
 const DEFAULT_PARENT_TOOL_HINT = 'Use the available tools when they are helpful for answering the user or performing a requested action.';
 const MCP_TOOL_TIMEOUT_MS = 30000;
 
+type ProviderModelOption = {
+  provider: string;
+  model: string;
+  id: string;
+  label: string;
+};
+
+type ProviderModelSelection = Pick<ProviderModelOption, 'provider' | 'model'>;
+
 const DEFAULT_CONFIG: Required<Pick<OzwellConfig, 'title' | 'placeholder' | 'endpoint' | 'debug' | 'thinkingEnabled' | 'thinkingDefaultMode'>> = {
   title: 'Ozwell',
   placeholder: 'Ask a question...',
@@ -127,6 +136,84 @@ function requestHeaders(config: OzwellConfig) {
   if (authKey) headers.Authorization = `Bearer ${authKey}`;
   if (config.headers) Object.assign(headers, config.headers);
   return headers;
+}
+
+function effectiveModelsEndpoint(endpoint?: string) {
+  let url: URL;
+  try {
+    url = new URL(endpoint || DEFAULT_CONFIG.endpoint, window.location.href);
+  } catch {
+    url = new URL(DEFAULT_CONFIG.endpoint, window.location.href);
+  }
+  url.pathname = '/v1/models/effective';
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+function normalizeEffectiveModels(payload: unknown): ProviderModelOption[] {
+  const data = payload && typeof payload === 'object' && Array.isArray((payload as { data?: unknown[] }).data)
+    ? (payload as { data: unknown[] }).data
+    : [];
+  const seen = new Set<string>();
+  const models: ProviderModelOption[] = [];
+
+  for (const item of data) {
+    if (!item || typeof item !== 'object') continue;
+    const record = item as Record<string, unknown>;
+    const provider = typeof record.provider === 'string' ? record.provider.trim() : '';
+    const model = typeof record.model === 'string' ? record.model.trim() : '';
+    if (!provider || !model) continue;
+    const key = `${provider}:${model}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const id = typeof record.id === 'string' && record.id.trim() ? record.id : model;
+    const label = typeof record.label === 'string' && record.label.trim() ? record.label : model;
+    models.push({ provider, model, id, label });
+  }
+
+  return models;
+}
+
+function providerLabel(provider: string) {
+  return provider
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ') || provider;
+}
+
+function modelOptionLabel(option: ProviderModelSelection | ProviderModelOption) {
+  const label = 'label' in option && option.label ? option.label : option.model;
+  return `${providerLabel(option.provider)} / ${label}`;
+}
+
+function sameProviderModel(left: ProviderModelSelection | null, right: ProviderModelSelection | null) {
+  return left?.provider === right?.provider && left?.model === right?.model;
+}
+
+function resolveActiveModel(
+  config: OzwellConfig,
+  models: ProviderModelOption[],
+  current: ProviderModelSelection | null
+): ProviderModelSelection | null {
+  if (models.length === 0) return null;
+  if (config.provider && config.model) {
+    const configured = models.find((item) => item.provider === config.provider && (item.model === config.model || item.id === config.model));
+    if (configured) return { provider: configured.provider, model: configured.model };
+  }
+
+  if (config.model) {
+    const matches = models.filter((item) => item.model === config.model || item.id === config.model);
+    if (matches.length === 1) return { provider: matches[0].provider, model: matches[0].model };
+  }
+
+  const currentAllowed = current
+    ? models.find((item) => item.provider === current.provider && item.model === current.model)
+    : null;
+  if (currentAllowed) return { provider: currentAllowed.provider, model: currentAllowed.model };
+
+  return { provider: models[0].provider, model: models[0].model };
 }
 
 function parseToolCallsFromContent(content: string) {
@@ -306,8 +393,13 @@ export function WidgetApp() {
   const [thinkingMenuOpen, setThinkingMenuOpen] = useState(false);
   const [messagesMenuOpen, setMessagesMenuOpen] = useState(false);
   const [messagesButtonFlare, setMessagesButtonFlare] = useState(false);
+  const [effectiveModels, setEffectiveModels] = useState<ProviderModelOption[]>([]);
+  const [activeModel, setActiveModel] = useState<ProviderModelSelection | null>(null);
+  const [modelMenuOpen, setModelMenuOpen] = useState(false);
 
   const configRef = useRef(config);
+  const activeModelRef = useRef(activeModel);
+  const modelSelectorRef = useRef<HTMLDivElement | null>(null);
   const historyRef = useRef(historyMessages);
   const parentOriginRef = useRef<string | null>(null);
   const pendingToolCallsRef = useRef<Record<string, true>>({});
@@ -320,9 +412,75 @@ export function WidgetApp() {
   const messagesFlaredRef = useRef(false);
 
   useEffect(() => { configRef.current = config; }, [config]);
+  useEffect(() => { activeModelRef.current = activeModel; }, [activeModel]);
   useEffect(() => { historyRef.current = historyMessages; }, [historyMessages]);
   useEffect(() => { queuedRef.current = queuedMessage; }, [queuedMessage]);
   useEffect(() => { sendingRef.current = sending; }, [sending]);
+
+  useEffect(() => {
+    const authKey = getAuthKey(config);
+    if (!authKey) {
+      setEffectiveModels([]);
+      setActiveModel(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const endpoint = effectiveModelsEndpoint(config.endpoint);
+
+    async function fetchEffectiveModels() {
+      try {
+        const response = await fetch(endpoint, {
+          method: 'GET',
+          headers: requestHeaders(config),
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          setEffectiveModels([]);
+          return;
+        }
+        const payload = await response.json();
+        setEffectiveModels(normalizeEffectiveModels(payload));
+      } catch (error) {
+        if (!controller.signal.aborted && configRef.current.debug) {
+          console.debug('[Ozwell] Effective model fetch failed', error);
+        }
+        if (!controller.signal.aborted) setEffectiveModels([]);
+      }
+    }
+
+    void fetchEffectiveModels();
+
+    return () => controller.abort();
+  }, [config.endpoint, config.apiKey, config.openaiApiKey, config.headers]);
+
+  useEffect(() => {
+    const resolved = resolveActiveModel(config, effectiveModels, activeModelRef.current);
+    setActiveModel((current) => sameProviderModel(current, resolved) ? current : resolved);
+  }, [config.provider, config.model, effectiveModels]);
+
+  useEffect(() => {
+    if (!modelMenuOpen) return;
+
+    function handleModelMenuOutsidePointerDown(event: PointerEvent) {
+      if (!modelSelectorRef.current?.contains(event.target as Node)) {
+        setModelMenuOpen(false);
+      }
+    }
+
+    function handleModelMenuKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setModelMenuOpen(false);
+      }
+    }
+
+    document.addEventListener('pointerdown', handleModelMenuOutsidePointerDown, true);
+    document.addEventListener('keydown', handleModelMenuKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handleModelMenuOutsidePointerDown, true);
+      document.removeEventListener('keydown', handleModelMenuKeyDown);
+    };
+  }, [modelMenuOpen]);
 
   const postToParent = useCallback((message: Record<string, unknown>) => {
     window.parent.postMessage(message, parentOriginRef.current || '*');
@@ -446,7 +604,14 @@ export function WidgetApp() {
         messages: requestMessages,
         stream: true,
       };
-      if (configRef.current.model) requestBody.model = configRef.current.model;
+      const selectedModel = activeModelRef.current;
+      if (selectedModel) {
+        requestBody.provider = selectedModel.provider;
+        requestBody.model = selectedModel.model;
+      } else if (configRef.current.provider && configRef.current.model) {
+        requestBody.provider = configRef.current.provider;
+        requestBody.model = configRef.current.model;
+      } else if (configRef.current.model) requestBody.model = configRef.current.model;
       if (tools.length > 0) requestBody.tools = tools;
 
       const response = await fetch(configRef.current.endpoint || '/v1/chat/completions', {
@@ -899,6 +1064,16 @@ export function WidgetApp() {
     THINKING_MODE_OPTIONS.find((option) => option.value === String(thinkingMode))?.label || 'Auto'
   ), [thinkingMode]);
 
+  const selectedModelOption = useMemo(() => (
+    activeModel
+      ? effectiveModels.find((item) => item.provider === activeModel.provider && item.model === activeModel.model) || null
+      : null
+  ), [activeModel, effectiveModels]);
+
+  const selectedModelLabel = selectedModelOption ? modelOptionLabel(selectedModelOption) : '';
+
+  const showModelSelector = effectiveModels.length > 1 && Boolean(selectedModelOption);
+
   const scrollToMessage = useCallback((chatIndex: number) => {
     const messageNodes = document.querySelectorAll<HTMLElement>(
       '[data-slot="ai-chat-messages"] [data-slot="ai-message"]'
@@ -911,49 +1086,49 @@ export function WidgetApp() {
     <div className="ozwell-widget-shell">
       {(config.thinkingEnabled || showMessagesNav) && (
         <div className="ozwell-reasoning-bar">
-          {config.thinkingEnabled ? (
-            <div className="ozwell-thinking-control">
-              <Dropdown
-                open={thinkingMenuOpen}
-                onOpenChange={setThinkingMenuOpen}
-                placement="bottom-start"
-                width={248}
-                className="ozwell-thinking-menu"
-                trigger={(
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="secondary"
-                    className="ozwell-thinking-trigger"
-                    aria-label={`Show thinking: ${selectedThinkingLabel}`}
-                  >
-                    Show thinking: {selectedThinkingLabel}
-                  </Button>
-                )}
-              >
-                <DropdownContent className="ozwell-thinking-menu-content">
-                  {THINKING_MODE_OPTIONS.map((option) => (
-                    <DropdownItem
-                      key={option.value}
-                      searchText={`${option.label} ${option.description}`}
-                      onClick={() => selectThinkingMode(option.value)}
-                      className="ozwell-thinking-menu-item"
-                      aria-current={option.value === String(thinkingMode) ? 'true' : undefined}
+          <div className="ozwell-left-controls">
+            {config.thinkingEnabled ? (
+              <div className="ozwell-thinking-control">
+                <Dropdown
+                  open={thinkingMenuOpen}
+                  onOpenChange={setThinkingMenuOpen}
+                  placement="bottom-start"
+                  width={248}
+                  className="ozwell-thinking-menu"
+                  trigger={(
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="secondary"
+                      className="ozwell-thinking-trigger"
+                      aria-label={`Show thinking: ${selectedThinkingLabel}`}
                     >
-                      <Tooltip content={option.description} placement="right" delay={150} maxWidth={220}>
-                        <span className="ozwell-thinking-option">
-                          <span className="ozwell-thinking-option-label">{option.label}</span>
-                          <span className="ozwell-thinking-option-description">{option.description}</span>
-                        </span>
-                      </Tooltip>
-                    </DropdownItem>
-                  ))}
-                </DropdownContent>
-              </Dropdown>
-            </div>
-          ) : (
-            <span className="ozwell-control-spacer" aria-hidden="true" />
-          )}
+                      Show thinking: {selectedThinkingLabel}
+                    </Button>
+                  )}
+                >
+                  <DropdownContent className="ozwell-thinking-menu-content">
+                    {THINKING_MODE_OPTIONS.map((option) => (
+                      <DropdownItem
+                        key={option.value}
+                        searchText={`${option.label} ${option.description}`}
+                        onClick={() => selectThinkingMode(option.value)}
+                        className="ozwell-thinking-menu-item"
+                        aria-current={option.value === String(thinkingMode) ? 'true' : undefined}
+                      >
+                        <Tooltip content={option.description} placement="right" delay={150} maxWidth={220}>
+                          <span className="ozwell-thinking-option">
+                            <span className="ozwell-thinking-option-label">{option.label}</span>
+                            <span className="ozwell-thinking-option-description">{option.description}</span>
+                          </span>
+                        </Tooltip>
+                      </DropdownItem>
+                    ))}
+                  </DropdownContent>
+                </Dropdown>
+              </div>
+            ) : null}
+          </div>
           <div className="ozwell-reasoning-controls">
             {showMessagesNav && (
               <Dropdown
@@ -1016,6 +1191,56 @@ export function WidgetApp() {
         onClose={() => postToParent({ source: 'ozwell-chat-widget', type: 'closed' })}
         renderTextContent={renderTextContent}
       />
+
+      {showModelSelector && selectedModelOption ? (
+        <div className="ozwell-composer-model-control" ref={modelSelectorRef}>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            className="ozwell-composer-model-trigger"
+            aria-label={`Model: ${selectedModelLabel}`}
+            aria-haspopup="menu"
+            aria-expanded={modelMenuOpen}
+            onClick={() => setModelMenuOpen((open) => !open)}
+          >
+            <span className="ozwell-composer-model-label">{selectedModelOption.label}</span>
+            <span className="ozwell-composer-model-chevron" aria-hidden="true">{modelMenuOpen ? '⌃' : '⌄'}</span>
+          </Button>
+
+          {modelMenuOpen ? (
+            <div className="ozwell-composer-model-menu" role="menu">
+              <DropdownContent className="ozwell-model-menu-content">
+                <div className="ozwell-model-menu-summary" aria-hidden="true">
+                  <span>Model</span>
+                  <strong>{selectedModelOption.label}</strong>
+                </div>
+                {effectiveModels.map((option) => {
+                  const optionLabel = modelOptionLabel(option);
+                  const selected = option.provider === selectedModelOption.provider && option.model === selectedModelOption.model;
+                  return (
+                    <DropdownItem
+                      key={`${option.provider}:${option.model}`}
+                      searchText={optionLabel}
+                      onClick={() => {
+                        setActiveModel({ provider: option.provider, model: option.model });
+                        setModelMenuOpen(false);
+                      }}
+                      className="ozwell-model-menu-item"
+                      aria-current={selected ? 'true' : undefined}
+                    >
+                      <span className="ozwell-model-option">
+                        <span className="ozwell-model-provider">{providerLabel(option.provider)}</span>
+                        <span className="ozwell-model-name">{option.label}</span>
+                      </span>
+                    </DropdownItem>
+                  );
+                })}
+              </DropdownContent>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
 
       <div className="ozwell-footer">Powered by Ozwell</div>
     </div>

--- a/reference-server/embed/src/WidgetApp.tsx
+++ b/reference-server/embed/src/WidgetApp.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AIChat,
   Button,
+  ComposerModelSelector,
   Dropdown,
   DropdownContent,
   DropdownItem,
@@ -39,6 +40,7 @@ type ProviderModelOption = {
   model: string;
   id: string;
   label: string;
+  providerLabel?: string;
 };
 
 type ProviderModelSelection = Pick<ProviderModelOption, 'provider' | 'model'>;
@@ -169,7 +171,7 @@ function normalizeEffectiveModels(payload: unknown): ProviderModelOption[] {
     seen.add(key);
     const id = typeof record.id === 'string' && record.id.trim() ? record.id : model;
     const label = typeof record.label === 'string' && record.label.trim() ? record.label : model;
-    models.push({ provider, model, id, label });
+    models.push({ provider, model, id, label, providerLabel: providerLabel(provider) });
   }
 
   return models;
@@ -181,11 +183,6 @@ function providerLabel(provider: string) {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ') || provider;
-}
-
-function modelOptionLabel(option: ProviderModelSelection | ProviderModelOption) {
-  const label = 'label' in option && option.label ? option.label : option.model;
-  return `${providerLabel(option.provider)} / ${label}`;
 }
 
 function sameProviderModel(left: ProviderModelSelection | null, right: ProviderModelSelection | null) {
@@ -396,12 +393,10 @@ export function WidgetApp() {
   const [effectiveModels, setEffectiveModels] = useState<ProviderModelOption[]>([]);
   const [activeModel, setActiveModel] = useState<ProviderModelSelection | null>(null);
   const [providerFilter, setProviderFilter] = useState('any');
-  const [providerMenuOpen, setProviderMenuOpen] = useState(false);
-  const [modelMenuOpen, setModelMenuOpen] = useState(false);
 
   const configRef = useRef(config);
   const activeModelRef = useRef(activeModel);
-  const modelSelectorRef = useRef<HTMLDivElement | null>(null);
+  const shellRef = useRef<HTMLDivElement | null>(null);
   const historyRef = useRef(historyMessages);
   const parentOriginRef = useRef<string | null>(null);
   const pendingToolCallsRef = useRef<Record<string, true>>({});
@@ -460,31 +455,6 @@ export function WidgetApp() {
     const resolved = resolveActiveModel(config, effectiveModels, activeModelRef.current);
     setActiveModel((current) => sameProviderModel(current, resolved) ? current : resolved);
   }, [config.provider, config.model, effectiveModels]);
-
-  useEffect(() => {
-    if (!providerMenuOpen && !modelMenuOpen) return;
-
-    function handleModelMenuOutsidePointerDown(event: PointerEvent) {
-      if (!modelSelectorRef.current?.contains(event.target as Node)) {
-        setProviderMenuOpen(false);
-        setModelMenuOpen(false);
-      }
-    }
-
-    function handleModelMenuKeyDown(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        setProviderMenuOpen(false);
-        setModelMenuOpen(false);
-      }
-    }
-
-    document.addEventListener('pointerdown', handleModelMenuOutsidePointerDown, true);
-    document.addEventListener('keydown', handleModelMenuKeyDown);
-    return () => {
-      document.removeEventListener('pointerdown', handleModelMenuOutsidePointerDown, true);
-      document.removeEventListener('keydown', handleModelMenuKeyDown);
-    };
-  }, [providerMenuOpen, modelMenuOpen]);
 
   const postToParent = useCallback((message: Record<string, unknown>) => {
     window.parent.postMessage(message, parentOriginRef.current || '*');
@@ -1074,15 +1044,22 @@ export function WidgetApp() {
       : null
   ), [activeModel, effectiveModels]);
 
-  const selectedModelLabel = selectedModelOption ? modelOptionLabel(selectedModelOption) : '';
-  const providerOptions = useMemo(() => Array.from(new Set(effectiveModels.map((item) => item.provider))), [effectiveModels]);
-  const visibleModelOptions = useMemo(() => (
-    providerFilter === 'any'
-      ? effectiveModels
-      : effectiveModels.filter((item) => item.provider === providerFilter)
-  ), [effectiveModels, providerFilter]);
-
   const showModelSelector = effectiveModels.length > 1 && Boolean(selectedModelOption);
+
+  const composerModelSelector = showModelSelector && selectedModelOption ? (
+    <ComposerModelSelector
+      models={effectiveModels}
+      value={activeModel}
+      onChange={setActiveModel}
+      providerFilter={providerFilter}
+      onProviderFilterChange={setProviderFilter}
+      boundaryRef={shellRef}
+      className="ozwell-composer-model-selector"
+    />
+  ) : undefined;
+  const inputPlaceholder = showModelSelector
+    ? 'Ask a question...'
+    : (config.placeholder || DEFAULT_CONFIG.placeholder);
 
   const scrollToMessage = useCallback((chatIndex: number) => {
     const messageNodes = document.querySelectorAll<HTMLElement>(
@@ -1093,7 +1070,7 @@ export function WidgetApp() {
   }, []);
 
   return (
-    <div className="ozwell-widget-shell">
+    <div className="ozwell-widget-shell" ref={shellRef}>
       {(config.thinkingEnabled || showMessagesNav) && (
         <div className="ozwell-reasoning-bar">
           <div className="ozwell-left-controls">
@@ -1192,7 +1169,7 @@ export function WidgetApp() {
         messages={chatMessages}
         isGenerating={sending}
         title={config.title || DEFAULT_CONFIG.title}
-        inputPlaceholder={config.placeholder || DEFAULT_CONFIG.placeholder}
+        inputPlaceholder={inputPlaceholder}
         showHeader={false}
         height="100%"
         variant="embedded"
@@ -1200,103 +1177,8 @@ export function WidgetApp() {
         onSendMessage={(message) => void sendMessage(message)}
         onClose={() => postToParent({ source: 'ozwell-chat-widget', type: 'closed' })}
         renderTextContent={renderTextContent}
+        composerProps={{ inputTrailing: composerModelSelector }}
       />
-
-      {showModelSelector && selectedModelOption ? (
-        <div className="ozwell-composer-model-control" ref={modelSelectorRef}>
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            className="ozwell-composer-model-trigger"
-            aria-label={`Provider filter: ${providerFilter === 'any' ? 'Any' : providerLabel(providerFilter)}`}
-            aria-haspopup="menu"
-            aria-expanded={providerMenuOpen}
-            onClick={() => {
-              setProviderMenuOpen((open) => !open);
-              setModelMenuOpen(false);
-            }}
-          >
-            <span className="ozwell-composer-model-label">{providerFilter === 'any' ? 'Any provider' : providerLabel(providerFilter)}</span>
-            <span className="ozwell-composer-model-chevron" aria-hidden="true">{providerMenuOpen ? '⌃' : '⌄'}</span>
-          </Button>
-
-          {providerMenuOpen ? (
-            <div className="ozwell-composer-model-menu" role="menu">
-              <DropdownContent className="ozwell-model-menu-content">
-                {['any', ...providerOptions].map((provider) => (
-                  <DropdownItem
-                    key={provider}
-                    searchText={provider === 'any' ? 'Any provider' : providerLabel(provider)}
-                    onClick={() => {
-                      setProviderFilter(provider);
-                      if (provider !== 'any') {
-                        const currentVisible = activeModelRef.current?.provider === provider
-                          ? effectiveModels.find((item) => item.provider === provider && item.model === activeModelRef.current?.model)
-                          : null;
-                        const next = currentVisible || effectiveModels.find((item) => item.provider === provider);
-                        if (next) setActiveModel({ provider: next.provider, model: next.model });
-                      }
-                      setProviderMenuOpen(false);
-                    }}
-                    className="ozwell-model-menu-item"
-                    aria-current={provider === providerFilter ? 'true' : undefined}
-                  >
-                    <span className="ozwell-model-option">
-                      <span className="ozwell-model-name">{provider === 'any' ? 'Any provider' : providerLabel(provider)}</span>
-                    </span>
-                  </DropdownItem>
-                ))}
-              </DropdownContent>
-            </div>
-          ) : null}
-
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            className="ozwell-composer-model-trigger ozwell-composer-model-trigger-wide"
-            aria-label={`Model: ${selectedModelLabel}`}
-            aria-haspopup="menu"
-            aria-expanded={modelMenuOpen}
-            onClick={() => {
-              setModelMenuOpen((open) => !open);
-              setProviderMenuOpen(false);
-            }}
-          >
-            <span className="ozwell-composer-model-label">{selectedModelOption.label}</span>
-            <span className="ozwell-composer-model-chevron" aria-hidden="true">{modelMenuOpen ? '⌃' : '⌄'}</span>
-          </Button>
-
-          {modelMenuOpen ? (
-            <div className="ozwell-composer-model-menu ozwell-composer-model-menu-wide" role="menu">
-              <DropdownContent className="ozwell-model-menu-content">
-                {visibleModelOptions.map((option) => {
-                  const optionLabel = modelOptionLabel(option);
-                  const selected = option.provider === selectedModelOption.provider && option.model === selectedModelOption.model;
-                  return (
-                    <DropdownItem
-                      key={`${option.provider}:${option.model}`}
-                      searchText={optionLabel}
-                      onClick={() => {
-                        setActiveModel({ provider: option.provider, model: option.model });
-                        setModelMenuOpen(false);
-                      }}
-                      className="ozwell-model-menu-item"
-                      aria-current={selected ? 'true' : undefined}
-                    >
-                      <span className="ozwell-model-option">
-                        <span className="ozwell-model-provider">{providerLabel(option.provider)}</span>
-                        <span className="ozwell-model-name">{option.label}</span>
-                      </span>
-                    </DropdownItem>
-                  );
-                })}
-              </DropdownContent>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
 
       <div className="ozwell-footer">Powered by Ozwell</div>
     </div>

--- a/reference-server/embed/src/WidgetApp.tsx
+++ b/reference-server/embed/src/WidgetApp.tsx
@@ -395,6 +395,8 @@ export function WidgetApp() {
   const [messagesButtonFlare, setMessagesButtonFlare] = useState(false);
   const [effectiveModels, setEffectiveModels] = useState<ProviderModelOption[]>([]);
   const [activeModel, setActiveModel] = useState<ProviderModelSelection | null>(null);
+  const [providerFilter, setProviderFilter] = useState('any');
+  const [providerMenuOpen, setProviderMenuOpen] = useState(false);
   const [modelMenuOpen, setModelMenuOpen] = useState(false);
 
   const configRef = useRef(config);
@@ -460,16 +462,18 @@ export function WidgetApp() {
   }, [config.provider, config.model, effectiveModels]);
 
   useEffect(() => {
-    if (!modelMenuOpen) return;
+    if (!providerMenuOpen && !modelMenuOpen) return;
 
     function handleModelMenuOutsidePointerDown(event: PointerEvent) {
       if (!modelSelectorRef.current?.contains(event.target as Node)) {
+        setProviderMenuOpen(false);
         setModelMenuOpen(false);
       }
     }
 
     function handleModelMenuKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
+        setProviderMenuOpen(false);
         setModelMenuOpen(false);
       }
     }
@@ -480,7 +484,7 @@ export function WidgetApp() {
       document.removeEventListener('pointerdown', handleModelMenuOutsidePointerDown, true);
       document.removeEventListener('keydown', handleModelMenuKeyDown);
     };
-  }, [modelMenuOpen]);
+  }, [providerMenuOpen, modelMenuOpen]);
 
   const postToParent = useCallback((message: Record<string, unknown>) => {
     window.parent.postMessage(message, parentOriginRef.current || '*');
@@ -1071,6 +1075,12 @@ export function WidgetApp() {
   ), [activeModel, effectiveModels]);
 
   const selectedModelLabel = selectedModelOption ? modelOptionLabel(selectedModelOption) : '';
+  const providerOptions = useMemo(() => Array.from(new Set(effectiveModels.map((item) => item.provider))), [effectiveModels]);
+  const visibleModelOptions = useMemo(() => (
+    providerFilter === 'any'
+      ? effectiveModels
+      : effectiveModels.filter((item) => item.provider === providerFilter)
+  ), [effectiveModels, providerFilter]);
 
   const showModelSelector = effectiveModels.length > 1 && Boolean(selectedModelOption);
 
@@ -1199,23 +1209,69 @@ export function WidgetApp() {
             size="sm"
             variant="secondary"
             className="ozwell-composer-model-trigger"
+            aria-label={`Provider filter: ${providerFilter === 'any' ? 'Any' : providerLabel(providerFilter)}`}
+            aria-haspopup="menu"
+            aria-expanded={providerMenuOpen}
+            onClick={() => {
+              setProviderMenuOpen((open) => !open);
+              setModelMenuOpen(false);
+            }}
+          >
+            <span className="ozwell-composer-model-label">{providerFilter === 'any' ? 'Any provider' : providerLabel(providerFilter)}</span>
+            <span className="ozwell-composer-model-chevron" aria-hidden="true">{providerMenuOpen ? '⌃' : '⌄'}</span>
+          </Button>
+
+          {providerMenuOpen ? (
+            <div className="ozwell-composer-model-menu" role="menu">
+              <DropdownContent className="ozwell-model-menu-content">
+                {['any', ...providerOptions].map((provider) => (
+                  <DropdownItem
+                    key={provider}
+                    searchText={provider === 'any' ? 'Any provider' : providerLabel(provider)}
+                    onClick={() => {
+                      setProviderFilter(provider);
+                      if (provider !== 'any') {
+                        const currentVisible = activeModelRef.current?.provider === provider
+                          ? effectiveModels.find((item) => item.provider === provider && item.model === activeModelRef.current?.model)
+                          : null;
+                        const next = currentVisible || effectiveModels.find((item) => item.provider === provider);
+                        if (next) setActiveModel({ provider: next.provider, model: next.model });
+                      }
+                      setProviderMenuOpen(false);
+                    }}
+                    className="ozwell-model-menu-item"
+                    aria-current={provider === providerFilter ? 'true' : undefined}
+                  >
+                    <span className="ozwell-model-option">
+                      <span className="ozwell-model-name">{provider === 'any' ? 'Any provider' : providerLabel(provider)}</span>
+                    </span>
+                  </DropdownItem>
+                ))}
+              </DropdownContent>
+            </div>
+          ) : null}
+
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            className="ozwell-composer-model-trigger ozwell-composer-model-trigger-wide"
             aria-label={`Model: ${selectedModelLabel}`}
             aria-haspopup="menu"
             aria-expanded={modelMenuOpen}
-            onClick={() => setModelMenuOpen((open) => !open)}
+            onClick={() => {
+              setModelMenuOpen((open) => !open);
+              setProviderMenuOpen(false);
+            }}
           >
             <span className="ozwell-composer-model-label">{selectedModelOption.label}</span>
             <span className="ozwell-composer-model-chevron" aria-hidden="true">{modelMenuOpen ? '⌃' : '⌄'}</span>
           </Button>
 
           {modelMenuOpen ? (
-            <div className="ozwell-composer-model-menu" role="menu">
+            <div className="ozwell-composer-model-menu ozwell-composer-model-menu-wide" role="menu">
               <DropdownContent className="ozwell-model-menu-content">
-                <div className="ozwell-model-menu-summary" aria-hidden="true">
-                  <span>Model</span>
-                  <strong>{selectedModelOption.label}</strong>
-                </div>
-                {effectiveModels.map((option) => {
+                {visibleModelOptions.map((option) => {
                   const optionLabel = modelOptionLabel(option);
                   const selected = option.provider === selectedModelOption.provider && option.model === selectedModelOption.model;
                   return (

--- a/reference-server/embed/src/types.ts
+++ b/reference-server/embed/src/types.ts
@@ -8,6 +8,7 @@ export interface OzwellConfig {
   openaiApiKey?: string;
   title?: string;
   placeholder?: string;
+  provider?: string;
   model?: string;
   system?: string;
   tools?: OpenAITool[];

--- a/reference-server/embed/src/widget.css
+++ b/reference-server/embed/src/widget.css
@@ -23,6 +23,7 @@ textarea {
 }
 
 .ozwell-widget-shell {
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -61,6 +62,136 @@ textarea {
 
 .ozwell-reasoning-controls button {
   white-space: nowrap;
+}
+
+.ozwell-left-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.ozwell-widget-shell [data-slot="composer-input"] {
+  padding-bottom: 42px;
+  padding-right: 168px;
+}
+
+.ozwell-composer-model-control {
+  position: absolute;
+  right: 58px;
+  bottom: 42px;
+  z-index: 20;
+}
+
+.ozwell-composer-model-trigger {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 30px;
+  max-width: 168px;
+  padding-inline: 12px !important;
+  border-radius: 999px !important;
+  background: #e2e8f0 !important;
+  color: #263241 !important;
+  box-shadow: inset 0 0 0 1px rgba(100, 116, 139, 0.18);
+}
+
+.ozwell-composer-model-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ozwell-composer-model-chevron {
+  flex: 0 0 auto;
+  color: #64748b;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.ozwell-composer-model-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 10px);
+  width: min(320px, calc(100vw - 24px));
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 14px;
+  background: rgba(31, 35, 40, 0.98);
+  box-shadow: 0 18px 60px rgba(15, 23, 42, 0.22);
+}
+
+.ozwell-model-menu-content {
+  max-height: min(320px, 58vh);
+  overflow-y: auto;
+  padding: 6px;
+  background: rgba(31, 35, 40, 0.98);
+  color: #f8fafc;
+}
+
+.ozwell-model-menu-summary {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 8px 12px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  color: #f8fafc;
+  font-size: 13px;
+}
+
+.ozwell-model-menu-summary strong {
+  min-width: 0;
+  max-width: 160px;
+  overflow: hidden;
+  color: #cbd5e1;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ozwell-model-menu-item {
+  padding: 7px 8px !important;
+}
+
+.ozwell-model-menu-item[aria-current="true"] {
+  background: rgba(14, 165, 233, 0.18) !important;
+  color: #e5e7eb !important;
+}
+
+.ozwell-model-menu-item [data-slot="dropdown-item-label"] {
+  min-width: 0;
+  width: 100%;
+}
+
+.ozwell-model-option {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  width: 100%;
+}
+
+.ozwell-model-provider {
+  color: #93c5fd;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.ozwell-model-name {
+  overflow: hidden;
+  color: #e5e7eb;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ozwell-model-menu-item[aria-current="true"] .ozwell-model-name {
+  color: #f8fafc;
 }
 
 .ozwell-thinking-control {

--- a/reference-server/embed/src/widget.css
+++ b/reference-server/embed/src/widget.css
@@ -71,120 +71,28 @@ textarea {
   min-width: 0;
 }
 
-.ozwell-widget-shell [data-slot="composer-input"] {
-  padding-bottom: 42px;
-  padding-right: 236px;
+.ozwell-widget-shell [data-slot="composer-input-wrapper"] {
+  min-width: 0;
 }
 
-.ozwell-composer-model-control {
-  position: absolute;
-  right: 58px;
-  bottom: 42px;
-  z-index: 20;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  max-width: calc(100% - 72px);
+.ozwell-composer-model-selector {
+  max-width: min(142px, 38vw);
 }
 
-.ozwell-composer-model-trigger {
-  display: inline-flex !important;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  min-height: 30px;
-  max-width: 104px;
-  padding-inline: 10px !important;
-  border-radius: 999px !important;
-  border: 1px solid #d8e0ec !important;
-  background: #ffffff !important;
-  color: #334155 !important;
+.ozwell-composer-model-selector[data-slot="composer-model-selector-trigger"] {
+  min-height: 32px;
+  background: #ffffff;
+  color: #334155;
+  border-color: #d8e0ec;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
-.ozwell-composer-model-trigger-wide {
-  max-width: 126px;
+.ozwell-widget-shell [data-slot="composer-input"]:has(+ [data-slot="composer-input-trailing"]) {
+  padding-right: min(160px, 44vw);
 }
 
-.ozwell-composer-model-label {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ozwell-composer-model-chevron {
-  flex: 0 0 auto;
-  color: #64748b;
-  font-size: 14px;
-  line-height: 1;
-}
-
-.ozwell-composer-model-menu {
-  position: absolute;
-  right: 0;
-  bottom: calc(100% + 10px);
-  width: min(220px, calc(100vw - 24px));
-  overflow: hidden;
-  border: 1px solid #d8e0ec;
-  border-radius: 12px;
-  background: #ffffff;
-  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.18);
-}
-
-.ozwell-composer-model-menu-wide {
-  width: min(292px, calc(100vw - 24px));
-}
-
-.ozwell-model-menu-content {
-  max-height: min(240px, 44vh);
-  overflow-y: auto;
-  padding: 6px;
-  background: #ffffff;
-  color: #334155;
-}
-
-.ozwell-model-menu-item {
-  padding: 7px 8px !important;
-  color: #334155 !important;
-}
-
-.ozwell-model-menu-item[aria-current="true"] {
-  background: #e8f4f8 !important;
-  color: #0f5268 !important;
-}
-
-.ozwell-model-menu-item [data-slot="dropdown-item-label"] {
-  min-width: 0;
-  width: 100%;
-}
-
-.ozwell-model-option {
-  display: grid;
-  gap: 2px;
-  min-width: 0;
-  width: 100%;
-}
-
-.ozwell-model-provider {
-  color: #147895;
-  font-size: 11px;
-  font-weight: 700;
-  line-height: 1.2;
-}
-
-.ozwell-model-name {
-  overflow: hidden;
-  color: #334155;
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 1.25;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ozwell-model-menu-item[aria-current="true"] .ozwell-model-name {
-  color: #0f5268;
+[data-slot="composer-model-selector-menu"] {
+  --mieweb-primary: #147895;
 }
 
 .ozwell-thinking-control {

--- a/reference-server/embed/src/widget.css
+++ b/reference-server/embed/src/widget.css
@@ -73,7 +73,7 @@ textarea {
 
 .ozwell-widget-shell [data-slot="composer-input"] {
   padding-bottom: 42px;
-  padding-right: 168px;
+  padding-right: 236px;
 }
 
 .ozwell-composer-model-control {
@@ -81,6 +81,10 @@ textarea {
   right: 58px;
   bottom: 42px;
   z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: calc(100% - 72px);
 }
 
 .ozwell-composer-model-trigger {
@@ -89,12 +93,17 @@ textarea {
   justify-content: center;
   gap: 6px;
   min-height: 30px;
-  max-width: 168px;
-  padding-inline: 12px !important;
+  max-width: 104px;
+  padding-inline: 10px !important;
   border-radius: 999px !important;
-  background: #e2e8f0 !important;
-  color: #263241 !important;
-  box-shadow: inset 0 0 0 1px rgba(100, 116, 139, 0.18);
+  border: 1px solid #d8e0ec !important;
+  background: #ffffff !important;
+  color: #334155 !important;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.ozwell-composer-model-trigger-wide {
+  max-width: 126px;
 }
 
 .ozwell-composer-model-label {
@@ -115,50 +124,34 @@ textarea {
   position: absolute;
   right: 0;
   bottom: calc(100% + 10px);
-  width: min(320px, calc(100vw - 24px));
+  width: min(220px, calc(100vw - 24px));
   overflow: hidden;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  border-radius: 14px;
-  background: rgba(31, 35, 40, 0.98);
-  box-shadow: 0 18px 60px rgba(15, 23, 42, 0.22);
+  border: 1px solid #d8e0ec;
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.18);
+}
+
+.ozwell-composer-model-menu-wide {
+  width: min(292px, calc(100vw - 24px));
 }
 
 .ozwell-model-menu-content {
-  max-height: min(320px, 58vh);
+  max-height: min(240px, 44vh);
   overflow-y: auto;
   padding: 6px;
-  background: rgba(31, 35, 40, 0.98);
-  color: #f8fafc;
-}
-
-.ozwell-model-menu-summary {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 12px;
-  align-items: center;
-  padding: 10px 8px 12px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
-  color: #f8fafc;
-  font-size: 13px;
-}
-
-.ozwell-model-menu-summary strong {
-  min-width: 0;
-  max-width: 160px;
-  overflow: hidden;
-  color: #cbd5e1;
-  font-weight: 650;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  background: #ffffff;
+  color: #334155;
 }
 
 .ozwell-model-menu-item {
   padding: 7px 8px !important;
+  color: #334155 !important;
 }
 
 .ozwell-model-menu-item[aria-current="true"] {
-  background: rgba(14, 165, 233, 0.18) !important;
-  color: #e5e7eb !important;
+  background: #e8f4f8 !important;
+  color: #0f5268 !important;
 }
 
 .ozwell-model-menu-item [data-slot="dropdown-item-label"] {
@@ -174,7 +167,7 @@ textarea {
 }
 
 .ozwell-model-provider {
-  color: #93c5fd;
+  color: #147895;
   font-size: 11px;
   font-weight: 700;
   line-height: 1.2;
@@ -182,7 +175,7 @@ textarea {
 
 .ozwell-model-name {
   overflow: hidden;
-  color: #e5e7eb;
+  color: #334155;
   font-size: 12px;
   font-weight: 500;
   line-height: 1.25;
@@ -191,7 +184,7 @@ textarea {
 }
 
 .ozwell-model-menu-item[aria-current="true"] .ozwell-model-name {
-  color: #f8fafc;
+  color: #0f5268;
 }
 
 .ozwell-thinking-control {

--- a/reference-server/test/widget-tool-flow.test.js
+++ b/reference-server/test/widget-tool-flow.test.js
@@ -3,10 +3,20 @@ import { readFile } from 'node:fs/promises';
 import { test } from 'node:test';
 
 const WIDGET_PATH = new URL('../embed/ozwell.js', import.meta.url);
+const WIDGET_APP_PATH = new URL('../embed/src/WidgetApp.tsx', import.meta.url);
+const WIDGET_TYPES_PATH = new URL('../embed/src/types.ts', import.meta.url);
 const LOADER_PATH = new URL('../embed/ozwell-loader.js', import.meta.url);
 
 async function readWidgetSource() {
   return readFile(WIDGET_PATH, 'utf8');
+}
+
+async function readWidgetAppSource() {
+  return readFile(WIDGET_APP_PATH, 'utf8');
+}
+
+async function readWidgetTypesSource() {
+  return readFile(WIDGET_TYPES_PATH, 'utf8');
 }
 
 async function readLoaderSource() {
@@ -73,4 +83,39 @@ test('loader returns a tool error if the page handler never responds', async () 
   assert.match(source, /function finishToolCall\(message\)/);
   assert.match(source, /Tool "\$\{toolName\}" did not respond/);
   assert.match(source, /call respond\(\) or error\(\)/);
+});
+
+test('widget fetches effective provider model options for the selector', async () => {
+  const appSource = await readWidgetAppSource();
+  const bundleSource = await readWidgetSource();
+
+  assert.match(appSource, /\/v1\/models\/effective/);
+  assert.match(appSource, /function effectiveModelsEndpoint/);
+  assert.match(bundleSource, /\/v1\/models\/effective/);
+});
+
+test('widget chat payload can include selected provider and model', async () => {
+  const appSource = await readWidgetAppSource();
+  const typesSource = await readWidgetTypesSource();
+
+  assert.match(typesSource, /provider\?: string/);
+  assert.match(appSource, /requestBody\.provider = selectedModel\.provider/);
+  assert.match(appSource, /requestBody\.model = selectedModel\.model/);
+});
+
+test('widget model selector is anchored to the composer and closes on outside click', async () => {
+  const appSource = await readWidgetAppSource();
+  const bundleSource = await readWidgetSource();
+
+  assert.match(appSource, /ozwell-composer-model-control/);
+  assert.match(appSource, /ozwell-composer-model-menu/);
+  assert.match(appSource, /document\.addEventListener\('pointerdown', handleModelMenuOutsidePointerDown, true\)/);
+  assert.doesNotMatch(appSource, /className="ozwell-model-menu"/);
+  assert.match(bundleSource, /ozwell-composer-model-control/);
+});
+
+test('widget preserves legacy model-only chat config when no provider is resolved', async () => {
+  const appSource = await readWidgetAppSource();
+
+  assert.match(appSource, /else if \(configRef\.current\.model\) requestBody\.model = configRef\.current\.model;/);
 });

--- a/reference-server/test/widget-tool-flow.test.js
+++ b/reference-server/test/widget-tool-flow.test.js
@@ -103,17 +103,16 @@ test('widget chat payload can include selected provider and model', async () => 
   assert.match(appSource, /requestBody\.model = selectedModel\.model/);
 });
 
-test('widget model selector is anchored to the composer and closes on outside click', async () => {
+test('widget model selector uses the shared composer selector anchored to the composer', async () => {
   const appSource = await readWidgetAppSource();
   const bundleSource = await readWidgetSource();
 
-  assert.match(appSource, /ozwell-composer-model-control/);
-  assert.match(appSource, /providerFilter === 'any'/);
-  assert.match(appSource, /visibleModelOptions/);
-  assert.match(appSource, /ozwell-composer-model-menu/);
-  assert.match(appSource, /document\.addEventListener\('pointerdown', handleModelMenuOutsidePointerDown, true\)/);
+  assert.match(appSource, /ComposerModelSelector/);
+  assert.match(appSource, /composerProps=\{\{ inputTrailing: composerModelSelector \}\}/);
+  assert.match(appSource, /providerFilter=\{providerFilter\}/);
+  assert.match(appSource, /boundaryRef=\{shellRef\}/);
   assert.doesNotMatch(appSource, /className="ozwell-model-menu"/);
-  assert.match(bundleSource, /ozwell-composer-model-control/);
+  assert.match(bundleSource, /composer-model-selector-trigger/);
 });
 
 test('widget preserves legacy model-only chat config when no provider is resolved', async () => {

--- a/reference-server/test/widget-tool-flow.test.js
+++ b/reference-server/test/widget-tool-flow.test.js
@@ -108,6 +108,8 @@ test('widget model selector is anchored to the composer and closes on outside cl
   const bundleSource = await readWidgetSource();
 
   assert.match(appSource, /ozwell-composer-model-control/);
+  assert.match(appSource, /providerFilter === 'any'/);
+  assert.match(appSource, /visibleModelOptions/);
   assert.match(appSource, /ozwell-composer-model-menu/);
   assert.match(appSource, /document\.addEventListener\('pointerdown', handleModelMenuOutsidePointerDown, true\)/);
   assert.doesNotMatch(appSource, /className="ozwell-model-menu"/);


### PR DESCRIPTION
## Summary

Adds a ChatGPT-style model selector inside the widget composer.

- fetches effective provider/model options from the backend
- lets consumers switch among allowed models from the input area
- sends the selected provider/model with chat requests
- keeps legacy model-only config behavior

Closes #228