### PR TITLE
Fix CI builds for repo submodules

### DIFF
--- a/.github/workflows/deploy-reference-server.yml
+++ b/.github/workflows/deploy-reference-server.yml
@@ -13,6 +13,7 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'scripts/build-deploy-package.sh'
+      - 'vendor/mieweb-ui'
       - '.github/workflows/deploy-reference-server.yml'
 
 concurrency:
@@ -27,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -38,6 +41,10 @@ jobs:
             spec/package-lock.json
             clients/typescript/package-lock.json
             reference-server/package-lock.json
+
+      - name: Install and build pinned mieweb UI
+        working-directory: ./vendor/mieweb-ui
+        run: corepack pnpm install --frozen-lockfile && corepack pnpm run build
 
       - name: Install and build spec
         working-directory: ./spec

--- a/.github/workflows/landing-page-e2e.yml
+++ b/.github/workflows/landing-page-e2e.yml
@@ -12,6 +12,7 @@ on:
       - 'reference-server/embed/**'
       - 'spec/**'
       - 'clients/typescript/**'
+      - 'vendor/mieweb-ui'
       - '.github/workflows/landing-page-e2e.yml'
       - 'scripts/test-e2e.sh'
   pull_request:
@@ -22,6 +23,7 @@ on:
       - 'reference-server/embed/**'
       - 'spec/**'
       - 'clients/typescript/**'
+      - 'vendor/mieweb-ui'
       - '.github/workflows/landing-page-e2e.yml'
       - 'scripts/test-e2e.sh'
 
@@ -39,6 +41,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -49,6 +53,10 @@ jobs:
 
       - name: Install all dependencies
         run: npm ci
+
+      - name: Install and build pinned mieweb UI
+        working-directory: ./vendor/mieweb-ui
+        run: corepack pnpm install --frozen-lockfile && corepack pnpm run build
 
       - name: Install landing-page dependencies
         working-directory: ./landing-page

--- a/.github/workflows/reference-server-ci.yml
+++ b/.github/workflows/reference-server-ci.yml
@@ -8,6 +8,7 @@ on:
     branches: [ main, develop ]
     paths:
       - 'reference-server/**'
+      - 'vendor/mieweb-ui'
       - 'spec/**'
       - '.github/workflows/reference-server-ci.yml'
       - '.github/workflows/test-reference-server.yml'
@@ -15,6 +16,7 @@ on:
     branches: [ main ]
     paths:
       - 'reference-server/**'
+      - 'vendor/mieweb-ui'
       - 'spec/**'
       - '.github/workflows/reference-server-ci.yml'
       - '.github/workflows/test-reference-server.yml'

--- a/.github/workflows/test-reference-server.yml
+++ b/.github/workflows/test-reference-server.yml
@@ -10,8 +10,34 @@ on:
         type: string
 
 jobs:
+  build-pinned-ui:
+    name: Build pinned mieweb UI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install and build pinned mieweb UI
+        working-directory: ./vendor/mieweb-ui
+        run: corepack pnpm install --frozen-lockfile && corepack pnpm run build
+
+      - name: Upload pinned mieweb UI
+        uses: actions/upload-artifact@v4
+        with:
+          name: pinned-mieweb-ui-dist
+          path: vendor/mieweb-ui/dist
+
   test:
     name: Test on Node.js ${{ matrix.node-version }} (${{ matrix.os }})
+    needs: build-pinned-ui
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -33,9 +59,15 @@ jobs:
             spec/package-lock.json
             reference-server/package-lock.json
 
-      - name: Install and build pinned mieweb UI
+      - name: Download pinned mieweb UI
+        uses: actions/download-artifact@v4
+        with:
+          name: pinned-mieweb-ui-dist
+          path: vendor/mieweb-ui/dist
+
+      - name: Install pinned mieweb UI dependencies
         working-directory: ./vendor/mieweb-ui
-        run: corepack pnpm install --frozen-lockfile && corepack pnpm run build
+        run: corepack pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Install spec dependencies
         working-directory: ./spec

--- a/.github/workflows/test-reference-server.yml
+++ b/.github/workflows/test-reference-server.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -30,6 +32,10 @@ jobs:
           cache-dependency-path: |
             spec/package-lock.json
             reference-server/package-lock.json
+
+      - name: Install and build pinned mieweb UI
+        working-directory: ./vendor/mieweb-ui
+        run: corepack pnpm install --frozen-lockfile && corepack pnpm run build
 
       - name: Install spec dependencies
         working-directory: ./spec


### PR DESCRIPTION
Found while preparing the release PR.

Some reference-server CI and deploy builds did not checkout or build the pinned `vendor/mieweb-ui` submodule. They could fall back to the installed npm package instead.

This change checks out and builds the pinned UI before affected builds. It also runs the workflows when the pinned submodule commit changes.

Checks: YAML parse and local pinned UI/reference-server build.

Fixes #254