### PR TITLE
bug-fix: Handle unavailable configured agent models

### DIFF
--- a/reference-server/embed/src/WidgetApp.tsx
+++ b/reference-server/embed/src/WidgetApp.tsx
@@ -34,6 +34,7 @@ const MESSAGES_NAV_THRESHOLD = 3;
 const DEFAULT_PARENT_SYSTEM_PROMPT = 'You are a helpful assistant. Answer clearly and concisely.';
 const DEFAULT_PARENT_TOOL_HINT = 'Use the available tools when they are helpful for answering the user or performing a requested action.';
 const MCP_TOOL_TIMEOUT_MS = 30000;
+const ASSISTANT_UNAVAILABLE_MESSAGE = 'This assistant is temporarily unavailable. Please try again later.';
 
 type ProviderModelOption = {
   provider: string;
@@ -376,6 +377,20 @@ function systemDisplayMessage(content: string): WidgetMessage {
   };
 }
 
+class AssistantUnavailableError extends Error {}
+
+function chatRequestError(status: number, errorText: string) {
+  try {
+    const parsed = JSON.parse(errorText);
+    if (parsed?.error?.code === 'configured_model_unavailable') {
+      return new AssistantUnavailableError(ASSISTANT_UNAVAILABLE_MESSAGE);
+    }
+  } catch {
+    // Keep the original response text for unknown non-JSON failures.
+  }
+  return new Error(`Request failed with status ${status}: ${errorText}`);
+}
+
 export function WidgetApp() {
   const [config, setConfig] = useState<OzwellConfig>(() => ({
     ...DEFAULT_CONFIG,
@@ -597,7 +612,7 @@ export function WidgetApp() {
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Request failed with status ${response.status}: ${errorText}`);
+        throw chatRequestError(response.status, errorText);
       }
       if (!response.body) {
         throw new Error('Response body is null');
@@ -775,7 +790,9 @@ export function WidgetApp() {
       if (assistantMessageId) {
         setDisplayMessages((current) => current.filter((item) => item.id !== assistantMessageId));
       }
-      appendDisplay(systemDisplayMessage(`Error: ${message}`));
+      appendDisplay(error instanceof AssistantUnavailableError
+        ? assistantDisplayMessage(message)
+        : systemDisplayMessage(`Error: ${message}`));
     } finally {
       setSending(false);
       sendingRef.current = false;

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -723,14 +723,16 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
       ? agentStore.listEffectiveProviderModelsForAgent(usageContext.parentKeyId, usageContext.agentId)
       : agentStore.listEffectiveProviderModels(usageContext?.parentKeyId ?? null);
     const selectedModel = requestedModel || agentConfig?.modelPolicy.default_model || DEFAULT_MODEL;
+    const matchingModels = effectiveModels.filter(item => item.model === selectedModel || item.id === selectedModel);
+    const usingAgentDefaultModel = !requestedModel && Boolean(agentConfig?.modelPolicy.default_model);
     const selectedProvider = requestedProvider
       || agentConfig?.modelPolicy.default_provider
-      || (() => {
-        const matches = effectiveModels.filter(item => item.model === selectedModel || item.id === selectedModel);
-        return matches.length === 1 ? matches[0].provider : null;
-      })();
+      || (matchingModels.length === 1 ? matchingModels[0].provider : null);
     if (!selectedProvider) {
       reply.code(400);
+      if (usingAgentDefaultModel && matchingModels.length === 0) {
+        return createError("This assistant's configured model is currently unavailable.", 'invalid_request_error', 'model', 'configured_model_unavailable');
+      }
       return createError('Provider is required for ambiguous model selection', 'invalid_request_error', 'provider', 'provider_required');
     }
     const allowedModel = effectiveModels.find(item => item.provider === selectedProvider && (item.model === selectedModel || item.id === selectedModel));

--- a/reference-server/src/routes/chat.ts
+++ b/reference-server/src/routes/chat.ts
@@ -737,6 +737,10 @@ const chatRoute: FastifyPluginAsync = async (fastify) => {
     }
     const allowedModel = effectiveModels.find(item => item.provider === selectedProvider && (item.model === selectedModel || item.id === selectedModel));
     if (!allowedModel) {
+      if (usingAgentDefaultModel) {
+        reply.code(400);
+        return createError("This assistant's configured model is currently unavailable.", 'invalid_request_error', 'model', 'configured_model_unavailable');
+      }
       reply.code(403);
       return createError('Requested provider/model is not allowed for this key or agent', 'invalid_request_error', 'model', 'model_not_allowed');
     }

--- a/reference-server/test/provider-model-controls.test.js
+++ b/reference-server/test/provider-model-controls.test.js
@@ -412,3 +412,48 @@ test('provider models — ambiguous legacy model-only request requires provider'
         await gateway.close();
     }
 });
+
+test('provider models — unavailable agent default returns configured-model error', async () => {
+    const gateway = await startGateway({
+        openai: ['gpt-4o-mini'],
+    });
+    const { server, tmp } = startServer({
+        extraEnv: {
+            LLM_BASE_URL: gateway.baseURL,
+            LLM_API_KEY: 'test-key',
+            LLM_MODEL: 'gpt-4o-mini',
+            ALLOW_MOCK: '',
+        },
+    });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: HEADERS });
+        const models = await fetch(`${BASE}/v1/manager/models`, { headers: HEADERS });
+        assert.equal(models.status, 200);
+
+        const create = await fetch(`${BASE}/v1/manager/agents`, {
+            method: 'POST',
+            headers: H_YAML,
+            body: `name: Legacy Missing Model Agent
+instructions: Test unavailable model
+model: gpt-oss:latest
+`,
+        });
+        assert.equal(create.status, 201);
+        const { agent_key } = await create.json();
+
+        const response = await fetch(`${BASE}/v1/chat/completions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${agent_key}` },
+            body: JSON.stringify({
+                messages: [{ role: 'user', content: 'hello' }],
+            }),
+        });
+        assert.equal(response.status, 400);
+        assert.equal((await response.json()).error.code, 'configured_model_unavailable');
+        assert.equal(gateway.getChatCount(), 0);
+    } finally {
+        stopServer(server, tmp);
+        await gateway.close();
+    }
+});

--- a/reference-server/test/provider-model-controls.test.js
+++ b/reference-server/test/provider-model-controls.test.js
@@ -457,3 +457,49 @@ model: gpt-oss:latest
         await gateway.close();
     }
 });
+
+test('provider models — unavailable provider/model agent default returns configured-model error', async () => {
+    const gateway = await startGateway({
+        openai: ['gpt-4o-mini'],
+    });
+    const { server, tmp } = startServer({
+        extraEnv: {
+            LLM_BASE_URL: gateway.baseURL,
+            LLM_API_KEY: 'test-key',
+            LLM_MODEL: 'gpt-4o-mini',
+            ALLOW_MOCK: '',
+        },
+    });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: HEADERS });
+        const models = await fetch(`${BASE}/v1/manager/models`, { headers: HEADERS });
+        assert.equal(models.status, 200);
+
+        const create = await fetch(`${BASE}/v1/manager/agents`, {
+            method: 'POST',
+            headers: H_YAML,
+            body: `name: Legacy Missing Provider Model Agent
+instructions: Test unavailable provider model
+provider: ollama
+model: gpt-oss:latest
+`,
+        });
+        assert.equal(create.status, 201);
+        const { agent_key } = await create.json();
+
+        const response = await fetch(`${BASE}/v1/chat/completions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${agent_key}` },
+            body: JSON.stringify({
+                messages: [{ role: 'user', content: 'hello' }],
+            }),
+        });
+        assert.equal(response.status, 400);
+        assert.equal((await response.json()).error.code, 'configured_model_unavailable');
+        assert.equal(gateway.getChatCount(), 0);
+    } finally {
+        stopServer(server, tmp);
+        await gateway.close();
+    }
+});

--- a/reference-server/test/widget-tool-flow.test.js
+++ b/reference-server/test/widget-tool-flow.test.js
@@ -120,3 +120,10 @@ test('widget preserves legacy model-only chat config when no provider is resolve
 
   assert.match(appSource, /else if \(configRef\.current\.model\) requestBody\.model = configRef\.current\.model;/);
 });
+
+test('widget displays unavailable configured model errors as a friendly assistant message', async () => {
+  const appSource = await readWidgetAppSource();
+
+  assert.match(appSource, /configured_model_unavailable/);
+  assert.match(appSource, /This assistant is temporarily unavailable\. Please try again later\./);
+});


### PR DESCRIPTION
Closes #251

## Summary
- Return a specific configured_model_unavailable error when an agent's configured model is no longer available in the effective model registry.
- Show a friendly widget message instead of raw provider/model error JSON.
- Add backend and widget regression coverage for the unavailable configured model path.