### PR TITLE
Add monthly token usage controls

### DIFF
--- a/reference-server/src/routes/agents.ts
+++ b/reference-server/src/routes/agents.ts
@@ -1,7 +1,7 @@
 import { FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
 import { createError, generateId, getKeyHint, isValidApiKey, extractToken, isAgentKey, AGENT_KEY_PREFIX, formatAgentKeyHint } from '../util';
 import * as yaml from 'yaml';
-import { agentStore, Agent, ManagerIdentity, ManagerUser, ProviderModelSelection } from '../storage/agents';
+import { agentStore, Agent, ManagerIdentity, ManagerUser, ProviderModelSelection, QuotaScopeType } from '../storage/agents';
 import { getCachedModelsList, getModelsList } from './models';
 
 // Extend FastifyRequest to include auth data
@@ -192,6 +192,27 @@ type ProviderModelSelectionBody = {
     provider?: unknown;
     model?: unknown;
 };
+
+type QuotaBody = {
+    monthly_token_limit?: unknown;
+    status?: unknown;
+};
+
+function normalizeQuotaBody(body: QuotaBody | undefined): { monthlyTokenLimit: number | null; status: 'active' | 'disabled' } | null {
+    const status = body?.status === 'disabled' ? 'disabled' : 'active';
+    if (status === 'disabled') {
+        return {
+            monthlyTokenLimit: typeof body?.monthly_token_limit === 'number' && body.monthly_token_limit > 0
+                ? Math.floor(body.monthly_token_limit)
+                : null,
+            status,
+        };
+    }
+    if (typeof body?.monthly_token_limit !== 'number' || !Number.isFinite(body.monthly_token_limit) || body.monthly_token_limit <= 0) {
+        return null;
+    }
+    return { monthlyTokenLimit: Math.floor(body.monthly_token_limit), status };
+}
 
 function normalizeRestrictionBody(body: { allowed_models?: ProviderModelSelectionBody[] } | undefined) {
     return (body?.allowed_models || [])
@@ -671,6 +692,99 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
             unattributed_usage: metricDifference(parentKeys, agents),
         };
     });
+
+    function quotaTargetExists(scopeType: QuotaScopeType, scopeId: string): boolean {
+        return scopeType === 'user'
+            ? Boolean(agentStore.getManagerUserById(scopeId))
+            : Boolean(agentStore.getById(scopeId));
+    }
+
+    async function getQuota(scopeType: QuotaScopeType, scopeId: string, reply: FastifyReply) {
+        if (!quotaTargetExists(scopeType, scopeId)) {
+            reply.code(404);
+            return createError(`${scopeType === 'user' ? 'User' : 'Agent'} not found`, 'invalid_request_error', 'scope_id', 'not_found');
+        }
+        return agentStore.getQuotaStatus(scopeType, scopeId);
+    }
+
+    async function putQuota(scopeType: QuotaScopeType, scopeId: string, body: QuotaBody | undefined, reply: FastifyReply) {
+        if (!quotaTargetExists(scopeType, scopeId)) {
+            reply.code(404);
+            return createError(`${scopeType === 'user' ? 'User' : 'Agent'} not found`, 'invalid_request_error', 'scope_id', 'not_found');
+        }
+        const normalized = normalizeQuotaBody(body);
+        if (!normalized) {
+            reply.code(400);
+            return createError("'monthly_token_limit' must be a positive number for active quotas", 'invalid_request_error', 'monthly_token_limit', 'invalid_quota');
+        }
+        return agentStore.upsertQuotaPolicy(scopeType, scopeId, normalized.monthlyTokenLimit, normalized.status);
+    }
+
+    fastify.get<{ Params: { user_id: string } }>('/v1/manager/admin/quotas/users/:user_id', {
+        schema: {
+            tags: ['Manager Admin'],
+            summary: 'Get user monthly token quota',
+            params: {
+                type: 'object',
+                properties: { user_id: { type: 'string' } },
+                required: ['user_id'],
+            },
+        },
+        preHandler: requireManagerAdmin,
+    }, async (request, reply) => getQuota('user', request.params.user_id, reply));
+
+    fastify.put<{ Params: { user_id: string }; Body: QuotaBody }>('/v1/manager/admin/quotas/users/:user_id', {
+        schema: {
+            tags: ['Manager Admin'],
+            summary: 'Set user monthly token quota',
+            params: {
+                type: 'object',
+                properties: { user_id: { type: 'string' } },
+                required: ['user_id'],
+            },
+            body: {
+                type: 'object',
+                properties: {
+                    monthly_token_limit: { type: 'number' },
+                    status: { type: 'string', enum: ['active', 'disabled'] },
+                },
+            },
+        },
+        preHandler: requireManagerAdmin,
+    }, async (request, reply) => putQuota('user', request.params.user_id, request.body, reply));
+
+    fastify.get<{ Params: { agent_id: string } }>('/v1/manager/admin/quotas/agents/:agent_id', {
+        schema: {
+            tags: ['Manager Admin'],
+            summary: 'Get agent monthly token quota',
+            params: {
+                type: 'object',
+                properties: { agent_id: { type: 'string' } },
+                required: ['agent_id'],
+            },
+        },
+        preHandler: requireManagerAdmin,
+    }, async (request, reply) => getQuota('agent', request.params.agent_id, reply));
+
+    fastify.put<{ Params: { agent_id: string }; Body: QuotaBody }>('/v1/manager/admin/quotas/agents/:agent_id', {
+        schema: {
+            tags: ['Manager Admin'],
+            summary: 'Set agent monthly token quota',
+            params: {
+                type: 'object',
+                properties: { agent_id: { type: 'string' } },
+                required: ['agent_id'],
+            },
+            body: {
+                type: 'object',
+                properties: {
+                    monthly_token_limit: { type: 'number' },
+                    status: { type: 'string', enum: ['active', 'disabled'] },
+                },
+            },
+        },
+        preHandler: requireManagerAdmin,
+    }, async (request, reply) => putQuota('agent', request.params.agent_id, request.body, reply));
 
     fastify.post<{ Params: { user_id: string } }>('/v1/manager/admin/users/:user_id/promote', {
         schema: {

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -651,9 +651,30 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
       }
     };
 
+    const quotaError = (requestedTokens: number) => {
+      if (!usageContext) return null;
+      const blocks = agentStore.getQuotaBlocks(usageContext.parentKeyId, usageContext.agentId, Math.max(requestedTokens, 1));
+      if (blocks.length === 0) return null;
+      reply.code(429);
+      const block = blocks[0];
+      return createError(
+        `Monthly token quota exceeded for ${block.scope_type} ${block.scope_id}`,
+        'rate_limit_error',
+        null,
+        'quota_exceeded',
+      );
+    };
+
+    const estimateChatTokens = (items: Message[], maxTokens?: number) => (
+      items.reduce((sum, message) => sum + countTokens(contentToText(message.content)), 0)
+      + (typeof maxTokens === 'number' && maxTokens > 0 ? Math.floor(maxTokens) : 0)
+    );
+
     // Early exit for mock-type agents — skip backend probing entirely (no LLM ever called).
     if (agentConfig?.type === 'mock') {
-      const { messages: rawMessages, stream = false } = body as ChatCompletionRequestWithTools;
+      const { messages: rawMessages, stream = false, max_tokens } = body as ChatCompletionRequestWithTools;
+      const quota = quotaError(estimateChatTokens(rawMessages as Message[], max_tokens));
+      if (quota) return quota;
       const mockMessages: NonNullableMessage[] = (rawMessages as Message[]).map((m) => ({
         role: m.role,
         content: m.content ?? '',
@@ -742,6 +763,9 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
         content: agentConfig.systemPrompt,
       });
     }
+
+    const quota = quotaError(estimateChatTokens(messages as Message[], max_tokens));
+    if (quota) return quota;
 
     // --- Agent: filter tools ---
     // Tools arriving from the widget use two namespaces:
@@ -910,9 +934,9 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
               }
             }
 
+            recordUsage(model, 200, latestUsage ? { usage: latestUsage } : undefined, provider);
             reply.raw.write('data: [DONE]\n\n');
             reply.raw.end();
-            recordUsage(model, 200, latestUsage ? { usage: latestUsage } : undefined, provider);
 
             // Clear heartbeat interval
             if (heartbeatInterval) {

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -7,6 +7,7 @@ import type { ChatCompletionRequest as ClientChatCompletionRequest } from 'ozwel
 import type { ChatCompletionRequest, Message } from '../../../spec/index';
 import { generateMockResponse, extractUserMessage, hasToolResult, extractToolResult, contentToText, type ChatMessage as MockChatMessage } from './mock-chat';
 import { getCachedModelsList } from './models';
+import { quotaExceededError, resolveRouteUsageContext } from './quota';
 
 // SSE Heartbeat Configuration
 // Send keepalive every 25s to prevent 60s Nginx timeout
@@ -556,6 +557,7 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
 
     const body = request.body as ChatCompletionRequestWithTools;
     const tokenIsAgentKey = isAgentKey(request.headers.authorization);
+    const resolvedUsageContext = resolveRouteUsageContext(request.headers.authorization);
     let usageContext: UsageContext | null = null;
 
     const invalidMessageIndex = (body.messages as Message[]).findIndex((m) => !isValidMessageContent(m.content));
@@ -572,14 +574,16 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
     let agentConfig: { systemPrompt: string; allowedTools: string[] | null; pageTools: PageToolsPolicy; modelPolicy: AgentModelPolicy; temperature: number | null; type: 'mock' | null } | null = null;
 
     if (tokenIsAgentKey) {
-      const agentKey = extractToken(request.headers.authorization);
-      const resolved = agentStore.getByKeyWithActiveParent(agentKey);
-      if (!resolved) {
+      if (!resolvedUsageContext.agent || !resolvedUsageContext.parentKey) {
         reply.code(401);
-        return createError(`Agent key not found: ...${agentKey.slice(-4)}. Verify the key exists and the server has the agent database.`, 'invalid_request_error');
+        return createError(`Agent key not found: ...${token.slice(-4)}. Verify the key exists and the server has the agent database.`, 'invalid_request_error');
       }
-      const { agent, parentKey } = resolved;
-      usageContext = { authType: 'agent', parentKeyId: parentKey.id, agentId: agent.id };
+      const agent = resolvedUsageContext.agent;
+      usageContext = {
+        authType: resolvedUsageContext.authType,
+        parentKeyId: resolvedUsageContext.parentKeyId,
+        agentId: resolvedUsageContext.agentId,
+      };
 
       // Parse the YAML blob once — the source of truth for agent config
       let parsed: Record<string, unknown> = {};
@@ -624,8 +628,11 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
         type: parsed.type === 'mock' ? 'mock' : null,
       };
     } else {
-      const parentKey = agentStore.lookupApiKey(token);
-      usageContext = { authType: 'parent', parentKeyId: parentKey?.id ?? null, agentId: null };
+      usageContext = {
+        authType: resolvedUsageContext.authType,
+        parentKeyId: resolvedUsageContext.parentKeyId,
+        agentId: null,
+      };
     }
 
     const recordUsage = (model: string | null, statusCode: number, response?: unknown, provider?: string | null) => {
@@ -653,22 +660,15 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
 
     const quotaError = (requestedTokens: number) => {
       if (!usageContext) return null;
-      const blocks = agentStore.getQuotaBlocks(usageContext.parentKeyId, usageContext.agentId, Math.max(requestedTokens, 1));
-      if (blocks.length === 0) return null;
-      reply.code(429);
-      const block = blocks[0];
-      return createError(
-        `Monthly token quota exceeded for ${block.scope_type} ${block.scope_id}`,
-        'rate_limit_error',
-        null,
-        'quota_exceeded',
-      );
+      return quotaExceededError(reply, usageContext.parentKeyId, usageContext.agentId, requestedTokens);
     };
 
-    const estimateChatTokens = (items: Message[], maxTokens?: number) => (
-      items.reduce((sum, message) => sum + countTokens(contentToText(message.content)), 0)
-      + (typeof maxTokens === 'number' && maxTokens > 0 ? Math.floor(maxTokens) : 0)
-    );
+    const estimateChatTokens = (items: Message[], maxTokens?: number) => {
+      const outputBudget = maxTokens ?? LLM_MAX_TOKENS;
+      const inputTokens = items.reduce((sum, message) => sum + countTokens(contentToText(message.content)), 0);
+      const outputTokens = typeof outputBudget === 'number' && outputBudget > 0 ? Math.floor(outputBudget) : 0;
+      return inputTokens + outputTokens;
+    };
 
     // Early exit for mock-type agents — skip backend probing entirely (no LLM ever called).
     if (agentConfig?.type === 'mock') {

--- a/reference-server/src/routes/embeddings.ts
+++ b/reference-server/src/routes/embeddings.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
-import { validateAuth, createError, generateEmbedding, countTokens, isLLMBackendConfigured, isOllamaAvailable } from '../util';
+import { validateAuth, createError, generateEmbedding, countTokens, isLLMBackendConfigured, isOllamaAvailable, extractToken, isAgentKey } from '../util';
+import { agentStore } from '../storage/agents';
 
 // Hoist static env reads (these never change at runtime)
 const LLM_BASE_URL = process.env.LLM_BASE_URL || '';
@@ -115,6 +116,11 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
       reply.code(401);
       return createError('Invalid API key provided', 'invalid_request_error');
     }
+    const token = extractToken(request.headers.authorization);
+    if (!agentStore.validateKey(token)) {
+      reply.code(401);
+      return createError('API key not found. Verify the key exists in the database.', 'invalid_request_error');
+    }
 
     const body = request.body as {
       model: string;
@@ -123,6 +129,10 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
       encoding_format?: string;
     };
     const { model, input, dimensions, encoding_format } = body;
+    const tokenIsAgentKey = isAgentKey(request.headers.authorization);
+    const resolvedAgent = tokenIsAgentKey ? agentStore.getByKeyWithActiveParent(token) : null;
+    const parentKey = tokenIsAgentKey ? resolvedAgent?.parentKey : agentStore.lookupApiKey(token);
+    const agentId = resolvedAgent?.agent.id ?? null;
 
     // Normalize input to an array (batch) and reject empty batches.
     const inputs = Array.isArray(input) ? input : [input];
@@ -130,6 +140,29 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
       reply.code(400);
       return createError('Input must not be empty', 'invalid_request_error', 'input');
     }
+    const estimatedTokens = inputs.reduce((sum, text) => sum + countTokens(text), 0);
+    const quotaBlocks = agentStore.getQuotaBlocks(parentKey?.id ?? null, agentId, estimatedTokens);
+    if (quotaBlocks.length > 0) {
+      reply.code(429);
+      const block = quotaBlocks[0];
+      return createError(`Monthly token quota exceeded for ${block.scope_type} ${block.scope_id}`, 'rate_limit_error', null, 'quota_exceeded');
+    }
+
+    const recordUsage = (statusCode: number, response?: { usage?: { prompt_tokens?: number; total_tokens?: number } }, provider?: string | null) => {
+      if (!parentKey) return;
+      agentStore.recordUsageEvent({
+        parent_key_id: parentKey.id,
+        agent_id: agentId,
+        auth_type: agentId ? 'agent' : 'parent',
+        route: '/v1/embeddings',
+        provider: provider ?? null,
+        model,
+        status_code: statusCode,
+        prompt_tokens: response?.usage?.prompt_tokens ?? null,
+        completion_tokens: null,
+        total_tokens: response?.usage?.total_tokens ?? null,
+      });
+    };
 
     // Add OpenAI-compatible headers
     reply.headers({
@@ -166,7 +199,9 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
         }
 
         // Upstream is OpenAI-compatible; return its body verbatim.
-        return await upstream.json();
+        const response = await upstream.json();
+        recordUsage(200, response, LLM_PROVIDER || null);
+        return response;
       } catch (err) {
         request.log.error({ err }, 'LLM embeddings backend request failed');
         reply.code(502);
@@ -187,7 +222,7 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
           index,
         }));
         const totalTokens = inputs.reduce((sum, text) => sum + countTokens(text), 0);
-        return {
+        const response = {
           object: 'list' as const,
           data,
           model,
@@ -196,6 +231,8 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
             total_tokens: totalTokens,
           },
         };
+        recordUsage(200, response, 'ollama');
+        return response;
       } catch (err) {
         request.log.error({ err }, 'Ollama embeddings backend request failed');
         reply.code(502);
@@ -226,7 +263,7 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
     }));
     const totalTokens = inputs.reduce((sum, text) => sum + countTokens(text), 0);
 
-    return {
+    const response = {
       object: 'list' as const,
       data,
       model,
@@ -236,6 +273,8 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
       },
       warning: buildMockWarning(model),
     };
+    recordUsage(200, response, 'mock');
+    return response;
   });
 };
 

--- a/reference-server/src/routes/embeddings.ts
+++ b/reference-server/src/routes/embeddings.ts
@@ -1,6 +1,7 @@
 import { FastifyPluginAsync } from 'fastify';
-import { validateAuth, createError, generateEmbedding, countTokens, isLLMBackendConfigured, isOllamaAvailable, extractToken, isAgentKey } from '../util';
+import { validateAuth, createError, generateEmbedding, countTokens, isLLMBackendConfigured, isOllamaAvailable, extractToken } from '../util';
 import { agentStore } from '../storage/agents';
+import { quotaExceededError, resolveRouteUsageContext } from './quota';
 
 // Hoist static env reads (these never change at runtime)
 const LLM_BASE_URL = process.env.LLM_BASE_URL || '';
@@ -129,10 +130,7 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
       encoding_format?: string;
     };
     const { model, input, dimensions, encoding_format } = body;
-    const tokenIsAgentKey = isAgentKey(request.headers.authorization);
-    const resolvedAgent = tokenIsAgentKey ? agentStore.getByKeyWithActiveParent(token) : null;
-    const parentKey = tokenIsAgentKey ? resolvedAgent?.parentKey : agentStore.lookupApiKey(token);
-    const agentId = resolvedAgent?.agent.id ?? null;
+    const usageContext = resolveRouteUsageContext(request.headers.authorization);
 
     // Normalize input to an array (batch) and reject empty batches.
     const inputs = Array.isArray(input) ? input : [input];
@@ -141,19 +139,15 @@ const embeddingsRoute: FastifyPluginAsync = async (fastify) => {
       return createError('Input must not be empty', 'invalid_request_error', 'input');
     }
     const estimatedTokens = inputs.reduce((sum, text) => sum + countTokens(text), 0);
-    const quotaBlocks = agentStore.getQuotaBlocks(parentKey?.id ?? null, agentId, estimatedTokens);
-    if (quotaBlocks.length > 0) {
-      reply.code(429);
-      const block = quotaBlocks[0];
-      return createError(`Monthly token quota exceeded for ${block.scope_type} ${block.scope_id}`, 'rate_limit_error', null, 'quota_exceeded');
-    }
+    const quota = quotaExceededError(reply, usageContext.parentKeyId, usageContext.agentId, estimatedTokens);
+    if (quota) return quota;
 
     const recordUsage = (statusCode: number, response?: { usage?: { prompt_tokens?: number; total_tokens?: number } }, provider?: string | null) => {
-      if (!parentKey) return;
+      if (!usageContext.parentKey) return;
       agentStore.recordUsageEvent({
-        parent_key_id: parentKey.id,
-        agent_id: agentId,
-        auth_type: agentId ? 'agent' : 'parent',
+        parent_key_id: usageContext.parentKey.id,
+        agent_id: usageContext.agentId,
+        auth_type: usageContext.authType,
         route: '/v1/embeddings',
         provider: provider ?? null,
         model,

--- a/reference-server/src/routes/quota.ts
+++ b/reference-server/src/routes/quota.ts
@@ -1,0 +1,43 @@
+import type { FastifyReply } from 'fastify';
+import { agentStore, type Agent } from '../storage/agents';
+import { createError, extractToken, isAgentKey } from '../util';
+
+type ParentKeyRef = { id: string; name: string };
+
+export type RouteUsageContext = {
+  authType: 'parent' | 'agent';
+  parentKey: ParentKeyRef | null;
+  parentKeyId: string | null;
+  agent: Agent | null;
+  agentId: string | null;
+};
+
+export function resolveRouteUsageContext(authorization: string | undefined): RouteUsageContext {
+  const token = extractToken(authorization);
+  const resolvedAgent = isAgentKey(authorization) ? agentStore.getByKeyWithActiveParent(token) : null;
+  const parentKey = resolvedAgent?.parentKey ?? agentStore.lookupApiKey(token) ?? null;
+  const agent = resolvedAgent?.agent ?? null;
+  const agentId = agent?.id ?? null;
+
+  return {
+    authType: agentId ? 'agent' : 'parent',
+    parentKey,
+    parentKeyId: parentKey?.id ?? null,
+    agent,
+    agentId,
+  };
+}
+
+export function quotaExceededError(reply: FastifyReply, parentKeyId: string | null, agentId: string | null, requestedTokens: number) {
+  const quotaBlocks = agentStore.getQuotaBlocks(parentKeyId, agentId, Math.max(requestedTokens, 1));
+  if (quotaBlocks.length === 0) return null;
+
+  reply.code(429);
+  const block = quotaBlocks[0];
+  return createError(
+    `Monthly token quota exceeded for ${block.scope_type} ${block.scope_id}`,
+    'rate_limit_error',
+    null,
+    'quota_exceeded',
+  );
+}

--- a/reference-server/src/routes/responses.ts
+++ b/reference-server/src/routes/responses.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
-import { validateAuth, createError, SimpleTextGenerator, generateId, countTokens, parsePositiveEnvNumber } from '../util';
+import { validateAuth, createError, SimpleTextGenerator, generateId, countTokens, parsePositiveEnvNumber, extractToken, isAgentKey } from '../util';
+import { agentStore } from '../storage/agents';
 
 const LLM_MAX_TOKENS = parsePositiveEnvNumber('LLM_MAX_TOKENS');
 
@@ -31,10 +32,19 @@ const responsesRoute: FastifyPluginAsync = async (fastify) => {
       reply.code(401);
       return createError('Invalid API key provided', 'invalid_request_error');
     }
+    const token = extractToken(request.headers.authorization);
+    if (!agentStore.validateKey(token)) {
+      reply.code(401);
+      return createError('API key not found. Verify the key exists in the database.', 'invalid_request_error');
+    }
 
     const body = request.body as any;
     const { model, input, stream = false, max_tokens, temperature = 0.7 } = body;
     const effectiveMaxTokens = max_tokens ?? LLM_MAX_TOKENS;
+    const tokenIsAgentKey = isAgentKey(request.headers.authorization);
+    const resolvedAgent = tokenIsAgentKey ? agentStore.getByKeyWithActiveParent(token) : null;
+    const parentKey = tokenIsAgentKey ? resolvedAgent?.parentKey : agentStore.lookupApiKey(token);
+    const agentId = resolvedAgent?.agent.id ?? null;
 
     // Validate model
     const supportedModels = ['gpt-4o', 'gpt-4o-mini'];
@@ -42,6 +52,30 @@ const responsesRoute: FastifyPluginAsync = async (fastify) => {
       reply.code(400);
       return createError(`Model '${model}' not found`, 'invalid_request_error', 'model');
     }
+
+    const requestedTokens = countTokens(input) + (typeof effectiveMaxTokens === 'number' && effectiveMaxTokens > 0 ? Math.floor(effectiveMaxTokens) : 0);
+    const quotaBlocks = agentStore.getQuotaBlocks(parentKey?.id ?? null, agentId, requestedTokens);
+    if (quotaBlocks.length > 0) {
+      reply.code(429);
+      const block = quotaBlocks[0];
+      return createError(`Monthly token quota exceeded for ${block.scope_type} ${block.scope_id}`, 'rate_limit_error', null, 'quota_exceeded');
+    }
+
+    const recordUsage = (statusCode: number, usage: { input_tokens: number; output_tokens: number; total_tokens: number }) => {
+      if (!parentKey) return;
+      agentStore.recordUsageEvent({
+        parent_key_id: parentKey.id,
+        agent_id: agentId,
+        auth_type: agentId ? 'agent' : 'parent',
+        route: '/v1/responses',
+        provider: 'mock',
+        model,
+        status_code: statusCode,
+        prompt_tokens: usage.input_tokens,
+        completion_tokens: usage.output_tokens,
+        total_tokens: usage.total_tokens,
+      });
+    };
 
     const requestId = generateId('resp');
     const created = Math.floor(Date.now() / 1000);
@@ -96,6 +130,7 @@ const responsesRoute: FastifyPluginAsync = async (fastify) => {
           total_tokens: inputTokens + outputTokens,
         },
       };
+      recordUsage(200, completionEvent.usage);
       reply.raw.write(`event: completion\ndata: ${JSON.stringify(completionEvent)}\n\n`);
       reply.raw.write(`event: done\ndata: [DONE]\n\n`);
       reply.raw.end();
@@ -107,17 +142,20 @@ const responsesRoute: FastifyPluginAsync = async (fastify) => {
     const inputTokens = countTokens(input);
     const outputTokens = countTokens(output);
 
+    const usage = {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      total_tokens: inputTokens + outputTokens,
+    };
+    recordUsage(200, usage);
+
     return {
       id: requestId,
       object: 'response' as const,
       created,
       model,
       output,
-      usage: {
-        input_tokens: inputTokens,
-        output_tokens: outputTokens,
-        total_tokens: inputTokens + outputTokens,
-      },
+      usage,
     };
   });
 };

--- a/reference-server/src/routes/responses.ts
+++ b/reference-server/src/routes/responses.ts
@@ -1,6 +1,7 @@
 import { FastifyPluginAsync } from 'fastify';
-import { validateAuth, createError, SimpleTextGenerator, generateId, countTokens, parsePositiveEnvNumber, extractToken, isAgentKey } from '../util';
+import { validateAuth, createError, SimpleTextGenerator, generateId, countTokens, parsePositiveEnvNumber, extractToken } from '../util';
 import { agentStore } from '../storage/agents';
+import { quotaExceededError, resolveRouteUsageContext } from './quota';
 
 const LLM_MAX_TOKENS = parsePositiveEnvNumber('LLM_MAX_TOKENS');
 
@@ -41,10 +42,7 @@ const responsesRoute: FastifyPluginAsync = async (fastify) => {
     const body = request.body as any;
     const { model, input, stream = false, max_tokens, temperature = 0.7 } = body;
     const effectiveMaxTokens = max_tokens ?? LLM_MAX_TOKENS;
-    const tokenIsAgentKey = isAgentKey(request.headers.authorization);
-    const resolvedAgent = tokenIsAgentKey ? agentStore.getByKeyWithActiveParent(token) : null;
-    const parentKey = tokenIsAgentKey ? resolvedAgent?.parentKey : agentStore.lookupApiKey(token);
-    const agentId = resolvedAgent?.agent.id ?? null;
+    const usageContext = resolveRouteUsageContext(request.headers.authorization);
 
     // Validate model
     const supportedModels = ['gpt-4o', 'gpt-4o-mini'];
@@ -54,19 +52,15 @@ const responsesRoute: FastifyPluginAsync = async (fastify) => {
     }
 
     const requestedTokens = countTokens(input) + (typeof effectiveMaxTokens === 'number' && effectiveMaxTokens > 0 ? Math.floor(effectiveMaxTokens) : 0);
-    const quotaBlocks = agentStore.getQuotaBlocks(parentKey?.id ?? null, agentId, requestedTokens);
-    if (quotaBlocks.length > 0) {
-      reply.code(429);
-      const block = quotaBlocks[0];
-      return createError(`Monthly token quota exceeded for ${block.scope_type} ${block.scope_id}`, 'rate_limit_error', null, 'quota_exceeded');
-    }
+    const quota = quotaExceededError(reply, usageContext.parentKeyId, usageContext.agentId, requestedTokens);
+    if (quota) return quota;
 
     const recordUsage = (statusCode: number, usage: { input_tokens: number; output_tokens: number; total_tokens: number }) => {
-      if (!parentKey) return;
+      if (!usageContext.parentKey) return;
       agentStore.recordUsageEvent({
-        parent_key_id: parentKey.id,
-        agent_id: agentId,
-        auth_type: agentId ? 'agent' : 'parent',
+        parent_key_id: usageContext.parentKey.id,
+        agent_id: usageContext.agentId,
+        auth_type: usageContext.authType,
         route: '/v1/responses',
         provider: 'mock',
         model,

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -232,6 +232,21 @@ export interface UsageEventInput {
     total_tokens?: number | null;
 }
 
+export type QuotaScopeType = 'user' | 'agent';
+
+export interface QuotaStatus {
+    scope_type: QuotaScopeType;
+    scope_id: string;
+    monthly_token_limit: number | null;
+    status: 'active' | 'disabled';
+    used_tokens: number;
+    remaining_tokens: number | null;
+    requested_tokens: number;
+    window_start: string;
+    window_end: string;
+    allowed: boolean;
+}
+
 export interface ProviderModelRecord {
     id: string;
     provider: string;
@@ -432,6 +447,18 @@ export class AgentStore {
         created_at TEXT DEFAULT (datetime('now'))
       );
       CREATE INDEX IF NOT EXISTS idx_notification_events_parent_key_id ON notification_events(parent_key_id);
+
+      CREATE TABLE IF NOT EXISTS quota_policies (
+        id TEXT PRIMARY KEY,
+        scope_type TEXT NOT NULL,
+        scope_id TEXT NOT NULL,
+        monthly_token_limit INTEGER,
+        status TEXT NOT NULL DEFAULT 'active',
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now')),
+        UNIQUE(scope_type, scope_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_quota_policies_scope ON quota_policies(scope_type, scope_id);
     `);
     }
 
@@ -521,6 +548,11 @@ export class AgentStore {
 
     getManagerUserByEmail(email: string): ManagerUser | null {
         const row = this.db.prepare('SELECT * FROM users WHERE email = ? COLLATE NOCASE').get(email) as DbManagerUserRow | undefined;
+        return row ? toManagerUser(row) : null;
+    }
+
+    getManagerUserById(userId: string): ManagerUser | null {
+        const row = this.db.prepare('SELECT * FROM users WHERE id = ?').get(userId) as DbManagerUserRow | undefined;
         return row ? toManagerUser(row) : null;
     }
 
@@ -701,6 +733,88 @@ export class AgentStore {
             total_tokens: input.total_tokens ?? null,
             created_at: new Date().toISOString(),
         });
+    }
+
+    monthWindow(now = new Date()): { start: string; end: string } {
+        const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+        const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+        return { start: start.toISOString(), end: end.toISOString() };
+    }
+
+    upsertQuotaPolicy(scopeType: QuotaScopeType, scopeId: string, monthlyTokenLimit: number | null, status: 'active' | 'disabled'): QuotaStatus {
+        this.db.prepare(`
+          INSERT INTO quota_policies (id, scope_type, scope_id, monthly_token_limit, status, created_at, updated_at)
+          VALUES (@id, @scope_type, @scope_id, @monthly_token_limit, @status, @now, @now)
+          ON CONFLICT(scope_type, scope_id) DO UPDATE SET
+            monthly_token_limit = excluded.monthly_token_limit,
+            status = excluded.status,
+            updated_at = excluded.updated_at
+        `).run({
+            id: generateId('quota'),
+            scope_type: scopeType,
+            scope_id: scopeId,
+            monthly_token_limit: monthlyTokenLimit,
+            status,
+            now: new Date().toISOString(),
+        });
+        return this.getQuotaStatus(scopeType, scopeId);
+    }
+
+    getMonthlyTokenUsage(scopeType: QuotaScopeType, scopeId: string, now = new Date()): number {
+        const { start, end } = this.monthWindow(now);
+        if (scopeType === 'agent') {
+            const row = this.db.prepare(`
+              SELECT COALESCE(SUM(total_tokens), 0) AS total
+              FROM usage_events
+              WHERE agent_id = ?
+                AND created_at >= ?
+                AND created_at < ?
+            `).get(scopeId, start, end) as { total: number };
+            return row.total;
+        }
+        const row = this.db.prepare(`
+          SELECT COALESCE(SUM(e.total_tokens), 0) AS total
+          FROM usage_events e
+          JOIN api_keys k ON k.id = e.parent_key_id
+          WHERE k.user_id = ?
+            AND e.created_at >= ?
+            AND e.created_at < ?
+        `).get(scopeId, start, end) as { total: number };
+        return row.total;
+    }
+
+    getQuotaStatus(scopeType: QuotaScopeType, scopeId: string, requestedTokens = 0): QuotaStatus {
+        const policy = this.db.prepare(`
+          SELECT monthly_token_limit, status
+          FROM quota_policies
+          WHERE scope_type = ? AND scope_id = ?
+        `).get(scopeType, scopeId) as { monthly_token_limit: number | null; status: 'active' | 'disabled' } | undefined;
+        const { start, end } = this.monthWindow();
+        const used = this.getMonthlyTokenUsage(scopeType, scopeId);
+        const active = policy?.status === 'active' && typeof policy.monthly_token_limit === 'number';
+        const remaining = active ? Math.max((policy.monthly_token_limit as number) - used, 0) : null;
+        return {
+            scope_type: scopeType,
+            scope_id: scopeId,
+            monthly_token_limit: policy?.monthly_token_limit ?? null,
+            status: policy?.status ?? 'disabled',
+            used_tokens: used,
+            remaining_tokens: remaining,
+            requested_tokens: requestedTokens,
+            window_start: start,
+            window_end: end,
+            allowed: !active || used + requestedTokens <= (policy.monthly_token_limit as number),
+        };
+    }
+
+    getQuotaBlocks(parentKeyId: string | null, agentId: string | null, requestedTokens: number): QuotaStatus[] {
+        const checks: QuotaStatus[] = [];
+        if (parentKeyId) {
+            const row = this.db.prepare('SELECT user_id FROM api_keys WHERE id = ?').get(parentKeyId) as { user_id: string | null } | undefined;
+            if (row?.user_id) checks.push(this.getQuotaStatus('user', row.user_id, requestedTokens));
+        }
+        if (agentId) checks.push(this.getQuotaStatus('agent', agentId, requestedTokens));
+        return checks.filter(check => !check.allowed);
     }
 
     upsertProviderModels(records: Array<Omit<ProviderModelRecord, 'enabled' | 'last_discovered_at'> & Partial<Pick<ProviderModelRecord, 'enabled' | 'last_discovered_at'>>>): ProviderModelRecord[] {

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -788,8 +788,9 @@ export class AgentStore {
           FROM quota_policies
           WHERE scope_type = ? AND scope_id = ?
         `).get(scopeType, scopeId) as { monthly_token_limit: number | null; status: 'active' | 'disabled' } | undefined;
-        const { start, end } = this.monthWindow();
-        const used = this.getMonthlyTokenUsage(scopeType, scopeId);
+        const now = new Date();
+        const { start, end } = this.monthWindow(now);
+        const used = this.getMonthlyTokenUsage(scopeType, scopeId, now);
         const active = policy?.status === 'active' && typeof policy.monthly_token_limit === 'number';
         const remaining = active ? Math.max((policy.monthly_token_limit as number) - used, 0) : null;
         return {

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -645,8 +645,7 @@ export class AgentStore {
                 if (current.source === 'auto') {
                     this.db.prepare(`
                       UPDATE api_keys
-                      SET user_id = NULL,
-                          status = 'revoked',
+                      SET status = 'revoked',
                           revoked_at = @revoked_at,
                           revoked_reason = @revoked_reason,
                           replaced_by_key_id = @replaced_by_key_id

--- a/reference-server/test/manager-auth.test.js
+++ b/reference-server/test/manager-auth.test.js
@@ -693,6 +693,212 @@ test('manager admin — user-first APIs include key history, agents, and usage m
     }
 });
 
+test('manager admin — user monthly quota blocks chat over the limit', async () => {
+    const { server, tmp, dbPath } = startServer({ adminExternalUserIds: 'admin-user' });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
+        const { user, key } = getUserAndActiveKey(dbPath);
+
+        const quota = await fetch(`${BASE}/v1/manager/admin/quotas/users/${user.id}`, {
+            method: 'PUT',
+            headers: { ...MANAGER_HEADERS, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ monthly_token_limit: 1, status: 'active' }),
+        });
+        assert.equal(quota.status, 200);
+        const quotaBody = await quota.json();
+        assert.equal(quotaBody.scope_type, 'user');
+        assert.equal(quotaBody.monthly_token_limit, 1);
+        assert.equal(quotaBody.status, 'active');
+
+        const chat = await fetch(`${BASE}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${key.key}`,
+            },
+            body: JSON.stringify({
+                messages: [{ role: 'user', content: 'this request should exceed one token' }],
+            }),
+        });
+        assert.equal(chat.status, 429);
+        const body = await chat.json();
+        assert.equal(body.error.type, 'rate_limit_error');
+        assert.equal(body.error.code, 'quota_exceeded');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('manager admin — disabled user quota allows chat', async () => {
+    const { server, tmp, dbPath } = startServer({ adminExternalUserIds: 'admin-user' });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
+        const { user, key } = getUserAndActiveKey(dbPath);
+
+        const quota = await fetch(`${BASE}/v1/manager/admin/quotas/users/${user.id}`, {
+            method: 'PUT',
+            headers: { ...MANAGER_HEADERS, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ monthly_token_limit: 1, status: 'disabled' }),
+        });
+        assert.equal(quota.status, 200);
+
+        const chat = await fetch(`${BASE}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${key.key}`,
+            },
+            body: JSON.stringify({
+                messages: [{ role: 'user', content: 'disabled quota should not block this request' }],
+            }),
+        });
+        assert.equal(chat.status, 200);
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('manager admin — agent monthly quota blocks agent chat over the limit', async () => {
+    const { server, tmp } = startServer({ adminExternalUserIds: 'admin-user' });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
+
+        const create = await fetch(`${BASE}/v1/manager/agents`, {
+            method: 'POST',
+            headers: H_YAML,
+            body: `name: Quota Mock\ninstructions: Mock for quota enforcement\ntype: mock\n`,
+        });
+        assert.equal(create.status, 201);
+        const created = await create.json();
+
+        const quota = await fetch(`${BASE}/v1/manager/admin/quotas/agents/${created.agent_id}`, {
+            method: 'PUT',
+            headers: { ...MANAGER_HEADERS, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ monthly_token_limit: 1, status: 'active' }),
+        });
+        assert.equal(quota.status, 200);
+
+        const chat = await fetch(`${BASE}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${created.agent_key}`,
+            },
+            body: JSON.stringify({
+                messages: [{ role: 'user', content: 'this agent request should exceed one token' }],
+            }),
+        });
+        assert.equal(chat.status, 429);
+        const body = await chat.json();
+        assert.equal(body.error.code, 'quota_exceeded');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('manager admin — previous-month usage does not count against user quota', async () => {
+    const { server, tmp, dbPath } = startServer({ adminExternalUserIds: 'admin-user' });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
+        const { user, key } = getUserAndActiveKey(dbPath);
+        const db = new Database(dbPath);
+        try {
+            db.prepare(`
+              INSERT INTO usage_events (
+                id, parent_key_id, agent_id, auth_type, route, model, status_code,
+                prompt_tokens, completion_tokens, total_tokens, created_at
+              )
+              VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)
+            `).run(
+                'usage-previous-month',
+                key.id,
+                'parent',
+                '/v1/chat/completions',
+                'mock',
+                200,
+                1000,
+                1000,
+                2000,
+                '2000-01-01T00:00:00.000Z',
+            );
+        } finally {
+            db.close();
+        }
+
+        const quota = await fetch(`${BASE}/v1/manager/admin/quotas/users/${user.id}`, {
+            method: 'PUT',
+            headers: { ...MANAGER_HEADERS, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ monthly_token_limit: 20, status: 'active' }),
+        });
+        assert.equal(quota.status, 200);
+
+        const chat = await fetch(`${BASE}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${key.key}`,
+            },
+            body: JSON.stringify({
+                messages: [{ role: 'user', content: 'current month should still have quota' }],
+            }),
+        });
+        assert.equal(chat.status, 200);
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
+test('manager admin — embeddings and responses record usage events', async () => {
+    const { server, tmp, dbPath } = startServer({ adminExternalUserIds: 'admin-user' });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
+        const { key } = getUserAndActiveKey(dbPath);
+
+        const embeddings = await fetch(`${BASE}/v1/embeddings`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${key.key}`,
+            },
+            body: JSON.stringify({ model: 'text-embedding-3-small', input: 'hello usage' }),
+        });
+        assert.equal(embeddings.status, 200);
+
+        const responses = await fetch(`${BASE}/v1/responses`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${key.key}`,
+            },
+            body: JSON.stringify({ model: 'gpt-4o-mini', input: 'hello response usage' }),
+        });
+        assert.equal(responses.status, 200);
+
+        const db = new Database(dbPath);
+        try {
+            const rows = db.prepare(`
+              SELECT route, auth_type, status_code, total_tokens
+              FROM usage_events
+              WHERE parent_key_id = ?
+              ORDER BY route
+            `).all(key.id);
+            assert.deepEqual(rows.map(row => row.route), ['/v1/embeddings', '/v1/responses']);
+            assert.ok(rows.every(row => row.auth_type === 'parent'));
+            assert.ok(rows.every(row => row.status_code === 200));
+            assert.ok(rows.every(row => row.total_tokens > 0));
+        } finally {
+            db.close();
+        }
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
 test('manager auth — streaming LLM usage chunks are requested and recorded', async () => {
     const upstream = await startStreamingLLMServer();
     const { server, tmp, dbPath } = startServer({

--- a/reference-server/test/manager-auth.test.js
+++ b/reference-server/test/manager-auth.test.js
@@ -403,12 +403,35 @@ test('manager auth — users cannot access or mutate agents owned by another man
 });
 
 test('manager auth — claim-key moves auto-key agents to claimed parent key and revokes auto key', async () => {
-    const { server, tmp, dbPath } = startServer();
+    const { server, tmp, dbPath } = startServer({ adminExternalUserIds: 'admin-user' });
     try {
         await waitForReady();
         await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
-        const { key: autoKey } = getUserAndActiveKey(dbPath);
+        const { user, key: autoKey } = getUserAndActiveKey(dbPath);
         seedClaimableKey(dbPath);
+        const usageDb = new Database(dbPath);
+        try {
+            usageDb.prepare(`
+              INSERT INTO usage_events (
+                id, parent_key_id, agent_id, auth_type, route, model, status_code,
+                prompt_tokens, completion_tokens, total_tokens, created_at
+              )
+              VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)
+            `).run(
+                'usage-before-claim',
+                autoKey.id,
+                'parent',
+                '/v1/chat/completions',
+                'mock',
+                200,
+                100,
+                100,
+                200,
+                new Date().toISOString(),
+            );
+        } finally {
+            usageDb.close();
+        }
 
         const created = await fetch(`${BASE}/v1/manager/agents`, {
             method: 'POST',
@@ -435,6 +458,10 @@ test('manager auth — claim-key moves auto-key agents to claimed parent key and
         assert.ok(listBody.data.some(agent => agent.id === 'existing-agent'), 'claimed key existing agent is listed');
         assert.ok(listBody.data.some(agent => agent.id === createdBody.agent_id), 'temporary agent moved to claimed key is listed');
 
+        const quota = await fetch(`${BASE}/v1/manager/admin/quotas/users/${user.id}`, { headers: MANAGER_HEADERS });
+        assert.equal(quota.status, 200);
+        assert.equal((await quota.json()).used_tokens, 200);
+
         const db = new Database(dbPath);
         try {
             const user = db.prepare('SELECT id FROM users WHERE external_user_id = ?').get('admin-user');
@@ -444,7 +471,7 @@ test('manager auth — claim-key moves auto-key agents to claimed parent key and
             assert.equal(claimedKey.revoked_at, null);
 
             const oldAutoKey = db.prepare('SELECT user_id, status, revoked_at, revoked_reason, replaced_by_key_id FROM api_keys WHERE id = ?').get(autoKey.id);
-            assert.equal(oldAutoKey.user_id, null);
+            assert.equal(oldAutoKey.user_id, user.id);
             assert.equal(oldAutoKey.status, 'revoked');
             assert.ok(oldAutoKey.revoked_at);
             assert.equal(oldAutoKey.revoked_reason, 'replaced_by_claimed_key');

--- a/reference-server/test/manager-auth.test.js
+++ b/reference-server/test/manager-auth.test.js
@@ -757,6 +757,41 @@ test('manager admin — user monthly quota blocks chat over the limit', async ()
     }
 });
 
+test('manager admin — chat quota estimate uses server max tokens when request omits max_tokens', async () => {
+    const { server, tmp, dbPath } = startServer({
+        adminExternalUserIds: 'admin-user',
+        extraEnv: { LLM_MAX_TOKENS: '50' },
+    });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: MANAGER_HEADERS });
+        const { user, key } = getUserAndActiveKey(dbPath);
+
+        const quota = await fetch(`${BASE}/v1/manager/admin/quotas/users/${user.id}`, {
+            method: 'PUT',
+            headers: { ...MANAGER_HEADERS, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ monthly_token_limit: 20, status: 'active' }),
+        });
+        assert.equal(quota.status, 200);
+
+        const chat = await fetch(`${BASE}/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${key.key}`,
+            },
+            body: JSON.stringify({
+                messages: [{ role: 'user', content: 'hi' }],
+            }),
+        });
+        assert.equal(chat.status, 429);
+        const body = await chat.json();
+        assert.equal(body.error.code, 'quota_exceeded');
+    } finally {
+        stopServer(server, tmp);
+    }
+});
+
 test('manager admin — disabled user quota allows chat', async () => {
     const { server, tmp, dbPath } = startServer({ adminExternalUserIds: 'admin-user' });
     try {


### PR DESCRIPTION
## Summary
- Add monthly user and agent token quota policies with manager admin GET/PUT routes.
- Enforce monthly quotas across chat completions, responses, and embeddings.
- Record usage for responses and embeddings, and make streaming chat usage persist before stream close.

Closes #183

## Validation
- `npm run build` in `reference-server`
- `npm test` in `reference-server` (84/84 passing)
- Manual smoke: active user quota returns HTTP 429 with `quota_exceeded`
- Manual smoke: disabled quota allows `/v1/responses` and records usage
- Manual smoke: real LLM chat succeeds for `gpt-4o-mini` and `gpt-5-mini`

## Screenshots

### Active quota configuration
<img width="1160" height="257" alt="Screenshot 2026-07-24 at 4 51 56 PM" src="https://github.com/user-attachments/assets/0d7d9e85-012c-476d-94f4-1c55a0a67e0c" />

### Quota exceeded response
<img width="1158" height="256" alt="Screenshot 2026-07-24 at 4 52 29 PM" src="https://github.com/user-attachments/assets/8f739bd0-24ac-48eb-b637-28b8b695448c" />

### Disabled quota configuration
<img width="1153" height="257" alt="Screenshot 2026-07-24 at 4 52 44 PM" src="https://github.com/user-attachments/assets/e93ac1d3-6e1d-4f08-a1a3-15e864de70ae" />

### Request allowed after disabling quota
<img width="1160" height="273" alt="Screenshot 2026-07-24 at 4 52 55 PM" src="https://github.com/user-attachments/assets/72b9052d-a504-4d5a-9ab8-9a9a404b93e8" />

### Real LLM smoke
<img width="1158" height="713" alt="Screenshot 2026-07-24 at 4 53 10 PM" src="https://github.com/user-attachments/assets/3a6fdf43-bba2-419a-8634-daeba48faee7" />