### PR TITLE
Fix reference-server test startup in CI

### DIFF
--- a/reference-server/test/audio.test.js
+++ b/reference-server/test/audio.test.js
@@ -33,7 +33,7 @@ before(async () => {
   env.LLM_BASE_URL = '';
   env.LLM_API_KEY = '';
   env.LLM_PROVIDER = '';
-  server = spawn('npm', ['run', 'dev'], {
+  server = spawn(process.execPath, ['dist/reference-server/src/server.js'], {
     cwd: process.cwd(),
     stdio: 'pipe',
     detached: true,

--- a/reference-server/test/embeddings.test.js
+++ b/reference-server/test/embeddings.test.js
@@ -42,7 +42,7 @@ function spawnServer({ port, dbPath, allowMock }) {
   };
   if (allowMock) env.ALLOW_MOCK = 'true';
   else delete env.ALLOW_MOCK;
-  return spawn('npm', ['run', 'dev'], {
+  return spawn(process.execPath, ['dist/reference-server/src/server.js'], {
     cwd: process.cwd(),
     stdio: 'pipe',
     detached: true,

--- a/reference-server/test/multimodal-content.test.js
+++ b/reference-server/test/multimodal-content.test.js
@@ -30,7 +30,7 @@ async function waitForReady(maxMs = 10_000) {
 before(async () => {
     tmp = mkdtempSync(path.join(tmpdir(), 'ozwell-multimodal-test-'));
     const dbPath = path.join(tmp, 'ozwell.db');
-    server = spawn('npm', ['run', 'dev'], {
+    server = spawn(process.execPath, ['dist/reference-server/src/server.js'], {
         cwd: process.cwd(),
         stdio: 'pipe',
         detached: true,


### PR DESCRIPTION
## Summary
- Run audio, embeddings, and multimodal server tests against the built reference-server artifact.
- Avoid spawning the dev TypeScript runner from inside node --test.
- Keeps CI behavior aligned with the existing pretest/workflow build steps.

## Why
These tests were starting npm run dev from inside the test process. That is slower and more fragile in CI-like environments, and it showed up as "server never became ready" failures in act and Windows CI logs even though the workflow currently allows npm test to continue on error.

## Validation
- npm run build in reference-server
- node --test test/audio.test.js test/embeddings.test.js test/multimodal-content.test.js: 29/29 passed
- Previously verified with act on Reference Server CI Ubuntu Node 20: 84/84 passed and smoke test passed
- Previously verified with act on Reference Server CI Ubuntu Node 22: full job passed and smoke test passed

Closes #246