### PR TITLE
fix: align manager auth proxy with forwarded headers

### DIFF
--- a/reference-server/test/manager-auth.test.js
+++ b/reference-server/test/manager-auth.test.js
@@ -210,15 +210,22 @@ test('manager auth — /v1/manager/me auto-provisions user and parent key from t
 
         const db = new Database(dbPath);
         try {
-            const user = db.prepare('SELECT external_user_id, username, email, status, is_admin FROM users WHERE external_user_id = ?').get('admin-user');
-            assert.deepEqual(user, {
+            const user = db.prepare('SELECT id, external_user_id, username, email, status, is_admin FROM users WHERE external_user_id = ?').get('admin-user');
+            assert.match(user.id, /^mgr_/);
+            assert.deepEqual({
+                external_user_id: user.external_user_id,
+                username: user.username,
+                email: user.email,
+                status: user.status,
+                is_admin: user.is_admin,
+            }, {
                 external_user_id: 'admin-user',
                 username: 'testadmin',
                 email: 'test-admin@example.test',
                 status: 'active',
                 is_admin: 0,
             });
-            const key = db.prepare('SELECT id, key, user_id, status FROM api_keys WHERE user_id = ?').get('mgr_admin-user');
+            const key = db.prepare('SELECT id, key, user_id, status FROM api_keys WHERE user_id = ?').get(user.id);
             assert.ok(key.id);
             assert.match(key.key, /^ozw_/);
             assert.doesNotMatch(key.key, /^ozw_manager-/);

--- a/reference-server/test/manager-auth.test.js
+++ b/reference-server/test/manager-auth.test.js
@@ -16,18 +16,18 @@ const PORT = 3341;
 const BASE = `http://localhost:${PORT}`;
 
 const MANAGER_HEADERS = {
-    'x-user-id': '2009',
-    'x-username': 'adamerla',
-    'x-user-first-name': 'A',
-    'x-user-last-name': 'Damerla',
-    'x-email': 'adamerla128@gmail.com',
+    'x-user': 'admin-user',
+    'x-preferred-username': 'testadmin',
+    'x-user-first-name': 'Test',
+    'x-user-last-name': 'Admin',
+    'x-email': 'test-admin@example.test',
     'x-groups': 'ldapusers',
 };
 
 const H_YAML = { 'Content-Type': 'application/yaml', ...MANAGER_HEADERS };
 const OTHER_MANAGER_HEADERS = {
-    'x-user-id': '2010',
-    'x-username': 'otheruser',
+    'x-user': 'other-user',
+    'x-preferred-username': 'otheruser',
     'x-user-first-name': 'Other',
     'x-user-last-name': 'User',
     'x-email': 'other@example.test',
@@ -35,7 +35,7 @@ const OTHER_MANAGER_HEADERS = {
 };
 const OTHER_H_YAML = { 'Content-Type': 'application/yaml', ...OTHER_MANAGER_HEADERS };
 
-async function waitForReady(maxMs = 10_000) {
+async function waitForReady(maxMs = 30_000) {
     const start = Date.now();
     while (Date.now() - start < maxMs) {
         try {
@@ -111,7 +111,7 @@ function stopServer(server, tmp) {
 function getUserAndActiveKey(dbPath) {
     const db = new Database(dbPath);
     try {
-        const user = db.prepare('SELECT id FROM users WHERE external_user_id = ?').get(MANAGER_HEADERS['x-user-id']);
+        const user = db.prepare('SELECT id FROM users WHERE external_user_id = ?').get(MANAGER_HEADERS['x-user']);
         assert.ok(user?.id, 'manager user should exist');
         const key = db.prepare("SELECT id, key, status FROM api_keys WHERE user_id = ? AND COALESCE(status, 'active') = 'active' AND revoked_at IS NULL").get(user.id);
         assert.ok(key?.id, 'manager user should have an active parent key');
@@ -199,9 +199,9 @@ test('manager auth — /v1/manager/me auto-provisions user and parent key from t
         const res = await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
         assert.equal(res.status, 200);
         const body = await res.json();
-        assert.equal(body.identity.external_user_id, '2009');
-        assert.equal(body.identity.username, 'adamerla');
-        assert.equal(body.identity.email, 'adamerla128@gmail.com');
+        assert.equal(body.identity.external_user_id, 'admin-user');
+        assert.equal(body.identity.username, 'testadmin');
+        assert.equal(body.identity.email, 'test-admin@example.test');
         assert.equal(body.status, 'active');
         assert.equal(body.is_admin, false);
         assert.equal(body.has_parent_key, true);
@@ -210,15 +210,15 @@ test('manager auth — /v1/manager/me auto-provisions user and parent key from t
 
         const db = new Database(dbPath);
         try {
-            const user = db.prepare('SELECT external_user_id, username, email, status, is_admin FROM users WHERE external_user_id = ?').get('2009');
+            const user = db.prepare('SELECT external_user_id, username, email, status, is_admin FROM users WHERE external_user_id = ?').get('admin-user');
             assert.deepEqual(user, {
-                external_user_id: '2009',
-                username: 'adamerla',
-                email: 'adamerla128@gmail.com',
+                external_user_id: 'admin-user',
+                username: 'testadmin',
+                email: 'test-admin@example.test',
                 status: 'active',
                 is_admin: 0,
             });
-            const key = db.prepare('SELECT id, key, user_id, status FROM api_keys WHERE user_id = ?').get('mgr_2009');
+            const key = db.prepare('SELECT id, key, user_id, status FROM api_keys WHERE user_id = ?').get('mgr_admin-user');
             assert.ok(key.id);
             assert.match(key.key, /^ozw_/);
             assert.doesNotMatch(key.key, /^ozw_manager-/);
@@ -424,7 +424,7 @@ test('manager auth — claim-key moves auto-key agents to claimed parent key and
 
         const db = new Database(dbPath);
         try {
-            const user = db.prepare('SELECT id FROM users WHERE external_user_id = ?').get('2009');
+            const user = db.prepare('SELECT id FROM users WHERE external_user_id = ?').get('admin-user');
             const claimedKey = db.prepare('SELECT user_id, status, revoked_at FROM api_keys WHERE id = ?').get('existing-key');
             assert.equal(claimedKey.user_id, user.id);
             assert.equal(claimedKey.status, 'active');
@@ -494,7 +494,7 @@ test('manager auth — /v1/manager/models returns allowed models without bearer 
 });
 
 test('manager admin — bootstrap admin can view users and non-admin cannot', async () => {
-    const { server, tmp } = startServer({ adminExternalUserIds: '2009' });
+    const { server, tmp } = startServer({ adminExternalUserIds: 'admin-user' });
     try {
         await waitForReady();
 
@@ -507,8 +507,8 @@ test('manager admin — bootstrap admin can view users and non-admin cannot', as
         const users = await fetch(`${BASE}/v1/manager/admin/users`, { headers: MANAGER_HEADERS });
         assert.equal(users.status, 200);
         const usersBody = await users.json();
-        const adminUser = usersBody.data.find(user => user.external_user_id === '2009');
-        const otherUser = usersBody.data.find(user => user.external_user_id === '2010');
+        const adminUser = usersBody.data.find(user => user.external_user_id === 'admin-user');
+        const otherUser = usersBody.data.find(user => user.external_user_id === 'other-user');
         assert.equal(adminUser.is_admin, true);
         assert.match(adminUser.current_parent_key.key_hint, /^ozw_\.\.\.[a-z0-9]{4}$/);
         assert.equal(adminUser.current_parent_key.status, 'active');
@@ -526,12 +526,12 @@ test('manager admin — bootstrap admin can view users and non-admin cannot', as
 });
 
 test('manager admin — can promote and demote users with self-demote guard', async () => {
-    const { server, tmp, dbPath } = startServer({ adminExternalUserIds: '2009' });
+    const { server, tmp, dbPath } = startServer({ adminExternalUserIds: 'admin-user' });
     try {
         await waitForReady();
         await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
         await fetch(`${BASE}/v1/manager/me`, { headers: OTHER_MANAGER_HEADERS });
-        const other = getUserByExternalId(dbPath, '2010');
+        const other = getUserByExternalId(dbPath, 'other-user');
 
         const promote = await fetch(`${BASE}/v1/manager/admin/users/${other.id}/promote`, {
             method: 'POST',
@@ -559,7 +559,7 @@ test('manager admin — can promote and demote users with self-demote guard', as
 });
 
 test('manager admin — revoking a parent key disables agent keys under it', async () => {
-    const { server, tmp, dbPath } = startServer({ adminExternalUserIds: '2009' });
+    const { server, tmp, dbPath } = startServer({ adminExternalUserIds: 'admin-user' });
     try {
         await waitForReady();
         await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
@@ -572,7 +572,7 @@ test('manager admin — revoking a parent key disables agent keys under it', asy
         });
         assert.equal(create.status, 201);
         const created = await create.json();
-        const otherParentKey = getActiveKeyForExternalUser(dbPath, '2010');
+        const otherParentKey = getActiveKeyForExternalUser(dbPath, 'other-user');
 
         const revoke = await fetch(`${BASE}/v1/manager/admin/parent-keys/${otherParentKey.id}/revoke`, {
             method: 'POST',
@@ -601,7 +601,7 @@ test('manager admin — revoking a parent key disables agent keys under it', asy
 });
 
 test('manager admin — user-first APIs include key history, agents, and usage metrics', async () => {
-    const { server, tmp, dbPath } = startServer({ adminExternalUserIds: '2009' });
+    const { server, tmp, dbPath } = startServer({ adminExternalUserIds: 'admin-user' });
     try {
         await waitForReady();
         await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
@@ -659,7 +659,7 @@ test('manager admin — user-first APIs include key history, agents, and usage m
 
         const users = await fetch(`${BASE}/v1/manager/admin/users`, { headers: MANAGER_HEADERS });
         assert.equal(users.status, 200);
-        const userRow = (await users.json()).data.find(user => user.external_user_id === '2009');
+        const userRow = (await users.json()).data.find(user => user.external_user_id === 'admin-user');
         assert.equal(userRow.agent_count, 1);
         assert.equal(userRow.metrics.request_count, 2);
         assert.ok(userRow.metrics.total_tokens > 0);
@@ -669,7 +669,7 @@ test('manager admin — user-first APIs include key history, agents, and usage m
         const detail = await fetch(`${BASE}/v1/manager/admin/users/${userRow.id}`, { headers: MANAGER_HEADERS });
         assert.equal(detail.status, 200);
         const detailBody = await detail.json();
-        assert.equal(detailBody.user.external_user_id, '2009');
+        assert.equal(detailBody.user.external_user_id, 'admin-user');
         assert.equal(detailBody.parent_keys.length, 1);
         assert.equal(detailBody.parent_keys[0].metrics.request_count, 2);
         assert.ok(detailBody.parent_keys[0].metrics.total_tokens > 0);
@@ -794,7 +794,7 @@ test('manager auth — gpt-5 streaming request omits unsupported temperature', a
 });
 
 test('manager admin — global key and agent table routes are not exposed', async () => {
-    const { server, tmp } = startServer({ adminExternalUserIds: '2009' });
+    const { server, tmp } = startServer({ adminExternalUserIds: 'admin-user' });
     try {
         await waitForReady();
         await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });

--- a/scripts/dev/manager-auth-proxy.js
+++ b/scripts/dev/manager-auth-proxy.js
@@ -7,11 +7,11 @@ const listenPort = Number(process.env.LOCAL_AUTH_PROXY_PORT || 3100);
 const target = new URL(process.env.LOCAL_AUTH_PROXY_TARGET || 'http://localhost:3000');
 
 const injectedHeaders = {
-  'x-user-id': process.env.LOCAL_AUTH_X_USER_ID || 'local-dev-user-1',
-  'x-username': process.env.LOCAL_AUTH_X_USERNAME || 'localdev',
-  'x-user-first-name': process.env.LOCAL_AUTH_X_USER_FIRST_NAME || 'Local',
-  'x-user-last-name': process.env.LOCAL_AUTH_X_USER_LAST_NAME || 'Developer',
-  'x-email': process.env.LOCAL_AUTH_X_EMAIL || 'localdev@example.test',
+  'x-user': process.env.LOCAL_AUTH_X_USER || process.env.LOCAL_AUTH_X_USER_ID || 'local-dev-user-1',
+  'x-preferred-username': process.env.LOCAL_AUTH_X_USERNAME || 'exampleuser',
+  'x-user-first-name': process.env.LOCAL_AUTH_X_USER_FIRST_NAME || 'Example',
+  'x-user-last-name': process.env.LOCAL_AUTH_X_USER_LAST_NAME || 'User',
+  'x-email': process.env.LOCAL_AUTH_X_EMAIL || 'example-user@example.test',
   'x-groups': process.env.LOCAL_AUTH_X_GROUPS || 'ldapusers',
 };
 
@@ -49,5 +49,5 @@ const server = http.createServer((clientReq, clientRes) => {
 
 server.listen(listenPort, '127.0.0.1', () => {
   console.log(`[manager-auth-proxy] http://localhost:${listenPort} -> ${target.origin}`);
-  console.log(`[manager-auth-proxy] injecting x-user-id=${injectedHeaders['x-user-id']} x-username=${injectedHeaders['x-username']} x-email=${injectedHeaders['x-email']}`);
+  console.log(`[manager-auth-proxy] injecting x-user=${injectedHeaders['x-user']} x-preferred-username=${injectedHeaders['x-preferred-username']} x-email=${injectedHeaders['x-email']}`);
 });

--- a/scripts/dev/manager-auth-proxy.js
+++ b/scripts/dev/manager-auth-proxy.js
@@ -6,9 +6,14 @@ import { URL } from 'node:url';
 const listenPort = Number(process.env.LOCAL_AUTH_PROXY_PORT || 3100);
 const target = new URL(process.env.LOCAL_AUTH_PROXY_TARGET || 'http://localhost:3000');
 
+const localUser = process.env.LOCAL_AUTH_X_USER || process.env.LOCAL_AUTH_X_USER_ID || 'local-dev-user-1';
+const localUsername = process.env.LOCAL_AUTH_X_USERNAME || 'exampleuser';
+
 const injectedHeaders = {
-  'x-user': process.env.LOCAL_AUTH_X_USER || process.env.LOCAL_AUTH_X_USER_ID || 'local-dev-user-1',
-  'x-preferred-username': process.env.LOCAL_AUTH_X_USERNAME || 'exampleuser',
+  'x-user': localUser,
+  'x-user-id': localUser,
+  'x-preferred-username': localUsername,
+  'x-username': localUsername,
   'x-user-first-name': process.env.LOCAL_AUTH_X_USER_FIRST_NAME || 'Example',
   'x-user-last-name': process.env.LOCAL_AUTH_X_USER_LAST_NAME || 'User',
   'x-email': process.env.LOCAL_AUTH_X_EMAIL || 'example-user@example.test',
@@ -49,5 +54,5 @@ const server = http.createServer((clientReq, clientRes) => {
 
 server.listen(listenPort, '127.0.0.1', () => {
   console.log(`[manager-auth-proxy] http://localhost:${listenPort} -> ${target.origin}`);
-  console.log(`[manager-auth-proxy] injecting x-user=${injectedHeaders['x-user']} x-preferred-username=${injectedHeaders['x-preferred-username']} x-email=${injectedHeaders['x-email']}`);
+  console.log(`[manager-auth-proxy] injecting x-user=${injectedHeaders['x-user']} x-user-id=${injectedHeaders['x-user-id']} x-preferred-username=${injectedHeaders['x-preferred-username']} x-username=${injectedHeaders['x-username']} x-email=${injectedHeaders['x-email']}`);
 });


### PR DESCRIPTION
## Summary

Aligns the local manager auth proxy and manager auth tests with the forwarded-header auth behavior already on `dev`.

- updates the dev proxy to inject `x-user`, `x-preferred-username`, and `x-email`
- updates manager auth test fixtures to use the same forwarded-header shape
- replaces personal fixture values with generic test identities
- increases the manager auth readiness wait to avoid flaky local server startup timeouts

## Merge order

This should land before PR #208. After this merges into `dev`, PR #208 can be rebased so these auth proxy/test changes disappear from the provider/model controls diff.