### PR TITLE
feat(embeddings): return real embeddings from /v1/embeddings (#231)

### DIFF
--- a/reference-server/.env.example
+++ b/reference-server/.env.example
@@ -72,6 +72,22 @@ OLLAMA_BASE_URL=http://localhost:11434
 #
 # If OLLAMA_MODEL is not set, the server auto-detects from available models.
 # Common models: llama3.2:latest, llama3.1:latest, mistral:latest, qwen2.5-coder:3b
+#
+# OLLAMA_EMBED_MODEL — embedding model used for /v1/embeddings when routing to
+# Ollama. Requested OpenAI model names (e.g. text-embedding-3-small) don't exist
+# in Ollama, so the server maps them to this model. Pull it first:
+#   ollama pull nomic-embed-text
+# OLLAMA_EMBED_MODEL=nomic-embed-text
+
+# ============================================
+# EMBEDDINGS
+# ============================================
+# POST /v1/embeddings follows the same backend priority as chat:
+#   1. LLM_BASE_URL configured → proxied to the OpenAI-compatible /v1/embeddings
+#      (OpenAI, Portkey Gateway). Best for text-embedding-3-small @ 1536 dims.
+#   2. Ollama reachable        → OLLAMA_EMBED_MODEL via /api/embed
+#   3. Deterministic mock      → only when ALLOW_MOCK=true (see below); otherwise
+#      a 503 is returned so a missing/unreachable backend stays visible.
 
 # ============================================
 # OUTPUT LIMIT

--- a/reference-server/src/routes/embeddings.ts
+++ b/reference-server/src/routes/embeddings.ts
@@ -1,10 +1,90 @@
 import { FastifyPluginAsync } from 'fastify';
-import { validateAuth, createError, generateEmbedding, countTokens } from '../util';
+import { validateAuth, createError, generateEmbedding, countTokens, isLLMBackendConfigured, isOllamaAvailable } from '../util';
+
+// Hoist static env reads (these never change at runtime)
+const LLM_BASE_URL = process.env.LLM_BASE_URL || '';
+const LLM_API_KEY = process.env.LLM_API_KEY || '';
+const LLM_PROVIDER = process.env.LLM_PROVIDER || '';
+const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'http://127.0.0.1:11434';
+// Embedding model to use when routing to Ollama. Requested OpenAI model names
+// (e.g. text-embedding-3-small) don't exist in Ollama, so map to a real one.
+const OLLAMA_EMBED_MODEL = process.env.OLLAMA_EMBED_MODEL || 'nomic-embed-text';
+// Mock embeddings are OFF by default so a real backend failure surfaces as a 503
+// instead of returning semantically meaningless vectors. Set ALLOW_MOCK=true to
+// return deterministic mock embeddings when no backend is configured or reachable.
+const MOCK_ENABLED = process.env.ALLOW_MOCK === 'true';
+
+// Known OpenAI embedding models and their native dimensions.
+const MODEL_DIMENSIONS: Record<string, number> = {
+  'text-embedding-3-small': 1536,
+  'text-embedding-3-large': 3072,
+  'text-embedding-ada-002': 1536,
+};
+
+// Marks a mock embeddings response so callers can always tell a deterministic
+// mock from real vectors. Mirrors the mock-warning semantics in chat.ts.
+function buildMockWarning(model: string) {
+  return {
+    type: 'mock_response' as const,
+    reason: 'no_backend' as const,
+    model,
+    message: `No embeddings backend configured or reachable — deterministic mock returned for model ${model}. These vectors are semantically meaningless.`,
+  };
+}
+
+type EmbeddingItem = { object: 'embedding'; embedding: number[]; index: number };
+
+/**
+ * Forward the request to an OpenAI-compatible embeddings backend
+ * (OpenAI, Portkey Gateway, etc.).
+ */
+async function fetchLLMEmbeddings(body: {
+  model: string;
+  input: string[];
+  dimensions?: number;
+  encoding_format?: string;
+}): Promise<Response> {
+  const headers: Record<string, string> = {
+    'Authorization': `Bearer ${LLM_API_KEY}`,
+    'Content-Type': 'application/json',
+  };
+  if (LLM_PROVIDER) headers['x-portkey-provider'] = LLM_PROVIDER;
+
+  return fetch(`${LLM_BASE_URL}/v1/embeddings`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Fetch embeddings from a local/remote Ollama instance via its native /api/embed
+ * endpoint (supports batch string arrays). Returns one vector per input.
+ */
+async function fetchOllamaEmbeddings(inputs: string[]): Promise<number[][]> {
+  const resp = await fetch(`${OLLAMA_BASE_URL}/api/embed`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: OLLAMA_EMBED_MODEL, input: inputs }),
+  });
+  if (!resp.ok) {
+    const errText = await resp.text();
+    throw new Error(`Ollama embeddings failed (${resp.status}): ${errText}`);
+  }
+  const data = (await resp.json()) as { embeddings?: number[][] };
+  if (!Array.isArray(data.embeddings) || data.embeddings.length !== inputs.length) {
+    throw new Error('Ollama returned an unexpected embeddings payload');
+  }
+  return data.embeddings;
+}
 
 const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
   // POST /v1/embeddings
   fastify.post('/v1/embeddings', {
     schema: {
+      summary: 'Create embeddings',
+      description: 'Creates an embedding vector representing the input text. Routes to a configured OpenAI-compatible backend (LLM_BASE_URL) or a local Ollama instance, falling back to deterministic mock vectors when ALLOW_MOCK is enabled. Accepts a single string or an array of strings.',
+      tags: ['Embeddings'],
       headers: {
         type: 'object',
         properties: {
@@ -15,10 +95,16 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
         type: 'object',
         properties: {
           model: { type: 'string' },
-          input: { 
-            type: 'string'
+          input: {
+            // Accept either a single string or an array of strings (batch).
+            anyOf: [
+              { type: 'string' },
+              { type: 'array', items: { type: 'string' } },
+            ],
           },
-          dimensions: { type: 'number' }
+          dimensions: { type: 'number' },
+          encoding_format: { type: 'string', enum: ['float', 'base64'] },
+          user: { type: 'string' },
         },
         required: ['model', 'input']
       }
@@ -30,22 +116,20 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
       return createError('Invalid API key provided', 'invalid_request_error');
     }
 
-    const body = request.body as any;
-    const { model, input, dimensions } = body;
-
-    // Validate model and get dimensions
-    const modelDimensions: Record<string, number> = {
-      'text-embedding-3-small': 1536,
-      'text-embedding-3-large': 3072,
-      'text-embedding-ada-002': 1536,
+    const body = request.body as {
+      model: string;
+      input: string | string[];
+      dimensions?: number;
+      encoding_format?: string;
     };
+    const { model, input, dimensions, encoding_format } = body;
 
-    if (!modelDimensions[model]) {
+    // Normalize input to an array (batch) and reject empty batches.
+    const inputs = Array.isArray(input) ? input : [input];
+    if (inputs.length === 0) {
       reply.code(400);
-      return createError(`Model '${model}' not found`, 'invalid_request_error', 'model');
+      return createError('Input must not be empty', 'invalid_request_error', 'input');
     }
-
-    const actualDimensions = dimensions || modelDimensions[model];
 
     // Add OpenAI-compatible headers
     reply.headers({
@@ -54,26 +138,103 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
       'openai-version': '2020-10-01',
     });
 
-    // Handle both string and array inputs
-    const inputs = Array.isArray(input) ? input : [input];
-    
-    const embeddings = inputs.map((text: string, index: number) => ({
-      object: 'embedding' as const,
+    // Backend selection priority (mirrors chat.ts):
+    //   1. LLM_BASE_URL configured → OpenAI-compatible backend (OpenAI, Portkey Gateway)
+    //   2. Ollama reachable        → local embeddings via /api/embed
+    //   3. Deterministic mock      → flagged fallback (only when ALLOW_MOCK=true)
+    const llmConfigured = isLLMBackendConfigured();
+    const ollamaAvailable = llmConfigured ? false : await isOllamaAvailable();
+
+    // ── 1. OpenAI-compatible backend (proxy request through) ──
+    if (llmConfigured) {
+      try {
+        const upstream = await fetchLLMEmbeddings({
+          model,
+          input: inputs,
+          ...(dimensions !== undefined && { dimensions }),
+          ...(encoding_format !== undefined && { encoding_format }),
+        });
+
+        if (!upstream.ok) {
+          const errBody = await upstream.text();
+          reply.code(upstream.status);
+          try {
+            return JSON.parse(errBody);
+          } catch {
+            return createError(errBody, 'upstream_error');
+          }
+        }
+
+        // Upstream is OpenAI-compatible; return its body verbatim.
+        return await upstream.json();
+      } catch (err) {
+        request.log.error({ err }, 'LLM embeddings backend request failed');
+        reply.code(502);
+        return createError(
+          `Embeddings backend request failed: ${err instanceof Error ? err.message : 'unknown error'}`,
+          'upstream_error',
+        );
+      }
+    }
+
+    // ── 2. Ollama backend ──
+    if (ollamaAvailable) {
+      try {
+        const vectors = await fetchOllamaEmbeddings(inputs);
+        const data: EmbeddingItem[] = vectors.map((embedding, index) => ({
+          object: 'embedding',
+          embedding,
+          index,
+        }));
+        const totalTokens = inputs.reduce((sum, text) => sum + countTokens(text), 0);
+        return {
+          object: 'list' as const,
+          data,
+          model,
+          usage: {
+            prompt_tokens: totalTokens,
+            total_tokens: totalTokens,
+          },
+        };
+      } catch (err) {
+        request.log.error({ err }, 'Ollama embeddings backend request failed');
+        reply.code(502);
+        return createError(
+          `Embeddings backend request failed: ${err instanceof Error ? err.message : 'unknown error'}`,
+          'upstream_error',
+        );
+      }
+    }
+
+    // ── 3. Deterministic mock fallback (only when ALLOW_MOCK=true) ──
+    // Determine dimensions: explicit request wins, else the known model default,
+    // else fall back to 1536 (text-embedding-3-small).
+    const actualDimensions = dimensions || MODEL_DIMENSIONS[model] || 1536;
+
+    if (!MOCK_ENABLED) {
+      reply.code(503);
+      return createError(
+        'No embeddings backend configured or reachable and mock responses are disabled. Set LLM_BASE_URL (or run Ollama), or set ALLOW_MOCK=true to return deterministic mock embeddings.',
+        'server_error',
+      );
+    }
+
+    const data: EmbeddingItem[] = inputs.map((text, index) => ({
+      object: 'embedding',
       embedding: generateEmbedding(text, actualDimensions),
       index,
     }));
-
-    // Calculate token usage
-    const totalTokens = inputs.reduce((sum: number, text: string) => sum + countTokens(text), 0);
+    const totalTokens = inputs.reduce((sum, text) => sum + countTokens(text), 0);
 
     return {
       object: 'list' as const,
-      data: embeddings,
+      data,
       model,
       usage: {
         prompt_tokens: totalTokens,
         total_tokens: totalTokens,
       },
+      warning: buildMockWarning(model),
     };
   });
 };

--- a/reference-server/test/embeddings.test.js
+++ b/reference-server/test/embeddings.test.js
@@ -1,0 +1,163 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const API_KEY = 'ozw_demo_localhost_key_for_testing';
+const PORT = 3337;
+const BASE = `http://localhost:${PORT}`;
+
+let server;
+let tmp;
+
+async function waitForReady(base, maxMs = 10_000) {
+  const start = Date.now();
+  while (Date.now() - start < maxMs) {
+    try {
+      const r = await fetch(`${base}/health`);
+      if (r.status === 200) return;
+    } catch { /* not ready */ }
+    await delay(200);
+  }
+  throw new Error('server never became ready');
+}
+
+// Spawn a reference server with mock/LLM env fully controlled so dotenv/.env
+// can't leak a real backend into the test.
+function spawnServer({ port, dbPath, allowMock }) {
+  const env = {
+    ...process.env,
+    PORT: String(port),
+    DB_PATH: dbPath,
+    NODE_ENV: 'development',
+    // Force mock mode — no real LLM/Ollama backend during tests.
+    LLM_BASE_URL: '',
+    LLM_API_KEY: '',
+    LLM_PROVIDER: '',
+    // Point Ollama at an unused port so isOllamaAvailable() resolves false fast.
+    OLLAMA_BASE_URL: 'http://127.0.0.1:59999',
+  };
+  if (allowMock) env.ALLOW_MOCK = 'true';
+  else delete env.ALLOW_MOCK;
+  return spawn('npm', ['run', 'dev'], {
+    cwd: process.cwd(),
+    stdio: 'pipe',
+    detached: true,
+    env,
+  });
+}
+
+before(async () => {
+  tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-embeddings-test-'));
+  const dbPath = path.join(tmp, 'ozwell.db');
+  server = spawnServer({ port: PORT, dbPath, allowMock: true });
+  await waitForReady(BASE);
+});
+
+after(() => {
+  try { process.kill(-server.pid, 'SIGKILL'); } catch { /* ignore */ }
+  try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+async function postEmbeddings(body, { auth = API_KEY } = {}) {
+  return fetch(`${BASE}/v1/embeddings`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(auth ? { Authorization: `Bearer ${auth}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// --- Success (mock fallback) cases ---
+
+test('embeddings — single string input returns one 1536-dim vector', async () => {
+  const r = await postEmbeddings({ model: 'text-embedding-3-small', input: 'hello world' });
+  assert.equal(r.status, 200);
+  const json = await r.json();
+  assert.equal(json.object, 'list');
+  assert.equal(json.model, 'text-embedding-3-small');
+  assert.equal(json.data.length, 1);
+  assert.equal(json.data[0].object, 'embedding');
+  assert.equal(json.data[0].index, 0);
+  assert.equal(json.data[0].embedding.length, 1536);
+  assert.ok(json.usage.total_tokens > 0);
+  // Mock responses are flagged so callers can tell them from real vectors.
+  assert.equal(json.warning?.type, 'mock_response');
+  assert.equal(json.warning?.reason, 'no_backend');
+});
+
+test('embeddings — array input returns one vector per item with correct indices', async () => {
+  const r = await postEmbeddings({ model: 'text-embedding-3-small', input: ['hello', 'world', 'foo'] });
+  assert.equal(r.status, 200);
+  const json = await r.json();
+  assert.equal(json.data.length, 3);
+  assert.deepEqual(json.data.map((d) => d.index), [0, 1, 2]);
+  for (const item of json.data) {
+    assert.equal(item.embedding.length, 1536);
+  }
+});
+
+test('embeddings — deterministic mock is stable for identical input', async () => {
+  const r1 = await postEmbeddings({ model: 'text-embedding-3-small', input: 'repeatable' });
+  const r2 = await postEmbeddings({ model: 'text-embedding-3-small', input: 'repeatable' });
+  const [j1, j2] = [await r1.json(), await r2.json()];
+  assert.deepEqual(j1.data[0].embedding, j2.data[0].embedding);
+});
+
+test('embeddings — explicit dimensions parameter is honored', async () => {
+  const r = await postEmbeddings({ model: 'text-embedding-3-small', input: 'hello', dimensions: 256 });
+  assert.equal(r.status, 200);
+  const json = await r.json();
+  assert.equal(json.data[0].embedding.length, 256);
+});
+
+test('embeddings — text-embedding-3-large defaults to 3072 dims', async () => {
+  const r = await postEmbeddings({ model: 'text-embedding-3-large', input: 'hello' });
+  assert.equal(r.status, 200);
+  const json = await r.json();
+  assert.equal(json.data[0].embedding.length, 3072);
+});
+
+// --- Error cases ---
+
+test('embeddings — missing API key returns 401', async () => {
+  const r = await postEmbeddings({ model: 'text-embedding-3-small', input: 'hello' }, { auth: null });
+  assert.equal(r.status, 401);
+});
+
+test('embeddings — missing input returns 400', async () => {
+  const r = await postEmbeddings({ model: 'text-embedding-3-small' });
+  assert.equal(r.status, 400);
+});
+
+// --- Mock disabled: no backend + ALLOW_MOCK unset → 503 ---
+
+test('embeddings — 503 when no backend and mock disabled', async () => {
+  const localTmp = mkdtempSync(path.join(tmpdir(), 'ozwell-embeddings-nomock-'));
+  const localPort = 3338;
+  const localBase = `http://localhost:${localPort}`;
+  const localServer = spawnServer({
+    port: localPort,
+    dbPath: path.join(localTmp, 'ozwell.db'),
+    allowMock: false,
+  });
+  try {
+    await waitForReady(localBase);
+    const r = await fetch(`${localBase}/v1/embeddings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${API_KEY}` },
+      body: JSON.stringify({ model: 'text-embedding-3-small', input: 'hello' }),
+    });
+    assert.equal(r.status, 503);
+    const json = await r.json();
+    assert.equal(json.error.type, 'server_error');
+  } finally {
+    try { process.kill(-localServer.pid, 'SIGKILL'); } catch { /* ignore */ }
+    try { rmSync(localTmp, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});


### PR DESCRIPTION
## Summary
Makes `POST /v1/embeddings` return **real** embeddings instead of deterministic-only mock vectors, unblocking ozwell-workspace semantic search (which routes embeddings through ozwellai-api).

Closes #231.

## What changed
Mirrors the `chat.ts` backend-selection pattern in [reference-server/src/routes/embeddings.ts](reference-server/src/routes/embeddings.ts):

1. **LLM backend** — when `LLM_BASE_URL` is set, proxy to the OpenAI-compatible `/v1/embeddings` (OpenAI or Portkey Gateway; forwards `x-portkey-provider`).
2. **Ollama** — when reachable, call the native `/api/embed` (batch) using `OLLAMA_EMBED_MODEL`.
3. **Mock fallback** — deterministic vectors, now **flagged** with a `warning` field and gated by `ALLOW_MOCK`. Returns `503` when no backend is reachable and mock is disabled (matches `chat.ts` mock-warning semantics).

## Acceptance criteria (#231)
- [x] Returns real vectors when a provider is configured (Portkey→OpenAI or Ollama)
- [x] Accepts both string and array `input` (batch)
- [x] OpenAI-compatible response shape (`object: 'list'`, `data[].embedding`, `usage`)
- [x] Deterministic mock kept as a flagged, `ALLOW_MOCK`-gated fallback
- [x] Supports `text-embedding-3-small` @ 1536 dims

## Other changes
- New `OLLAMA_EMBED_MODEL` env (default `nomic-embed-text`) + docs in `.env.example`
- Fastify body schema now accepts `string | string[]`
- New test suite `reference-server/test/embeddings.test.js` (8 tests, all passing)

## Testing
- `npm run build` — clean
- `npm run lint` — no new errors
- `node --test test/embeddings.test.js` — 8/8 pass
- Verified live against a real backend: `cat`~`kitten` = 0.57, `cat`~`airplane` = 0.24 (semantically meaningful, not mock)

> Manual curl check in a comment below.

> Note: pre-existing `manager-auth.test.js` failures are unrelated to this change (they fail in isolation).