### PR TITLE
Add commit hash to health endpoint

### DIFF
--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -105,9 +105,10 @@ jobs:
           SERVICE_USER: ${{ vars.OZWELL_REFSERVER_SERVICE_USER || 'ozwell' }}
           NODE_BIN: ${{ vars.OZWELL_REFSERVER_NODE_BIN || '/usr/bin/node' }}
           RESTART_COMMAND: ${{ vars.OZWELL_REFSERVER_RESTART_COMMAND || 'sudo systemctl restart ozwellai-api' }}
+          GIT_COMMIT: ${{ github.sha }}
         run: |
           set -euo pipefail
-          ssh "$DEPLOY_HOST" "DEPLOY_PATH='$DEPLOY_PATH' ENV_FILE='$ENV_FILE' START_SCRIPT='$START_SCRIPT' SERVICE_USER='$SERVICE_USER' NODE_BIN='$NODE_BIN' RESTART_COMMAND='$RESTART_COMMAND' bash -s" <<'REMOTE'
+          ssh "$DEPLOY_HOST" "DEPLOY_PATH='$DEPLOY_PATH' ENV_FILE='$ENV_FILE' START_SCRIPT='$START_SCRIPT' SERVICE_USER='$SERVICE_USER' NODE_BIN='$NODE_BIN' RESTART_COMMAND='$RESTART_COMMAND' GIT_COMMIT='$GIT_COMMIT' bash -s" <<'REMOTE'
             set -euo pipefail
 
             deploy_path="${DEPLOY_PATH:-/storage/apps/ozwellai-api}"
@@ -115,6 +116,7 @@ jobs:
             start_script="${START_SCRIPT:-/storage/apps/env/start-ozwellai-api.sh}"
             service_user="${SERVICE_USER:-ozwell}"
             node_bin="${NODE_BIN:-/usr/bin/node}"
+            git_commit="${GIT_COMMIT:-unknown}"
             case "$deploy_path" in
               "~") deploy_path="$HOME" ;;
               "~/"*) deploy_path="$HOME/${deploy_path#~/}" ;;
@@ -157,6 +159,7 @@ jobs:
             set_env_var PORT 8000
             set_env_var NODE_ENV production
             set_env_var DB_PATH "$deploy_path/data/ozwell.db"
+            set_env_var GIT_COMMIT "$git_commit"
 
             sudo mkdir -p "$(dirname "$start_script")"
             printf '#!/bin/bash\ncd %s/reference-server\nexec %s %s/reference-server/dist/reference-server/src/server.js\n' "$deploy_path" "$node_bin" "$deploy_path" | sudo tee "$start_script" >/dev/null

--- a/reference-server/README.md
+++ b/reference-server/README.md
@@ -392,7 +392,7 @@ Restart the server after changing `.env`; these values are read at startup.
 
 - `GET /docs` - Swagger UI documentation
 - `GET /openapi.json` - OpenAPI 3.1 specification
-- `GET /health` - Health check
+- `GET /health` - Health check with status, timestamp, and commit metadata
 
 ## Authentication
 

--- a/reference-server/src/server.ts
+++ b/reference-server/src/server.ts
@@ -35,8 +35,17 @@ function getCommitHash(): string {
     return configuredCommit.trim();
   }
 
+  if (process.env.NODE_ENV === 'production') {
+    return 'unknown';
+  }
+
   try {
-    return execSync('git rev-parse HEAD', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    return execSync('git rev-parse HEAD', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 1000,
+      maxBuffer: 128 * 1024,
+    }).trim();
   } catch {
     return 'unknown';
   }

--- a/reference-server/src/server.ts
+++ b/reference-server/src/server.ts
@@ -6,6 +6,7 @@ import multipart from '@fastify/multipart';
 import cors from '@fastify/cors';
 import fastifyStatic from '@fastify/static';
 import path from 'path';
+import { execSync } from 'child_process';
 
 // Import routes
 import modelsRoute, { refreshProviderModels } from './routes/models';
@@ -28,10 +29,25 @@ function getBodyLimitBytes(): number {
   return mb * 1024 * 1024;
 }
 
+function getCommitHash(): string {
+  const configuredCommit = process.env.GIT_COMMIT || process.env.APP_REVISION || process.env.SOURCE_VERSION || process.env.GITHUB_SHA;
+  if (configuredCommit?.trim()) {
+    return configuredCommit.trim();
+  }
+
+  try {
+    return execSync('git rev-parse HEAD', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
 const fastify = Fastify({
   logger: process.env.NODE_ENV !== 'production',
   bodyLimit: getBodyLimitBytes(),
 });
+
+const commitHash = getCommitHash();
 
 function getModelDiscoveryRefreshMs(): number {
   const raw = parseInt(process.env.MODEL_DISCOVERY_REFRESH_MS || `${DEFAULT_MODEL_DISCOVERY_REFRESH_MS}`, 10);
@@ -166,7 +182,7 @@ async function buildServer() {
 
   // Health check endpoint
   fastify.get('/health', async (_request, _reply) => {
-    return { status: 'ok', timestamp: new Date().toISOString() };
+    return { status: 'ok', timestamp: new Date().toISOString(), commit: commitHash };
   });
 
   // OpenAPI spec endpoint

--- a/reference-server/test/server.test.js
+++ b/reference-server/test/server.test.js
@@ -8,6 +8,7 @@ import { setTimeout } from 'node:timers/promises';
 
 const PORT = 3000;
 const BASE = `http://localhost:${PORT}`;
+const TEST_COMMIT = '0123456789abcdef0123456789abcdef01234567';
 
 // Poll until the server answers /health, instead of a fixed sleep — a fixed
 // delay is flaky on slow hosts (Windows CI, constrained containers).
@@ -34,7 +35,7 @@ function startServer() {
     cwd: process.cwd(),
     stdio: 'pipe',
     detached: true,
-    env: { ...process.env, HOST: '127.0.0.1', PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development' }
+    env: { ...process.env, HOST: '127.0.0.1', PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development', GIT_COMMIT: TEST_COMMIT }
   });
   return { server, tmp };
 }
@@ -60,6 +61,8 @@ test('Reference Server - Health Check', async () => {
     const data = await response.json();
     assert.strictEqual(data.status, 'ok');
     assert.ok(data.timestamp, 'should have a timestamp');
+    assert.strictEqual(typeof data.commit, 'string');
+    assert.strictEqual(data.commit, TEST_COMMIT);
 
   } finally {
     cleanup(server, tmp);

--- a/reference-server/test/server.test.js
+++ b/reference-server/test/server.test.js
@@ -28,14 +28,22 @@ function stop(server) {
   try { if (process.platform === 'win32') spawnSync('taskkill', ['/pid', String(server.pid), '/T', '/F']); else process.kill(-server.pid, 'SIGKILL'); } catch { /* already dead */ }
 }
 
-function startServer() {
+function startServer(envOverrides = {}) {
   const tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-server-test-'));
   const dbPath = path.join(tmp, 'ozwell.db');
   const server = spawn(process.execPath, ['dist/reference-server/src/server.js'], {
     cwd: process.cwd(),
     stdio: 'pipe',
     detached: true,
-    env: { ...process.env, HOST: '127.0.0.1', PORT: String(PORT), DB_PATH: dbPath, NODE_ENV: 'development', GIT_COMMIT: TEST_COMMIT }
+    env: {
+      ...process.env,
+      HOST: '127.0.0.1',
+      PORT: String(PORT),
+      DB_PATH: dbPath,
+      NODE_ENV: 'development',
+      GIT_COMMIT: TEST_COMMIT,
+      ...envOverrides,
+    }
   });
   return { server, tmp };
 }
@@ -63,6 +71,30 @@ test('Reference Server - Health Check', async () => {
     assert.ok(data.timestamp, 'should have a timestamp');
     assert.strictEqual(typeof data.commit, 'string');
     assert.strictEqual(data.commit, TEST_COMMIT);
+
+  } finally {
+    cleanup(server, tmp);
+  }
+});
+
+test('Reference Server - Health Check uses unknown commit in production without revision metadata', async () => {
+  const { server, tmp } = startServer({
+    NODE_ENV: 'production',
+    GIT_COMMIT: '',
+    APP_REVISION: '',
+    SOURCE_VERSION: '',
+    GITHUB_SHA: '',
+  });
+
+  try {
+    await waitForReady();
+
+    const response = await fetch(`${BASE}/health`);
+    assert.strictEqual(response.status, 200);
+
+    const data = await response.json();
+    assert.strictEqual(data.status, 'ok');
+    assert.strictEqual(data.commit, 'unknown');
 
   } finally {
     cleanup(server, tmp);


### PR DESCRIPTION
## Summary
- Add commit metadata to the reference server /health response.
- Populate GIT_COMMIT from github.sha during the production reference-server deploy.
- Cover the health response commit field in the server test and document the endpoint metadata.

Fixes #242

## Validation
- npm run build
- node --test test/server.test.js
- npm test
- git diff --check