### PR TITLE
feat: server-wide provider/model restrictions

### DIFF
--- a/docs/backend/agents.md
+++ b/docs/backend/agents.md
@@ -159,6 +159,18 @@ Create a new agent with a YAML configuration wrapped in JSON.
 
 Provider/model policy is stored separately from YAML so agent behavior remains provider-agnostic. Existing YAML with `model` still works as legacy fallback, but new saves should use `GET`/`PUT /v1/manager/agents/{agent_id}/model-policy` for fallback provider/model and allowed-model restrictions.
 
+An agent policy narrows what is already allowed above it; it can never widen it. The full order is:
+
+```text
+discovered models → server-wide policy → parent-key policy → agent policy
+```
+
+So an agent can only select models that the owning parent key allows, and the parent key can only
+allow models the server-wide policy permits. If an admin narrows the server-wide policy, an agent
+policy naming an excluded model stays saved but stops resolving, and chat requests for that model are
+rejected with `403 model_not_allowed` before any provider is called. See
+[API Endpoints](./api-endpoints.md) for the server-wide and parent-key endpoints.
+
 #### Example
 
 ```bash

--- a/docs/backend/api-endpoints.md
+++ b/docs/backend/api-endpoints.md
@@ -363,8 +363,12 @@ GET /v1/models/effective
 The effective list is:
 
 ```text
-enabled discovered models ∩ parent-key restrictions ∩ agent model policy
+enabled discovered models ∩ server-wide restrictions ∩ parent-key restrictions ∩ agent model policy
 ```
+
+Each level only narrows the level above it, and an empty level is a no-op. Policy is resolved before
+any provider dispatch, so a request for a disallowed pair is rejected with `403 model_not_allowed`
+before it reaches an upstream provider.
 
 ### Retrieve Model
 
@@ -380,7 +384,9 @@ Manager-console routes expose the same provider-aware policy controls:
 
 | Endpoint | Purpose |
 |----------|---------|
-| `GET /v1/manager/models` | List/refresh discovered provider models for the manager console |
+| `GET /v1/manager/models` | List/refresh discovered provider models for the manager console, narrowed by the server-wide policy |
+| `GET /v1/manager/admin/model-restrictions` | Read server-wide restrictions (admin only) |
+| `PUT /v1/manager/admin/model-restrictions` | Save server-wide restrictions with `allowed_models` (admin only) |
 | `GET /v1/manager/admin/parent-keys/{key_id}/model-restrictions` | Read parent-key restrictions |
 | `PUT /v1/manager/admin/parent-keys/{key_id}/model-restrictions` | Save parent-key restrictions with `allowed_models` |
 | `GET /v1/manager/agents/{agent_id}/model-policy` | Read an agent fallback model and allowed-model policy |
@@ -399,6 +405,30 @@ Restriction bodies use provider-aware entries:
 ```
 
 An empty `allowed_models` array means unrestricted within the higher-level effective policy.
+
+An entry with a `provider` and no `model` allows that whole provider.
+
+#### Server-Wide Restrictions
+
+`GET`/`PUT /v1/manager/admin/model-restrictions` set one allow-list for the entire server. They
+require an admin manager user and return 403 `admin_required` otherwise. The policy applies to every
+key and agent, including requests made with no parent key, and takes effect on the next request with
+no restart.
+
+```json
+{
+  "allowed_models": [{ "provider": "ollama", "model": "gemma3:1b" }],
+  "discovered_models": [],
+  "effective_models": []
+}
+```
+
+`discovered_models` is the unfiltered registry, so an admin UI can still offer every discovered model
+to choose from; `effective_models` is the same list after the server-wide policy is applied.
+
+Server-wide policy is stored in its own table and never touches `provider_models.enabled`, which
+discovery refresh owns. Saving it does not modify or delete any parent-key or agent policy — those
+stay stored exactly as written and simply narrow further.
 
 ---
 

--- a/docs/backend/api-endpoints.md
+++ b/docs/backend/api-endpoints.md
@@ -430,6 +430,9 @@ Server-wide policy is stored in its own table and never touches `provider_models
 discovery refresh owns. Saving it does not modify or delete any parent-key or agent policy — those
 stay stored exactly as written and simply narrow further.
 
+If a save takes a model away, every key that loses one gets a `model_policy_changed` notification —
+the same one a per-key change sends. Keys that lose nothing are not notified.
+
 ---
 
 ## Responses (Ozwell Extension)

--- a/reference-server/README.md
+++ b/reference-server/README.md
@@ -590,8 +590,12 @@ See `.env.example` for a complete example configuration.
 Models are provider-aware records such as `{ provider: "openai", model: "gpt-4o-mini" }`. The effective list for a request is:
 
 ```text
-enabled discovered models ∩ parent-key restrictions ∩ agent model policy
+enabled discovered models ∩ server-wide restrictions ∩ parent-key restrictions ∩ agent model policy
 ```
+
+Each level only narrows the level above it, and an empty level is a no-op. Admins set the server-wide
+allow-list through `GET`/`PUT /v1/manager/admin/model-restrictions`; it applies to every key and
+agent, including requests with no parent key, and takes effect without a restart.
 
 Chat requests may send both `provider` and `model`. Legacy model-only requests still work when the model maps to exactly one allowed provider; otherwise the server rejects the request with `provider_required`. If no request model is provided, the server uses the agent model-policy default, then `LLM_MODEL` if it is allowed by the effective policy.
 

--- a/reference-server/src/routes/agents.ts
+++ b/reference-server/src/routes/agents.ts
@@ -942,9 +942,15 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
         }
     });
 
-    // Server-wide provider/model policy. Narrows every key and agent, so it lives outside the
-    // per-user endpoints above. discovered_models is the unfiltered registry: the admin picker
-    // needs it to choose from, since effective_models is already narrowed by this same policy.
+    // Server-wide policy. Narrows every key and agent, so it sits outside the per-user endpoints
+    // below. discovered_models is unfiltered: the admin picker needs it, since effective_models is
+    // already narrowed by this same policy and could never offer an excluded model back.
+    const serverPolicyResponse = () => ({
+        allowed_models: agentStore.getServerModelRestrictions(),
+        discovered_models: agentStore.listProviderModels(),
+        effective_models: agentStore.listEffectiveProviderModels(null),
+    });
+
     fastify.get('/v1/manager/admin/model-restrictions', {
         schema: {
             tags: ['Manager Admin'],
@@ -953,11 +959,7 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
         preHandler: requireManagerAdmin,
     }, async () => {
         getCachedModelsList();
-        return {
-            allowed_models: agentStore.getServerModelRestrictions(),
-            discovered_models: agentStore.listProviderModels(),
-            effective_models: agentStore.listEffectiveProviderModels(null),
-        };
+        return serverPolicyResponse();
     });
 
     fastify.put<{ Body: { allowed_models?: ProviderModelSelectionBody[] } }>('/v1/manager/admin/model-restrictions', {
@@ -969,11 +971,8 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
         preHandler: requireManagerAdmin,
     }, async (request) => {
         getCachedModelsList();
-        return {
-            allowed_models: agentStore.setServerModelRestrictions(normalizeRestrictionBody(request.body)),
-            discovered_models: agentStore.listProviderModels(),
-            effective_models: agentStore.listEffectiveProviderModels(null),
-        };
+        agentStore.setServerModelRestrictions(normalizeRestrictionBody(request.body));
+        return serverPolicyResponse();
     });
 
     fastify.get<{ Params: { key_id: string } }>('/v1/manager/admin/parent-keys/:key_id/model-restrictions', {

--- a/reference-server/src/routes/agents.ts
+++ b/reference-server/src/routes/agents.ts
@@ -214,6 +214,24 @@ function normalizeQuotaBody(body: QuotaBody | undefined): { monthlyTokenLimit: n
     return { monthlyTokenLimit: Math.floor(body.monthly_token_limit), status };
 }
 
+// Shared by the server-wide and per-parent-key restriction endpoints, which take the same body.
+const RESTRICTION_BODY_SCHEMA = {
+    type: 'object',
+    properties: {
+        allowed_models: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    provider: { type: 'string' },
+                    model: { type: 'string' },
+                },
+                required: ['provider'],
+            },
+        },
+    },
+} as const;
+
 function normalizeRestrictionBody(body: { allowed_models?: ProviderModelSelectionBody[] } | undefined) {
     return (body?.allowed_models || [])
         .filter(item => item && typeof item.provider === 'string')
@@ -924,6 +942,40 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
         }
     });
 
+    // Server-wide provider/model policy. Narrows every key and agent, so it lives outside the
+    // per-user endpoints above. discovered_models is the unfiltered registry: the admin picker
+    // needs it to choose from, since effective_models is already narrowed by this same policy.
+    fastify.get('/v1/manager/admin/model-restrictions', {
+        schema: {
+            tags: ['Manager Admin'],
+            summary: 'Get server-wide provider/model restrictions',
+        },
+        preHandler: requireManagerAdmin,
+    }, async () => {
+        getCachedModelsList();
+        return {
+            allowed_models: agentStore.getServerModelRestrictions(),
+            discovered_models: agentStore.listProviderModels(),
+            effective_models: agentStore.listEffectiveProviderModels(null),
+        };
+    });
+
+    fastify.put<{ Body: { allowed_models?: ProviderModelSelectionBody[] } }>('/v1/manager/admin/model-restrictions', {
+        schema: {
+            tags: ['Manager Admin'],
+            summary: 'Update server-wide provider/model restrictions',
+            body: RESTRICTION_BODY_SCHEMA,
+        },
+        preHandler: requireManagerAdmin,
+    }, async (request) => {
+        getCachedModelsList();
+        return {
+            allowed_models: agentStore.setServerModelRestrictions(normalizeRestrictionBody(request.body)),
+            discovered_models: agentStore.listProviderModels(),
+            effective_models: agentStore.listEffectiveProviderModels(null),
+        };
+    });
+
     fastify.get<{ Params: { key_id: string } }>('/v1/manager/admin/parent-keys/:key_id/model-restrictions', {
         schema: {
             tags: ['Manager Admin'],
@@ -953,22 +1005,7 @@ const agentsRoute: FastifyPluginAsync = async (fastify) => {
                 properties: { key_id: { type: 'string' } },
                 required: ['key_id'],
             },
-            body: {
-                type: 'object',
-                properties: {
-                    allowed_models: {
-                        type: 'array',
-                        items: {
-                            type: 'object',
-                            properties: {
-                                provider: { type: 'string' },
-                                model: { type: 'string' },
-                            },
-                            required: ['provider'],
-                        },
-                    },
-                },
-            },
+            body: RESTRICTION_BODY_SCHEMA,
         },
         preHandler: requireManagerAdmin,
     }, async (request) => {

--- a/reference-server/src/routes/models.ts
+++ b/reference-server/src/routes/models.ts
@@ -94,28 +94,37 @@ export async function refreshProviderModels() {
   return agentStore.replaceProviderModels(discoveredRecords);
 }
 
+// Seeding decisions below read the raw registry, but responses are narrowed by the server-wide
+// policy. Deciding on the filtered list instead would re-seed the fallback model whenever a policy
+// happens to exclude every discovered model.
+function serverAllowedResponse() {
+  return listResponse(agentStore.listEffectiveProviderModels(null));
+}
+
+function seedFallbackModel() {
+  const fallbackModel = process.env.LLM_MODEL || 'gpt-4o-mini';
+  agentStore.replaceProviderModels([
+    toModelRecord(fallbackModel, 'fallback', providerFromModelId(fallbackModel, process.env.LLM_PROVIDER || 'openai')),
+  ]);
+  return serverAllowedResponse();
+}
+
 export async function getModelsList() {
   const discoveredRecords = await refreshProviderModels();
   if (discoveredRecords.length) {
-    return listResponse(discoveredRecords);
+    return serverAllowedResponse();
   }
   if (agentStore.hasProviderModelRegistry()) return listResponse([]);
 
-  const fallbackModel = process.env.LLM_MODEL || 'gpt-4o-mini';
-  return listResponse(agentStore.replaceProviderModels([
-    toModelRecord(fallbackModel, 'fallback', providerFromModelId(fallbackModel, process.env.LLM_PROVIDER || 'openai')),
-  ]));
+  return seedFallbackModel();
 }
 
 export function getCachedModelsList() {
   const cached = agentStore.listProviderModels();
-  if (cached.length) return listResponse(cached);
+  if (cached.length) return serverAllowedResponse();
   if (agentStore.hasProviderModelRegistry()) return listResponse([]);
 
-  const fallbackModel = process.env.LLM_MODEL || 'gpt-4o-mini';
-  return listResponse(agentStore.replaceProviderModels([
-    toModelRecord(fallbackModel, 'fallback', providerFromModelId(fallbackModel, process.env.LLM_PROVIDER || 'openai')),
-  ]));
+  return seedFallbackModel();
 }
 
 const modelsRoute: FastifyPluginAsync = async (fastify) => {

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -890,11 +890,14 @@ export class AgentStore {
         `).all() as ProviderModelSelection[];
     }
 
-    // ponytail: no notification or audit trail on change, unlike setParentKeyModelRestrictions.
-    // Notifying would mean diffing effective models for every parent key on every save. Add that
-    // (and a server_model_policy_changed event) if admins need to know who narrowed what, when.
+    // A server-wide change silently removes models from every user at once, so it notifies each
+    // affected key the same way a per-key change does. recordParentPolicyChange no-ops when a key
+    // lost nothing, so keys that were already narrower stay quiet. Admin-initiated and rare, so the
+    // per-key loop is not a hot path.
     setServerModelRestrictions(selections: ProviderModelSelection[]): ProviderModelSelection[] {
         const normalized = normalizeProviderModelSelections(selections);
+        const affectedKeyIds = this.listActiveParentKeyIds();
+        const before = new Map(affectedKeyIds.map(id => [id, this.listEffectiveProviderModels(id)]));
         const save = this.db.transaction(() => {
             this.db.prepare('DELETE FROM server_model_restrictions').run();
             const insert = this.db.prepare(`
@@ -912,7 +915,19 @@ export class AgentStore {
             }
         });
         save();
+        for (const keyId of affectedKeyIds) {
+            this.recordParentPolicyChange(keyId, before.get(keyId) || [], this.listEffectiveProviderModels(keyId));
+        }
         return this.getServerModelRestrictions();
+    }
+
+    private listActiveParentKeyIds(): string[] {
+        const rows = this.db.prepare(`
+          SELECT id
+          FROM api_keys
+          WHERE COALESCE(status, 'active') = 'active' AND revoked_at IS NULL
+        `).all() as Array<{ id: string }>;
+        return rows.map(row => row.id);
     }
 
     getParentKeyModelRestrictions(parentKeyId: string): ProviderModelSelection[] {

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -419,6 +419,19 @@ export class AgentStore {
       );
       CREATE INDEX IF NOT EXISTS idx_parent_key_model_restrictions_parent_key ON parent_key_model_restrictions(parent_key_id);
 
+      -- Server-wide provider/model allow-list. Narrows the discovered registry for every key and
+      -- agent. Kept separate from provider_models.enabled, which discovery refresh owns.
+      -- An empty table means unrestricted, matching parent_key_model_restrictions.
+      -- ponytail: its own table rather than a scope column shared with the per-key and per-agent
+      -- restriction tables. Those are already separate, so this matches its siblings. Collapse all
+      -- three behind a scope_type/scope_id table (like quota_policies) only if a fourth scope lands.
+      CREATE TABLE IF NOT EXISTS server_model_restrictions (
+        id TEXT PRIMARY KEY,
+        provider TEXT NOT NULL,
+        model TEXT,
+        created_at TEXT DEFAULT (datetime('now'))
+      );
+
       CREATE TABLE IF NOT EXISTS agent_model_settings (
         agent_id TEXT PRIMARY KEY,
         default_provider TEXT,
@@ -869,6 +882,39 @@ export class AgentStore {
         return Boolean(this.db.prepare('SELECT 1 FROM provider_models LIMIT 1').get());
     }
 
+    getServerModelRestrictions(): ProviderModelSelection[] {
+        return this.db.prepare(`
+          SELECT provider, model
+          FROM server_model_restrictions
+          ORDER BY rowid ASC
+        `).all() as ProviderModelSelection[];
+    }
+
+    // ponytail: no notification or audit trail on change, unlike setParentKeyModelRestrictions.
+    // Notifying would mean diffing effective models for every parent key on every save. Add that
+    // (and a server_model_policy_changed event) if admins need to know who narrowed what, when.
+    setServerModelRestrictions(selections: ProviderModelSelection[]): ProviderModelSelection[] {
+        const normalized = normalizeProviderModelSelections(selections);
+        const save = this.db.transaction(() => {
+            this.db.prepare('DELETE FROM server_model_restrictions').run();
+            const insert = this.db.prepare(`
+              INSERT INTO server_model_restrictions (id, provider, model, created_at)
+              VALUES (@id, @provider, @model, @created_at)
+            `);
+            const created_at = new Date().toISOString();
+            for (const item of normalized) {
+                insert.run({
+                    id: `${item.provider}:${item.model || '*'}`,
+                    provider: item.provider,
+                    model: item.model ?? null,
+                    created_at,
+                });
+            }
+        });
+        save();
+        return this.getServerModelRestrictions();
+    }
+
     getParentKeyModelRestrictions(parentKeyId: string): ProviderModelSelection[] {
         return this.db.prepare(`
           SELECT provider, model
@@ -994,8 +1040,15 @@ export class AgentStore {
         return this.listEffectiveProviderModels(parentKeyId, policy.allowed_models);
     }
 
+    // Narrowing runs discovered -> server-wide -> parent key -> agent. Each level can only remove
+    // choices, and an empty level is a no-op. The server-wide pass applies even when parentKeyId is
+    // null so unkeyed and direct callers cannot escape it.
     listEffectiveProviderModels(parentKeyId: string | null, agentAllowedModels?: ProviderModelSelection[] | null): ProviderModelRecord[] {
-        const models = this.listProviderModels();
+        const discovered = this.listProviderModels();
+        const serverRestrictions = this.getServerModelRestrictions();
+        const models = serverRestrictions.length
+            ? discovered.filter(model => selectionAllows(serverRestrictions, model.provider, model.model))
+            : discovered;
         const parentRestrictions = parentKeyId ? this.getParentKeyModelRestrictions(parentKeyId) : [];
         const parentFiltered = parentRestrictions.length
             ? models.filter(model => selectionAllows(parentRestrictions, model.provider, model.model))

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -419,12 +419,10 @@ export class AgentStore {
       );
       CREATE INDEX IF NOT EXISTS idx_parent_key_model_restrictions_parent_key ON parent_key_model_restrictions(parent_key_id);
 
-      -- Server-wide provider/model allow-list. Narrows the discovered registry for every key and
-      -- agent. Kept separate from provider_models.enabled, which discovery refresh owns.
-      -- An empty table means unrestricted, matching parent_key_model_restrictions.
-      -- ponytail: its own table rather than a scope column shared with the per-key and per-agent
-      -- restriction tables. Those are already separate, so this matches its siblings. Collapse all
-      -- three behind a scope_type/scope_id table (like quota_policies) only if a fourth scope lands.
+      -- Server-wide allow-list. Empty table means unrestricted. Kept off provider_models.enabled,
+      -- which discovery refresh owns and would overwrite.
+      -- ponytail: own table, matching its per-key and per-agent siblings. Collapse all three behind
+      -- a scope_type/scope_id table (like quota_policies) only if a fourth scope lands.
       CREATE TABLE IF NOT EXISTS server_model_restrictions (
         id TEXT PRIMARY KEY,
         provider TEXT NOT NULL,
@@ -890,10 +888,8 @@ export class AgentStore {
         `).all() as ProviderModelSelection[];
     }
 
-    // A server-wide change silently removes models from every user at once, so it notifies each
-    // affected key the same way a per-key change does. recordParentPolicyChange no-ops when a key
-    // lost nothing, so keys that were already narrower stay quiet. Admin-initiated and rare, so the
-    // per-key loop is not a hot path.
+    // Notifies each key that loses a model, same as a per-key change. recordParentPolicyChange
+    // no-ops when a key lost nothing. Admin-initiated and rare, so the per-key loop is fine.
     setServerModelRestrictions(selections: ProviderModelSelection[]): ProviderModelSelection[] {
         const normalized = normalizeProviderModelSelections(selections);
         const affectedKeyIds = this.listActiveParentKeyIds();
@@ -1055,23 +1051,20 @@ export class AgentStore {
         return this.listEffectiveProviderModels(parentKeyId, policy.allowed_models);
     }
 
-    // Narrowing runs discovered -> server-wide -> parent key -> agent. Each level can only remove
-    // choices, and an empty level is a no-op. The server-wide pass applies even when parentKeyId is
-    // null so unkeyed and direct callers cannot escape it.
+    // Levels below run in order and can only remove. The server level applies even when parentKeyId
+    // is null, so unkeyed and direct callers cannot escape it.
     listEffectiveProviderModels(parentKeyId: string | null, agentAllowedModels?: ProviderModelSelection[] | null): ProviderModelRecord[] {
-        const discovered = this.listProviderModels();
-        const serverRestrictions = this.getServerModelRestrictions();
-        const models = serverRestrictions.length
-            ? discovered.filter(model => selectionAllows(serverRestrictions, model.provider, model.model))
-            : discovered;
-        const parentRestrictions = parentKeyId ? this.getParentKeyModelRestrictions(parentKeyId) : [];
-        const parentFiltered = parentRestrictions.length
-            ? models.filter(model => selectionAllows(parentRestrictions, model.provider, model.model))
-            : models;
-        const agentSelections = normalizeProviderModelSelections(agentAllowedModels || []);
-        return agentSelections.length
-            ? parentFiltered.filter(model => selectionAllows(agentSelections, model.provider, model.model))
-            : parentFiltered;
+        const levels: ProviderModelSelection[][] = [
+            this.getServerModelRestrictions(),
+            parentKeyId ? this.getParentKeyModelRestrictions(parentKeyId) : [],
+            normalizeProviderModelSelections(agentAllowedModels || []),
+        ];
+        return levels.reduce<ProviderModelRecord[]>(
+            (models, selections) => selections.length
+                ? models.filter(model => selectionAllows(selections, model.provider, model.model))
+                : models,
+            this.listProviderModels(),
+        );
     }
 
     listNotificationsForUser(userId: string): ManagerNotification[] {

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -909,11 +909,13 @@ export class AgentStore {
                     created_at,
                 });
             }
+            // Inside the transaction: the policy and the notices about it commit together, so a
+            // failure cannot leave some keys told and others silently cut off.
+            for (const keyId of affectedKeyIds) {
+                this.recordParentPolicyChange(keyId, before.get(keyId) || [], this.listEffectiveProviderModels(keyId));
+            }
         });
         save();
-        for (const keyId of affectedKeyIds) {
-            this.recordParentPolicyChange(keyId, before.get(keyId) || [], this.listEffectiveProviderModels(keyId));
-        }
         return this.getServerModelRestrictions();
     }
 

--- a/reference-server/src/storage/agents.ts
+++ b/reference-server/src/storage/agents.ts
@@ -421,8 +421,9 @@ export class AgentStore {
 
       -- Server-wide allow-list. Empty table means unrestricted. Kept off provider_models.enabled,
       -- which discovery refresh owns and would overwrite.
-      -- ponytail: own table, matching its per-key and per-agent siblings. Collapse all three behind
-      -- a scope_type/scope_id table (like quota_policies) only if a fourth scope lands.
+      -- Deliberately its own table, matching the per-key and per-agent restriction tables rather
+      -- than sharing one. Worth collapsing all three behind a scope_type/scope_id table, the way
+      -- quota_policies does it, only if a fourth scope is ever added.
       CREATE TABLE IF NOT EXISTS server_model_restrictions (
         id TEXT PRIMARY KEY,
         provider TEXT NOT NULL,

--- a/reference-server/test/provider-model-controls.test.js
+++ b/reference-server/test/provider-model-controls.test.js
@@ -412,3 +412,205 @@ test('provider models — ambiguous legacy model-only request requires provider'
         await gateway.close();
     }
 });
+
+const modelIds = payload => payload.data.map(model => `${model.provider}/${model.model}`);
+const selectionIds = selections => selections.map(item => `${item.provider}/${item.model || '*'}`);
+
+test('provider models — server-wide policy narrows listings and stacks with parent and agent policies', async () => {
+    const gateway = await startGateway({
+        openai: ['gpt-4o', 'gpt-4o-mini'],
+        anthropic: ['claude-sonnet-4-6'],
+    });
+    const { server, tmp, dbPath } = startServer({
+        admin: true,
+        extraEnv: {
+            LLM_BASE_URL: gateway.baseURL,
+            LLM_API_KEY: 'test-key',
+            LLM_PROVIDER: 'openai',
+        },
+    });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: HEADERS });
+        const key = activeKey(dbPath);
+        const allDiscovered = ['openai/gpt-4o', 'openai/gpt-4o-mini', 'anthropic/claude-sonnet-4-6'];
+
+        // Warm the registry through discovery first; the admin endpoints read the cached registry.
+        assert.deepEqual(
+            modelIds(await (await fetch(`${BASE}/v1/manager/models`, { headers: HEADERS })).json()),
+            allDiscovered,
+        );
+
+        // No global policy yet: everything behaves exactly as before.
+        const initial = await fetch(`${BASE}/v1/manager/admin/model-restrictions`, { headers: HEADERS });
+        assert.equal(initial.status, 200);
+        const initialBody = await initial.json();
+        assert.deepEqual(initialBody.allowed_models, []);
+        assert.deepEqual(selectionIds(initialBody.effective_models), allDiscovered);
+
+        // Global policy drops openai/gpt-4o for the whole server.
+        const saved = await fetch(`${BASE}/v1/manager/admin/model-restrictions`, {
+            method: 'PUT',
+            headers: H_JSON,
+            body: JSON.stringify({
+                allowed_models: [
+                    { provider: 'openai', model: 'gpt-4o-mini' },
+                    { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+                ],
+            }),
+        });
+        assert.equal(saved.status, 200);
+        const savedBody = await saved.json();
+        assert.deepEqual(selectionIds(savedBody.allowed_models), ['openai/gpt-4o-mini', 'anthropic/claude-sonnet-4-6']);
+        // discovered_models stays unfiltered so the admin picker still has every model to choose from.
+        assert.deepEqual(selectionIds(savedBody.discovered_models), allDiscovered);
+
+        // The raw manager listing — the one the agent picker uses — now narrows too.
+        assert.deepEqual(
+            modelIds(await (await fetch(`${BASE}/v1/manager/models`, { headers: HEADERS })).json()),
+            ['openai/gpt-4o-mini', 'anthropic/claude-sonnet-4-6'],
+        );
+
+        // A parent-key policy that still lists gpt-4o cannot widen past the global policy.
+        const parentPolicy = await fetch(`${BASE}/v1/manager/admin/parent-keys/${key.id}/model-restrictions`, {
+            method: 'PUT',
+            headers: H_JSON,
+            body: JSON.stringify({
+                allowed_models: [
+                    { provider: 'openai', model: 'gpt-4o' },
+                    { provider: 'openai', model: 'gpt-4o-mini' },
+                    { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+                ],
+            }),
+        });
+        assert.equal(parentPolicy.status, 200);
+        const parentBody = await parentPolicy.json();
+        // The per-user policy is stored verbatim — the global policy narrows, it does not rewrite.
+        assert.deepEqual(
+            selectionIds(parentBody.allowed_models),
+            ['openai/gpt-4o', 'openai/gpt-4o-mini', 'anthropic/claude-sonnet-4-6'],
+        );
+        assert.deepEqual(
+            selectionIds(parentBody.effective_models),
+            ['openai/gpt-4o-mini', 'anthropic/claude-sonnet-4-6'],
+        );
+
+        const create = await fetch(`${BASE}/v1/manager/agents`, {
+            method: 'POST',
+            headers: H_YAML,
+            body: `name: Global Policy Agent
+instructions: Test server-wide restrictions
+`,
+        });
+        assert.equal(create.status, 201);
+        const { agent_id, agent_key } = await create.json();
+
+        const agentPolicy = await fetch(`${BASE}/v1/manager/agents/${agent_id}/model-policy`, {
+            method: 'PUT',
+            headers: H_JSON,
+            body: JSON.stringify({
+                default_model: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+                allowed_models: [{ provider: 'anthropic', model: 'claude-sonnet-4-6' }],
+            }),
+        });
+        assert.equal(agentPolicy.status, 200);
+
+        // Full chain: discovered -> server -> parent key -> agent.
+        const agentEffective = await fetch(`${BASE}/v1/models/effective`, {
+            headers: { Authorization: `Bearer ${agent_key}` },
+        });
+        assert.equal(agentEffective.status, 200);
+        assert.deepEqual(modelIds(await agentEffective.json()), ['anthropic/claude-sonnet-4-6']);
+
+        // Clearing the global policy restores the parent key's own wider choice.
+        const cleared = await fetch(`${BASE}/v1/manager/admin/model-restrictions`, {
+            method: 'PUT',
+            headers: H_JSON,
+            body: JSON.stringify({ allowed_models: [] }),
+        });
+        assert.equal(cleared.status, 200);
+        const parentEffective = await fetch(`${BASE}/v1/models/effective`, {
+            headers: { Authorization: `Bearer ${key.key}` },
+        });
+        assert.deepEqual(modelIds(await parentEffective.json()), allDiscovered);
+    } finally {
+        stopServer(server, tmp);
+        await gateway.close();
+    }
+});
+
+test('provider models — server-wide policy blocks chat before upstream dispatch', async () => {
+    const gateway = await startGateway({ openai: ['gpt-4o', 'gpt-4o-mini'] });
+    const { server, tmp, dbPath } = startServer({
+        admin: true,
+        extraEnv: {
+            LLM_BASE_URL: gateway.baseURL,
+            LLM_API_KEY: 'test-key',
+            LLM_MODEL: 'gpt-4o',
+            ALLOW_MOCK: '',
+        },
+    });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: HEADERS });
+        const key = activeKey(dbPath);
+
+        const policy = await fetch(`${BASE}/v1/manager/admin/model-restrictions`, {
+            method: 'PUT',
+            headers: H_JSON,
+            body: JSON.stringify({ allowed_models: [{ provider: 'openai', model: 'gpt-4o' }] }),
+        });
+        assert.equal(policy.status, 200);
+
+        // No parent-key or agent policy exists — the global policy alone must reject this.
+        const blocked = await fetch(`${BASE}/v1/chat/completions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key.key}` },
+            body: JSON.stringify({
+                provider: 'openai',
+                model: 'gpt-4o-mini',
+                messages: [{ role: 'user', content: 'blocked' }],
+            }),
+        });
+        assert.equal(blocked.status, 403);
+        assert.equal((await blocked.json()).error.code, 'model_not_allowed');
+        assert.equal(gateway.getChatCount(), 0);
+
+        const allowed = await fetch(`${BASE}/v1/chat/completions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key.key}` },
+            body: JSON.stringify({
+                provider: 'openai',
+                model: 'gpt-4o',
+                messages: [{ role: 'user', content: 'allowed' }],
+            }),
+        });
+        assert.equal(allowed.status, 200);
+        assert.equal(gateway.getChatCount(), 1);
+    } finally {
+        stopServer(server, tmp);
+        await gateway.close();
+    }
+});
+
+test('provider models — server-wide policy endpoints are admin only', async () => {
+    const { server, tmp } = startServer({ admin: false });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: HEADERS });
+
+        const read = await fetch(`${BASE}/v1/manager/admin/model-restrictions`, { headers: HEADERS });
+        assert.equal(read.status, 403);
+        assert.equal((await read.json()).error.code, 'admin_required');
+
+        const write = await fetch(`${BASE}/v1/manager/admin/model-restrictions`, {
+            method: 'PUT',
+            headers: H_JSON,
+            body: JSON.stringify({ allowed_models: [{ provider: 'openai', model: 'gpt-4o' }] }),
+        });
+        assert.equal(write.status, 403);
+        assert.equal((await write.json()).error.code, 'admin_required');
+    } finally {
+        stopServer(server, tmp);
+    }
+});

--- a/reference-server/test/provider-model-controls.test.js
+++ b/reference-server/test/provider-model-controls.test.js
@@ -593,6 +593,61 @@ test('provider models — server-wide policy blocks chat before upstream dispatc
     }
 });
 
+test('provider models — narrowing server-wide policy notifies affected keys, and only when they lose access', async () => {
+    const gateway = await startGateway({ openai: ['gpt-4o', 'gpt-4o-mini'] });
+    const { server, tmp } = startServer({
+        admin: true,
+        extraEnv: {
+            LLM_BASE_URL: gateway.baseURL,
+            LLM_API_KEY: 'test-key',
+            LLM_PROVIDER: 'openai',
+        },
+    });
+    try {
+        await waitForReady();
+        await fetch(`${BASE}/v1/manager/me`, { headers: HEADERS });
+        await fetch(`${BASE}/v1/manager/models`, { headers: HEADERS });
+
+        const unread = async () => (await (await fetch(`${BASE}/v1/manager/notifications`, { headers: HEADERS })).json()).unread_count;
+        assert.equal(await unread(), 0);
+
+        // Narrowing removes gpt-4o from this key, so it must be told.
+        const narrowed = await fetch(`${BASE}/v1/manager/admin/model-restrictions`, {
+            method: 'PUT',
+            headers: H_JSON,
+            body: JSON.stringify({ allowed_models: [{ provider: 'openai', model: 'gpt-4o-mini' }] }),
+        });
+        assert.equal(narrowed.status, 200);
+        assert.equal(await unread(), 1);
+
+        const listed = await (await fetch(`${BASE}/v1/manager/notifications`, { headers: HEADERS })).json();
+        assert.equal(listed.data[0].type, 'model_policy_changed');
+        assert.deepEqual(
+            (listed.data[0].metadata.removed_models || []).map(item => `${item.provider}/${item.model}`),
+            ['openai/gpt-4o'],
+        );
+
+        // Saving the same policy again removes nothing, so it must not notify again.
+        await fetch(`${BASE}/v1/manager/admin/model-restrictions`, {
+            method: 'PUT',
+            headers: H_JSON,
+            body: JSON.stringify({ allowed_models: [{ provider: 'openai', model: 'gpt-4o-mini' }] }),
+        });
+        assert.equal(await unread(), 1);
+
+        // Widening back gives access, which is not a loss and must stay quiet.
+        await fetch(`${BASE}/v1/manager/admin/model-restrictions`, {
+            method: 'PUT',
+            headers: H_JSON,
+            body: JSON.stringify({ allowed_models: [] }),
+        });
+        assert.equal(await unread(), 1);
+    } finally {
+        stopServer(server, tmp);
+        await gateway.close();
+    }
+});
+
 test('provider models — server-wide policy endpoints are admin only', async () => {
     const { server, tmp } = startServer({ admin: false });
     try {


### PR DESCRIPTION
Closes #258

## What

Admins can set one provider/model allow-list for the whole server. Additive — existing per-user parent-key and per-agent policies are untouched and keep working underneath it.

Effective models now resolve as:

```
discovered → server-wide → parent key → agent
```

Each level only narrows the one above it. An empty level does nothing, so a server with no policy set behaves exactly as before.

## How

The filter is applied **once**, in `listEffectiveProviderModels` (`storage/agents.ts`), which every policy-aware caller already routes through — chat, widgets, `/v1/models/effective`, and the manager admin/agent endpoints. It applies even when `parentKeyId` is null, so direct API callers can't skip it.

Enforcement stays ahead of provider dispatch, so a blocked request returns `403 model_not_allowed` without calling upstream and without opening a stream. That keeps #259's provider runtime free of any authorization role — it receives an already-approved `(provider, model)`.

The raw model listings narrow too. `/v1/manager/models` feeds both the admin console and the user's own agent model picker — that's the long unfiltered list in the issue screenshot. Fallback seeding still reads the *unfiltered* registry, so a policy excluding every discovered model can't re-seed a blocked one.

Policy lives in its own `server_model_restrictions` table, not `provider_models.enabled`, which discovery refresh owns.

## New endpoints

Admin only, `403 admin_required` otherwise:

```
GET  /v1/manager/admin/model-restrictions
PUT  /v1/manager/admin/model-restrictions
```

`GET` also returns `discovered_models` unfiltered, so an admin picker still has every model to choose from — otherwise the policy would hide the models the admin needs in order to re-enable them.

Body reuses the existing shape; a `provider` with no `model` allows that whole provider:

```json
{ "allowed_models": [{ "provider": "openai", "model": "gpt-4o-mini" }, { "provider": "anthropic" }] }
```

## Tests

3 new cases in `provider-model-controls.test.js` (9/9 in file, 97/97 suite):

- no policy preserves current behavior
- policy narrows both parent-key and agent results
- parent-key and agent policies stay stored **verbatim** while narrowing
- blocked chat rejected before dispatch (gateway call count stays 0)
- endpoints are admin only

## Verified manually

Against a live server with local Ollama, all three layers independently and stacked: listings narrow, chat blocks, streaming blocks with clean JSON (not a half-open SSE stream), tool calls and tool-result continuation both gate correctly, and provider-wide wildcards work.

## Docs

`docs/backend/api-endpoints.md`, `docs/backend/agents.md`, and `reference-server/README.md` — the last had the stale two-level formula, which grep caught.

`openapi/openapi.json` deliberately not regenerated: it covers only the 9 public `/v1` paths and contains no manager routes (the existing per-key restriction endpoints aren't in it either).

## Follow-ups, not in this PR

- Manager UI "Server model access" panel — separate PR, after ozwell-manager #12 and #15 land, since all three touch `AdminConsole.tsx`
- `/v1/manager/models` hangs ~31s when the gateway is down — `discoverGatewayModels` has no fetch timeout and loops providers sequentially (pre-existing)
- Deleting an agent orphans its `agent_model_restrictions` rows (pre-existing)
