### PR TITLE
Add dev2 deploy automation

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,16 +1,18 @@
 name: Deploy Demo Site
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
+      - dev
     paths:
       - 'landing-page/**'
       - '.github/workflows/deploy-demo.yml'
       - 'reference-server/embed/**'
 
 concurrency:
-  group: deploy-demo
+  group: deploy-demo-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -32,9 +34,10 @@ jobs:
           path: landing-page-build.tar.gz
           retention-days: 1
 
-  deploy:
+  deploy-prod:
     name: Deploy to ozwell-prod landing
     needs: build
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
 
     steps:
@@ -84,3 +87,75 @@ jobs:
 
             # Cleanup
             rm /tmp/landing-page-build.tar.gz
+
+  deploy-dev:
+    name: Deploy to ozwell-dev2 landing
+    needs: build
+    if: github.ref_name == 'dev'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: landing-page-build
+
+      - name: Set up SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          DEPLOY_HOSTNAME: ${{ vars.OZWELL_DEV2_HOST || 'ozwell-dev2.os.mieweb.org' }}
+          DEPLOY_PORT: ${{ vars.OZWELL_DEV2_PORT || '2029' }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$SSH_PRIVATE_KEY" ]]; then
+            echo "SSH_PRIVATE_KEY is required"
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p "$DEPLOY_PORT" "$DEPLOY_HOSTNAME" >> ~/.ssh/known_hosts
+
+      - name: Upload to dev2
+        env:
+          DEPLOY_HOSTNAME: ${{ vars.OZWELL_DEV2_HOST || 'ozwell-dev2.os.mieweb.org' }}
+          DEPLOY_PORT: ${{ vars.OZWELL_DEV2_PORT || '2029' }}
+          DEPLOY_USER: ${{ vars.OZWELL_DEV2_USER || 'adamerla' }}
+        run: rsync -e "ssh -p $DEPLOY_PORT" -ruva --progress landing-page-build.tar.gz "$DEPLOY_USER@$DEPLOY_HOSTNAME:/tmp/"
+
+      - name: Extract and restart dev2 landing
+        env:
+          DEPLOY_HOSTNAME: ${{ vars.OZWELL_DEV2_HOST || 'ozwell-dev2.os.mieweb.org' }}
+          DEPLOY_PORT: ${{ vars.OZWELL_DEV2_PORT || '2029' }}
+          DEPLOY_USER: ${{ vars.OZWELL_DEV2_USER || 'adamerla' }}
+          DEPLOY_PATH: ${{ vars.OZWELL_DEV2_DEPLOY_PATH || '/home/adamerla/ozwellai-api' }}
+          DEV_MANAGER_URL: ${{ vars.OZWELL_DEV2_MANAGER_URL || 'https://ozwellconsole.os.mieweb.org' }}
+        run: |
+          set -euo pipefail
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOSTNAME" "DEPLOY_PATH='$DEPLOY_PATH' DEV_MANAGER_URL='$DEV_MANAGER_URL' bash -s" <<'REMOTE'
+            set -euo pipefail
+
+            deploy_path="${DEPLOY_PATH:-/home/adamerla/ozwellai-api}"
+            dev_manager_url="${DEV_MANAGER_URL:-https://ozwellconsole.os.mieweb.org}"
+            cd "$deploy_path"
+
+            tar -xzf /tmp/landing-page-build.tar.gz
+
+            cd landing-page
+            npm ci --omit=dev
+
+            touch .env
+            if grep -q '^MANAGER_URL=' .env; then
+              sed -i "s|^MANAGER_URL=.*|MANAGER_URL=${dev_manager_url}|" .env
+            else
+              printf '\nMANAGER_URL=%s\n' "$dev_manager_url" >> .env
+            fi
+
+            pm2 stop landing || true
+            pm2 delete landing || true
+            pm2 start server.js --name landing
+            pm2 save
+
+            rm /tmp/landing-page-build.tar.gz
+          REMOTE

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -122,7 +122,7 @@ jobs:
           DEPLOY_HOSTNAME: ${{ vars.OZWELL_DEV2_HOST || 'ozwell-dev2.os.mieweb.org' }}
           DEPLOY_PORT: ${{ vars.OZWELL_DEV2_PORT || '2029' }}
           DEPLOY_USER: ${{ vars.OZWELL_DEV2_USER || 'adamerla' }}
-        run: rsync -e "ssh -p $DEPLOY_PORT" -ruva --progress landing-page-build.tar.gz "$DEPLOY_USER@$DEPLOY_HOSTNAME:/tmp/"
+        run: rsync -e "ssh -p $DEPLOY_PORT" -av --progress landing-page-build.tar.gz "$DEPLOY_USER@$DEPLOY_HOSTNAME:/tmp/"
 
       - name: Extract and restart dev2 landing
         env:

--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - 'reference-server/**'
       - 'clients/typescript/**'
@@ -15,7 +16,7 @@ on:
       - '.github/workflows/deploy-reference-server.yml'
 
 concurrency:
-  group: deploy-reference-server
+  group: deploy-reference-server-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -60,9 +61,10 @@ jobs:
           path: reference-server-build.tar.gz
           retention-days: 1
 
-  deploy:
+  deploy-prod:
     name: Deploy to ozwell-prod refserver
     needs: build
+    if: github.ref_name == 'main'
     # Placeholder pending Aaron's exact self-hosted runner labels.
     # Expected target server name from Aaron: ozwell-phxdc-node1.
     runs-on: [self-hosted, ozwell-phxdc-node1]
@@ -163,5 +165,69 @@ jobs:
             sudo chmod +x "$start_script"
 
             eval "$RESTART_COMMAND"
+            rm /tmp/reference-server-build.tar.gz
+          REMOTE
+
+  deploy-dev:
+    name: Deploy to ozwell-dev2 refserver
+    needs: build
+    if: github.ref_name == 'dev'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: reference-server-build
+
+      - name: Set up SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          DEPLOY_HOSTNAME: ${{ vars.OZWELL_DEV2_HOST || 'ozwell-dev2.os.mieweb.org' }}
+          DEPLOY_PORT: ${{ vars.OZWELL_DEV2_PORT || '2029' }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$SSH_PRIVATE_KEY" ]]; then
+            echo "SSH_PRIVATE_KEY is required"
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p "$DEPLOY_PORT" "$DEPLOY_HOSTNAME" >> ~/.ssh/known_hosts
+
+      - name: Upload to dev2
+        env:
+          DEPLOY_HOSTNAME: ${{ vars.OZWELL_DEV2_HOST || 'ozwell-dev2.os.mieweb.org' }}
+          DEPLOY_PORT: ${{ vars.OZWELL_DEV2_PORT || '2029' }}
+          DEPLOY_USER: ${{ vars.OZWELL_DEV2_USER || 'adamerla' }}
+        run: rsync -e "ssh -p $DEPLOY_PORT" -ruva --progress reference-server-build.tar.gz "$DEPLOY_USER@$DEPLOY_HOSTNAME:/tmp/"
+
+      - name: Extract and restart dev2 refserver
+        env:
+          DEPLOY_HOSTNAME: ${{ vars.OZWELL_DEV2_HOST || 'ozwell-dev2.os.mieweb.org' }}
+          DEPLOY_PORT: ${{ vars.OZWELL_DEV2_PORT || '2029' }}
+          DEPLOY_USER: ${{ vars.OZWELL_DEV2_USER || 'adamerla' }}
+          DEPLOY_PATH: ${{ vars.OZWELL_DEV2_DEPLOY_PATH || '/home/adamerla/ozwellai-api' }}
+        run: |
+          set -euo pipefail
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOSTNAME" "DEPLOY_PATH='$DEPLOY_PATH' bash -s" <<'REMOTE'
+            set -euo pipefail
+
+            deploy_path="${DEPLOY_PATH:-/home/adamerla/ozwellai-api}"
+            cd "$deploy_path"
+
+            rm -rf reference-server/dist clients/typescript/dist spec/dist
+            tar -xzf /tmp/reference-server-build.tar.gz
+
+            npm ci --omit=dev --workspace reference-server --include-workspace-root=false
+
+            cd reference-server
+            pm2 stop refserver || true
+            pm2 delete refserver || true
+            pm2 start npm --name refserver -- start
+            pm2 save
+
             rm /tmp/reference-server-build.tar.gz
           REMOTE

--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -202,7 +202,7 @@ jobs:
           DEPLOY_HOSTNAME: ${{ vars.OZWELL_DEV2_HOST || 'ozwell-dev2.os.mieweb.org' }}
           DEPLOY_PORT: ${{ vars.OZWELL_DEV2_PORT || '2029' }}
           DEPLOY_USER: ${{ vars.OZWELL_DEV2_USER || 'adamerla' }}
-        run: rsync -e "ssh -p $DEPLOY_PORT" -ruva --progress reference-server-build.tar.gz "$DEPLOY_USER@$DEPLOY_HOSTNAME:/tmp/"
+        run: rsync -e "ssh -p $DEPLOY_PORT" -av --progress reference-server-build.tar.gz "$DEPLOY_USER@$DEPLOY_HOSTNAME:/tmp/"
 
       - name: Extract and restart dev2 refserver
         env:

--- a/landing-page/public/landing.html
+++ b/landing-page/public/landing.html
@@ -104,7 +104,7 @@ instructions: |
             </button>
             <div class="method-tab-content" id="method-builder">
               <p>Configure and manage your agents in the Ozwell Manager console.</p>
-              <a href="https://ozwellmanager.os.mieweb.org/" class="demo-link" style="display:inline-block; margin-top:0.5rem;">Open Agent Manager →</a>
+              <a href="__MANAGER_URL__/" class="demo-link" style="display:inline-block; margin-top:0.5rem;">Open Agent Manager →</a>
             </div>
           </div>
 
@@ -167,7 +167,7 @@ instructions: |
         <a href="/tictactoe.html" class="demo-link">
           Play Tic-Tac-Toe Demo →
         </a>
-        <a href="https://ozwellmanager.os.mieweb.org/" class="demo-link">
+        <a href="__MANAGER_URL__/" class="demo-link">
           Manage Agents →
         </a>
         <a href="https://github.com/mieweb/ozwellai-api/blob/main/docs/frontend/mcp-postmessage-standard.md" target="_blank" class="demo-link">

--- a/landing-page/server.js
+++ b/landing-page/server.js
@@ -10,6 +10,7 @@ const __dirname = path.dirname(__filename);
 const app = express();
 const port = Number(process.env.PORT || process.env.EMBED_TEST_PORT || 8080);
 const referenceBaseUrl = (process.env.REFERENCE_SERVER_URL || 'http://localhost:3000').replace(/\/$/, '');
+const managerUrl = (process.env.MANAGER_URL || 'https://ozwellmanager.os.mieweb.org/').replace(/\/$/, '');
 
 // Agent keys injected into HTML at serve time (keeps keys out of source control)
 const landingAgentKey = process.env.LANDING_AGENT_KEY || '';
@@ -47,6 +48,7 @@ function renderHtml(filename) {
   const html = fs.readFileSync(filePath, 'utf8');
   return html
     .replace(/__REFERENCE_BASE_URL__/g, referenceBaseUrl)
+    .replace(/__MANAGER_URL__/g, managerUrl)
     .replace(/__LANDING_AGENT_KEY__/g, landingAgentKey)
     .replace(/__TICTACTOE_AGENT_KEY__/g, tictactoeAgentKey);
 }
@@ -66,7 +68,7 @@ app.get('/tictactoe.html', (req, res) => {
 // register.html was retired; agent management moved to Ozwell Manager.
 // Keep old bookmarks/inbound links working with a permanent redirect.
 app.get('/register.html', (req, res) => {
-  res.redirect(301, 'https://ozwellmanager.os.mieweb.org/');
+  res.redirect(301, `${managerUrl}/`);
 });
 
 app.get('*', (req, res, next) => {


### PR DESCRIPTION
## Summary
- reuse the existing refserver and landing deploy workflows for `dev` pushes
- add dev2 deploy jobs for both refserver and landing using direct SSH/rsync
- preserve dev2's current `/home/adamerla/ozwellai-api` + PM2 + local `.env` shape while deploying build artifacts
- make the landing manager URL environment-driven so dev2 can use `ozwellconsole` without dirty tracked files
- include root workspace manifests in the refserver deploy package so remote installs can use the root lockfile


## Validation
- `git diff --check`
- `bash -n scripts/build-deploy-package.sh scripts/build-demo-package.sh`
- `node --check landing-page/server.js`
- workflow YAML parse

Fixes #234
